### PR TITLE
Fix parsing of integers and bytes

### DIFF
--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -102,12 +102,9 @@ class Assert(Instruction):
 
 
 class Int(Instruction):
-    def __init__(self, value: str):
+    def __init__(self, value: Union[str, int]):
         super().__init__()
-        if value.isdigit():
-            self._value: Union[int, str] = int(value)
-        else:
-            self._value = value
+        self._value = value
 
     @property
     def value(self) -> Union[str, int]:
@@ -118,12 +115,9 @@ class Int(Instruction):
 
 
 class PushInt(Instruction):
-    def __init__(self, value: str):
+    def __init__(self, value: Union[str, int]):
         super().__init__()
-        if value.isdigit():
-            self._value: Union[int, str] = int(value)
-        else:
-            self._value = value
+        self._value = value
         self._version = 3
 
     @property
@@ -1125,14 +1119,18 @@ class Sqrt(Instruction):
 
 
 class Intcblock(Instruction):
+    def __init__(self, int_list: List[int]):
+        super().__init__()
+        self._constants = int_list
+
     def __str__(self) -> str:
-        return "intcblock"
+        return " ".join(["intcblock"] + list(map(str, self._constants)))
 
 
 class Intc(Instruction):
-    def __init__(self, idx: str):
+    def __init__(self, idx: int):
         super().__init__()
-        self._idx = int(idx)
+        self._idx = idx
 
     def __str__(self) -> str:
         return f"intc {self._idx}"
@@ -1159,9 +1157,9 @@ class Intc3(Instruction):
 
 
 class Bytec(Instruction):
-    def __init__(self, idx: str):
+    def __init__(self, idx: int):
         super().__init__()
-        self._idx = int(idx)
+        self._idx = idx
 
     def __str__(self) -> str:
         return f"bytec {self._idx}"
@@ -1188,9 +1186,9 @@ class Bytec3(Instruction):
 
 
 class Arg(Instruction):
-    def __init__(self, idx: str):
+    def __init__(self, idx: int):
         super().__init__()
-        self._idx = int(idx)
+        self._idx = idx
         self._mode: ContractType = ContractType.STATELESS
 
     def __str__(self) -> str:
@@ -1233,15 +1231,6 @@ class Arg3(Instruction):
         return "arg_3"
 
 
-class ByteBase64(Instruction):
-    def __init__(self, bytesb64: str):
-        super().__init__()
-        self._bytes = bytesb64
-
-    def __str__(self) -> str:
-        return f"byte base64 {self._bytes}"
-
-
 class Byte(Instruction):
     def __init__(self, bytesb: str):
         super().__init__()
@@ -1266,15 +1255,19 @@ class Len(Instruction):
 
 
 class Bytecblock(Instruction):
+    def __init__(self, bytes_list: List[str]):
+        super().__init__()
+        self._constants = bytes_list
+
     def __str__(self) -> str:
-        return "bytecblock"
+        return " ".join(["bytecblock"] + self._constants)
 
 
 class Substring(Instruction):
     def __init__(self, start: int, stop: int):
         super().__init__()
-        self._start = int(start)
-        self._stop = int(stop)
+        self._start = start
+        self._stop = stop
         self._version: int = 2
 
     def __str__(self) -> str:

--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -1,4 +1,5 @@
 from typing import Optional, Callable, Tuple, List
+import base64
 
 from tealer.teal.instructions import instructions
 from tealer.teal.instructions.instructions import Instruction
@@ -9,62 +10,213 @@ from tealer.teal.instructions.parse_global_field import parse_global_field
 from tealer.teal.instructions.parse_transaction_field import parse_transaction_field
 
 
+class ParseError(Exception):
+    pass
+
+
 def handle_gtxn(x: str) -> instructions.Gtxn:
     split = x.split(" ")
