### PR TITLE
Upgrade CFG layout and styling

### DIFF
--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -63,7 +63,8 @@ def main():
 
     if args.print_cfg:
         print("CFG exported: cfg.dot")
-        teal.bbs_to_dot(Path("cfg.dot"))
+        # teal.bbs_to_dot(Path("cfg.dot"))
+        teal.render_cfg(Path("cfg.dot"))
 
     else:
         for Cls in get_detectors():

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -12,6 +12,7 @@ class Instruction:
         self._prev: List[Instruction] = []
         self._next: List[Instruction] = []
         self._line = 0
+        self._comment = ""
         self._bb: Optional["BasicBlock"] = None
 
     def add_prev(self, p):
@@ -35,6 +36,14 @@ class Instruction:
     @line.setter
     def line(self, l: int):
         self._line = l
+
+    @property
+    def comment(self) -> str:
+        return self._comment
+
+    @comment.setter
+    def comment(self, c:str):
+        self._comment = c
 
     @property
     def bb(self) -> Optional["BasicBlock"]:
@@ -459,7 +468,7 @@ class Addr(Instruction):
         self._addr = addr
 
     def __str__(self):
-        return "addr {self._addr}"
+        return f"addr {self._addr}"
 
 
 class Pop(Instruction):

--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -146,13 +146,20 @@ parser_rules = [
 
 
 def parse_line(line: str) -> Optional[instructions.Instruction]:
+    comment = ""
     if "//" in line:
-        line = line[0 : line.find("//")]
+        comment_start = line.find("//")
+        # save comment
+        comment = line[line.find("//") : len(line)]
+        # strip line of comments and leading/trailing whitespace
+        line = line[0 : comment_start].strip()
     if ":" in line:
         return instructions.Label(line[0 : line.find(":")])
     for key, f in parser_rules:
         if line.startswith(key):
-            return f(line[len(key) :].strip())
+            ins = f(line[len(key) :].strip())
+            ins.comment = comment
+            return ins
     if line:
         print(f"Not found {line}")
         return None

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -57,7 +57,11 @@ def _first_pass(
     call: Optional[Callsub] = None  # Flag: last instruction was a callsub
 
     for line in lines:
-        ins = parse_line(line.strip())
+        try:
+            ins = parse_line(line.strip())
+        except KeyError as e:
+            print(f'Parse error at line {idx} near {e}')
+            exit(1)
         idx = idx + 1
         if not ins:
             continue

--- a/tests/parsing/comments.teal
+++ b/tests/parsing/comments.teal
@@ -1,0 +1,11 @@
+#pragma version 2
+
+// some comment
+
+global GroupSize // another comment
++
+== // one more comment
+
+///////////////////
+// final comment //
+///////////////////

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -16,6 +16,7 @@ TARGETS = [
     "tests/parsing/teal4-test4.teal",
     "tests/parsing/teal4-test5.teal",
     "tests/parsing/teal4-random-opcodes.teal",
+    "tests/parsing/comments.teal",
 ]
 
 


### PR DESCRIPTION
This PR introduces an improved CFG rendered, using HTML-like labels features  of graphviz.

The following improvements are implemented:
* Align and separate instructions within basic blocks
* Display basic block IDs
* Improve layout of edges: add head and tail ports
* Retain some comments as on-hover  tooltips (available in SVG) 

Example output (no tooltips, since GitHub does not support SVG): 
![Example CFG](https://user-images.githubusercontent.com/8296326/131821075-c2f1fbf3-1a67-4fe1-bc5a-42be0b5acfc9.png)