-    idx = int(split[0])
+    idx = _parse_int(split[0])
     tx_field = parse_transaction_field(" ".join(split[1:]), False)
     return instructions.Gtxn(idx, tx_field)
 
 
 def handle_gtxna(x: str) -> instructions.Gtxna:
     split = x.split(" ")
-    idx = int(split[0])
+    idx = _parse_int(split[0])
     tx_field = parse_transaction_field(" ".join(split[1:]), False)
     return instructions.Gtxna(idx, tx_field)
 
 
 def handle_gtxnas(x: str) -> instructions.Gtxnas:
     args = x.split(" ")
-    idx = int(args[0])
+    idx = _parse_int(args[0])
     tx_field = parse_transaction_field(args[1], True)
     return instructions.Gtxnas(idx, tx_field)
 
 
 def handle_extract(x: str) -> instructions.Extract:
     args = x.split(" ")
-    start = int(args[0])
-    length = int(args[1])
+    start = _parse_int(args[0])
+    length = _parse_int(args[1])
     return instructions.Extract(start, length)
+
+
+def _parse_int(x: str) -> int:
+    if x.startswith("0x"):
+        return int(x[2:], 16)
+    if x.startswith("0"):
+        return int(x, 8)
+    return int(x)
+
+
+def _split_line(line: str) -> List[str]:
+    """split line using spaces as separators.
+
+    Divide the given line into fields, where each field is
+    either a string literal enclosed in '"' or a comment, field
+    starting with '//' or a sequence of non-space characters.
+
+    Args:
+        line (str): line to split
+
+    Returns:
+        List[str]: List of fields
+
+    Examples:
+        >>> _split_line('a "string" // comment')
+        ['a', '"string"', '// comment']
+        >>> _split_line('a "s tring //" // "comment"')
+        ['a', '"s tring //"', '// "comment"']
+
+    Raises:
+        ParseError: raises ParseError if string literals are not
+            properly enclosed in the line.
+
+    """
+    fields: List[str] = []
+    line = line.strip()
+    i = 0
+    start = i
+    while i < len(line):
+        if line[i].isspace():
+            if start != i:
+                fields.append(line[start:i].strip())
+            i += 1
+            start = i
+        elif line[i] == '"':
+            if start != i:
+                i += 1
+                continue
+            i += 1
+            while i < len(line):
+                if line[i] == '"' and line[i - 1] != "\\":
+                    fields.append(line[start : i + 1])
+                    i += 1
+                    start = i
+                    break
+                i += 1
+            else:
+                raise ParseError(f"missing closing qoute {line}")
+        elif line[i : i + 2] == "//":
+            fields.append(line[i:])
+            return fields
+        else:
+            i += 1
+    if start < len(line):
+        fields.append(line[start:].strip())
+    return fields
+
+
+def _b64_decode(s: str) -> str:
+    return "0x" + base64.b64decode(s + "=" * (-len(s) % 4)).hex()
+
+
+def _b32_decode(s: str) -> str:
+    return "0x" + base64.b32decode(s + "=" * (-len(s) % 8)).hex()
+
+
+def _parse_byte_arguments(fields: List[str]) -> List[str]:
+    """parse multiple representations of teal byte literals.
+
+    Parse byte literals and convert all base encoded strings to hex
+    encoding. currently parses
+    base64 AAAA..., b64 AAAA..., base64(AAAA...), b64(AAAA...),
+    base32 AAAA..., b32 AAAA..., base32(AAAA...), b32(AAAA...),
+    0x0123..., "literal".
+
+    Args:
+        fields (List[str]): list of space separated fields.
+
+    Returns:
+        List[str]: list of byte arguments, all either encoded in
+        hex or as string literals.
+
+    Examples:
+        >>> _parse_byte_arguments(['base64', 'AA', 'base64(AA)', 'b64(AA)'])
+        ['0x00', '0x00', '0x00']
+        >>> _parse_byte_arguments(['0x00', '"str"', 'base32', 'AA'])
+        ['0x00', '"str"', '0x00']
+
+    Raises:
+        ParseError: raises ParseError if the byte arguments are not correctly
+        encoded.
+    """
+    arguments: List[str] = []
+    error: bool = False
+    i: int = 0
+    while i < len(fields) and not error:
+        if fields[i] == "base64" or fields[i] == "b64":
+            if len(fields) <= i + 1:
+                error = True
+            arguments.append(_b64_decode(fields[i + 1]))
+            i += 2
+        elif fields[i] == "base32" or fields[i] == "b32":
+            if len(fields) <= i + 1:
+                error = True
+            arguments.append(_b32_decode(fields[i + 1]))
+            i += 2
+        elif fields[i].startswith("base64(") or fields[i].startswith("b64("):
+            if fields[i][-1] != ")":
+                error = True
+            data = fields[i].split("(")[1][:-1]
+            arguments.append(_b64_decode(data))
+            i += 1
+        elif fields[i].startswith("base32(") or fields[i].startswith("b32("):
+            if fields[i][-1] != ")":
+                error = True
+            data = fields[i].split("(")[1][:-1]
+            arguments.append(_b32_decode(data))
+            i += 1
+        elif fields[i].startswith("0x") or fields[i].startswith('"'):
+            arguments.append(fields[i])
+            i += 1
+        else:
+            error = True
+            i += 1
+    if error:
+        line = " ".join(fields)
+        raise ParseError(f"incorrect byte format {line}")
+    return arguments
+
+
+_is_int: Callable[[str], bool] = lambda x: x.startswith("0x") or x.isdigit()
 
 
 # Order in the parser_rules is important
 parser_rules: List[Tuple[str, Callable[[str], Instruction]]] = [
-    ("#pragma version ", lambda x: instructions.Pragma(int(x))),
+    ("#pragma version ", lambda x: instructions.Pragma(_parse_int(x))),
     ("err", lambda _x: instructions.Err()),
     ("assert", lambda _x: instructions.Assert()),
-    ("int ", lambda x: instructions.Int(x)),
-    ("pushint ", lambda x: instructions.PushInt(x)),
+    ("int ", lambda x: instructions.Int(_parse_int(x) if _is_int(x) else x)),
+    ("pushint ", lambda x: instructions.PushInt(_parse_int(x) if _is_int(x) else x)),
     ("txn ", lambda x: instructions.Txn(parse_transaction_field(x, False))),
     ("txna ", lambda x: instructions.Txna(parse_transaction_field(x, False))),
     ("gtxn ", lambda x: handle_gtxn(x)),
     ("gtxna ", lambda x: handle_gtxna(x)),
     ("gtxns ", lambda x: instructions.Gtxns(parse_transaction_field(x, False))),
     ("gtxnsa ", lambda x: instructions.Gtxnsa(parse_transaction_field(x, False))),
-    ("load ", lambda x: instructions.Load(int(x))),
-    ("store ", lambda x: instructions.Store(int(x))),
-    ("gload ", lambda x: instructions.Gload(int(x.split(" ")[0]), int(x.split(" ")[1]))),
-    ("gloads ", lambda x: instructions.Gloads(int(x))),
-    ("gaid ", lambda x: instructions.Gaid(int(x))),
+    ("load ", lambda x: instructions.Load(_parse_int(x))),
+    ("store ", lambda x: instructions.Store(_parse_int(x))),
+    (
+        "gload ",
+        lambda x: instructions.Gload(_parse_int(x.split(" ")[0]), _parse_int(x.split(" ")[1])),
+    ),
+    ("gloads ", lambda x: instructions.Gloads(_parse_int(x))),
+    ("gaid ", lambda x: instructions.Gaid(_parse_int(x))),
     ("gaids", lambda x: instructions.Gaids()),
     ("loads", lambda _x: instructions.Loads()),
     ("stores", lambda _x: instructions.Stores()),
-    ("dig ", lambda x: instructions.Dig(int(x))),
+    ("dig ", lambda x: instructions.Dig(_parse_int(x))),
     ("swap", lambda _x: instructions.Swap()),
     ("getbit", lambda _x: instructions.GetBit()),
     ("setbit", lambda _x: instructions.SetBit()),
     ("getbyte", lambda _x: instructions.GetByte()),
     ("setbyte", lambda _x: instructions.SetByte()),
-    ("extract ", lambda x: handle_extract(x)),
+    (
+        "extract ",
+        lambda x: instructions.Extract(_parse_int(x.split(" ")[0]), _parse_int(x.split(" ")[1])),
+    ),
     ("extract3", lambda _x: instructions.Extract3()),
     ("extract_uint16", lambda _x: instructions.Extract_uint16()),
     ("extract_uint32", lambda _x: instructions.Extract_uint32()),
@@ -80,8 +232,8 @@ parser_rules: List[Tuple[str, Callable[[str], Instruction]]] = [
     ("dup2", lambda _x: instructions.Dup2()),
     ("dup", lambda _x: instructions.Dup()),
     ("select", lambda _x: instructions.Select()),
-    ("cover", lambda x: instructions.Cover(int(x))),
-    ("uncover", lambda x: instructions.Uncover(int(x))),
+    ("cover", lambda x: instructions.Cover(_parse_int(x))),
+    ("uncover", lambda x: instructions.Uncover(_parse_int(x))),
     ("concat", lambda _x: instructions.Concat()),
     ("b ", lambda x: instructions.B(x)),
     ("bz ", lambda x: instructions.BZ(x)),
@@ -150,9 +302,6 @@ parser_rules: List[Tuple[str, Callable[[str], Instruction]]] = [
     ("args", lambda _x: instructions.Args()),
     ("itob", lambda x: instructions.Itob()),
     ("btoi", lambda x: instructions.Btoi()),
-    ("byte base64", lambda x: instructions.ByteBase64(x)),
-    ("byte ", lambda x: instructions.Byte(x)),
-    ("pushbytes ", lambda x: instructions.PushBytes(x)),
     ("pop", lambda x: instructions.Pop()),
     ("addr ", lambda x: instructions.Addr(x)),
     ("mulw", lambda x: instructions.Mulw()),
@@ -163,39 +312,68 @@ parser_rules: List[Tuple[str, Callable[[str], Instruction]]] = [
     ("shl", lambda x: instructions.Shl()),
     ("shr", lambda x: instructions.Shr()),
     ("sqrt", lambda x: instructions.Sqrt()),
-    ("intcblock", lambda x: instructions.Intcblock()),
-    ("intc ", lambda x: instructions.Intc(x)),
+    ("intcblock", lambda x: instructions.Intcblock(list(map(_parse_int, x.strip().split())))),
+    ("intc ", lambda x: instructions.Intc(_parse_int(x))),
     ("intc_0", lambda x: instructions.Intc0()),
     ("intc_1", lambda x: instructions.Intc1()),
     ("intc_2", lambda x: instructions.Intc2()),
     ("intc_3", lambda x: instructions.Intc3()),
-    ("bytec ", lambda x: instructions.Bytec(x)),
+    ("bytec ", lambda x: instructions.Bytec(_parse_int(x))),
     ("bytec_0", lambda x: instructions.Bytec0()),
     ("bytec_1", lambda x: instructions.Bytec1()),
     ("bytec_2", lambda x: instructions.Bytec2()),
     ("bytec_3", lambda x: instructions.Bytec3()),
-    ("arg ", lambda x: instructions.Arg(x)),
+    ("arg ", lambda x: instructions.Arg(_parse_int(x))),
     ("arg_0", lambda x: instructions.Arg0()),
     ("arg_1", lambda x: instructions.Arg1()),
     ("arg_2", lambda x: instructions.Arg2()),
     ("arg_3", lambda x: instructions.Arg3()),
     ("len", lambda x: instructions.Len()),
-    ("bytecblock", lambda x: instructions.Bytecblock()),
-    ("substring ", lambda x: instructions.Substring(int(x.split(" ")[0]), int(x.split(" ")[1]))),
+    (
+        "substring ",
+        lambda x: instructions.Substring(_parse_int(x.split(" ")[0]), _parse_int(x.split(" ")[1])),
+    ),
     ("substring3", lambda x: instructions.Substring3()),
 ]
 
 
 def parse_line(line: str) -> Optional[instructions.Instruction]:
+    if not line.strip():
+        return None
+
+    fields = _split_line(line)
     comment = ""
-    if "//" in line:
-        comment_start = line.find("//")
-        # save comment
-        comment = line[comment_start:]
-        # strip line of comments and leading/trailing whitespace
-        line = line[:comment_start].strip()
-    if ":" in line:
-        return instructions.Label(line[0 : line.find(":")])
+    if fields[-1].startswith("//"):
+        comment = fields[-1]
+        fields = fields[:-1]
+
+    if not fields:
+        return None
+
+    ins: Optional[Instruction] = None
+    if fields[0][-1] == ":":
+        if len(fields) != 1:
+            raise ParseError(f"incorrect format of label: {line}")
+        ins = instructions.Label(fields[0][:-1])
+
+    if fields[0] == "byte" or fields[0] == "pushbytes":
+        imm: List[str] = _parse_byte_arguments(fields[1:])
+        if len(imm) != 1:
+            raise ParseError(f"{fields[0]} expects exactly one argument: {line}")
+        ins = {"byte": instructions.Byte, "pushbytes": instructions.PushBytes,}[
+            fields[0]
+        ](imm[0])
+
+    if fields[0] == "bytecblock":
+        imm = _parse_byte_arguments(fields[1:])
+        ins = instructions.Bytecblock(imm)
+
+    if ins is not None:
+        ins.comment = comment
+        return ins
+
+    line = " ".join(fields)
+
     f: Callable[[str], Instruction]
     for key, f in parser_rules:
         if line.startswith(key):

--- a/tealer/teal/instructions/parse_transaction_field.py
+++ b/tealer/teal/instructions/parse_transaction_field.py
@@ -61,21 +61,31 @@ TX_FIELD_TXT_TO_OBJECT = {
 }
 
 
+def _parse_int(x: str) -> int:
+    if x.startswith("0x"):
+        return int(x[2:], 16)
+    if x.startswith("0"):
+        return int(x, 8)
+    return int(x)
+
+
 def parse_transaction_field(tx_field: str, use_stack: bool) -> transaction_field.TransactionField:
     if tx_field.startswith("Accounts"):
-        return transaction_field.Accounts(-1 if use_stack else int(tx_field[len("Accounts ") :]))
+        return transaction_field.Accounts(
+            -1 if use_stack else _parse_int(tx_field[len("Accounts ") :])
+        )
     if tx_field.startswith("ApplicationArgs"):
         return transaction_field.ApplicationArgs(
-            -1 if use_stack else int(tx_field[len("ApplicationArgs ") :])
+            -1 if use_stack else _parse_int(tx_field[len("ApplicationArgs ") :])
         )
     if tx_field.startswith("Applications"):
         return transaction_field.Applications(
-            -1 if use_stack else int(tx_field[len("Applications ") :])
+            -1 if use_stack else _parse_int(tx_field[len("Applications ") :])
         )
     if tx_field.startswith("Assets"):
-        return transaction_field.Assets(-1 if use_stack else int(tx_field[len("Assets ") :]))
+        return transaction_field.Assets(-1 if use_stack else _parse_int(tx_field[len("Assets ") :]))
     if tx_field.startswith("Logs"):
-        return transaction_field.Logs(-1 if use_stack else int(tx_field[len("Logs ") :]))
+        return transaction_field.Logs(-1 if use_stack else _parse_int(tx_field[len("Logs ") :]))
 
     tx_field = tx_field.replace(" ", "")
     return TX_FIELD_TXT_TO_OBJECT[tx_field]()

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -15,7 +15,7 @@ from tealer.teal.instructions.instructions import (
     Pragma,
 )
 from tealer.teal.instructions.instructions import ContractType
-from tealer.teal.instructions.parse_instruction import parse_line
+from tealer.teal.instructions.parse_instruction import parse_line, ParseError
 from tealer.teal.teal import Teal
 
 
@@ -69,8 +69,8 @@ def _first_pass(
     for line in lines:
         try:
             ins = parse_line(line.strip())
-        except KeyError as e:
-            print(f"Parse error at line {idx} near {e}")
+        except ParseError as e:
+            print(f"Parse error at line {idx}: {e}")
             sys.exit(1)
         idx = idx + 1
         if not ins:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,6 +1,8 @@
+from typing import Type, Tuple
 import pytest
 
 from tealer.teal.parse_teal import parse_teal
+from tealer.teal.instructions import instructions
 
 TARGETS = [
     "tests/parsing/transaction_fields.teal",
@@ -29,6 +31,26 @@ TARGETS = [
     "tests/parsing/teal-fields-with-versions.teal",
 ]
 
+TEST_CODE = """
+intcblock 0xf 017 15
+intcblock
+int pay
+byte base64 AA
+byte b64 AA
+byte base64(AA)
+byte b64(AA)
+byte base32 AA
+byte b32 AA
+byte base32(AA)
+byte b32(AA)
+byte 0x0123456789abcdef
+byte "\x01\x02"
+byte "string literal"
+bytecblock b32(AA) base64 AA 0x00 "00"
+bytecblock
+byte "not label: // not comment either"
+"""
+
 
 @pytest.mark.parametrize("target", TARGETS)  # type: ignore
 def test_parsing(target: str) -> None:
@@ -37,3 +59,67 @@ def test_parsing(target: str) -> None:
     # print instruction to trigger __str__ on each ins
     for i in teal.instructions:
         print(i)
+
+
+def _cmp_instructions(
+    b1: instructions.Instruction,
+    b2: instructions.Instruction,
+    target: Type[instructions.Instruction],
+    attributes: Tuple[str],
+) -> bool:
+    check = isinstance(b1, target) and isinstance(b2, target)
+    if not check:
+        return check
+
+    for attr in attributes:
+        v1 = getattr(b1, attr, None)
+        v2 = getattr(b2, attr, None)
+        if v1 != v2:
+            return False
+    return True
+
+
+def test_parsing_2() -> None:
+    teal = parse_teal(TEST_CODE)
+    ins1 = teal.instructions
+    ins2 = [
+        instructions.Intcblock([15, 15, 15]),
+        instructions.Intcblock([]),
+        instructions.Int("pay"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x00"),
+        instructions.Byte("0x0123456789abcdef"),
+        instructions.Byte('"\x01\x02"'),
+        instructions.Byte('"string literal"'),
+        instructions.Bytecblock(["0x00", "0x00", "0x00", '"00"']),
+        instructions.Bytecblock([]),
+        instructions.Byte('"not label: // not comment either"'),
+    ]
+    t = [
+        (instructions.Intcblock, ("_constants",)),
+        (instructions.Intcblock, ("_constants",)),
+        (instructions.Int, ("value",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Byte, ("_bytes",)),
+        (instructions.Bytecblock, ("_constants",)),
+        (instructions.Bytecblock, ("_constants",)),
+        (instructions.Byte, ("_bytes",)),
+    ]
+
+    for (b1, b2, (target, attributes)) in zip(ins1, ins2, t):
+        assert _cmp_instructions(b1, b2, target, attributes)


### PR DESCRIPTION
Fix #16 #20 #22 #23
- add parsing of integers in hex, octal and decimal
- add parsing of bytes in all the available teal formats
- parse immediate arguments of `intcblock` and `bytecblock`
- parse labels and comments correctly for byte instructions containing `:` or `//`