### PR TITLE
Dev fix cfg recovery

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,3 +46,7 @@ jobs:
       run: |
         pytest tests/test_versions.py
         pytest tests/test_mode_detector.py
+
+    - name: Run cfg recovery tests
+      run: |
+        pytest tests/test_cfg.py

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -147,6 +147,10 @@ class Txna(Instruction):
         self._field: TransactionField = field
         self._version: int = 2
 
+    @property
+    def field(self) -> TransactionField:
+        return self._field
+
     def __str__(self) -> str:
         return f"txna {self._field}"
 

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -526,6 +526,8 @@ class Callsub(InstructionWithLabel):
 
     @return_point.setter
     def return_point(self, ins: Instruction) -> None:
+        if self._return_point is not None:
+            raise ValueError("Return point already set")
         self._return_point = ins
 
     def __str__(self) -> str:

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -513,7 +513,16 @@ class Label(InstructionWithLabel):
 class Callsub(InstructionWithLabel):
     def __init__(self, label: str):
         super().__init__(label)
+        self._return_point: Optional[Instruction] = None
         self._version: int = 4
+
+    @property
+    def return_point(self) -> Optional[Instruction]:
+        return self._return_point
+
+    @return_point.setter
+    def return_point(self, ins: Instruction) -> None:
+        self._return_point = ins
 
     def __str__(self) -> str:
         return f"callsub {self._label}"
@@ -528,18 +537,7 @@ class Return(Instruction):
 class Retsub(Instruction):
     def __init__(self) -> None:
         super().__init__()
-        self._labels: List[Label] = []
         self._version: int = 4
-
-    def add_label(self, p: Label) -> None:
-        self._labels.append(p)
-
-    def set_labels(self, p: List[Label]) -> None:
-        self._labels = p
-
-    @property
-    def labels(self) -> List[Label]:
-        return self._labels
 
 
 class AppGlobalGet(Instruction):

--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -35,13 +35,6 @@ def handle_gtxnas(x: str) -> instructions.Gtxnas:
     return instructions.Gtxnas(idx, tx_field)
 
 
-def handle_extract(x: str) -> instructions.Extract:
-    args = x.split(" ")
-    start = _parse_int(args[0])
-    length = _parse_int(args[1])
-    return instructions.Extract(start, length)
-
-
 def _parse_int(x: str) -> int:
     if x.startswith("0x"):
         return int(x[2:], 16)
@@ -149,22 +142,26 @@ def _parse_byte_arguments(fields: List[str]) -> List[str]:
         if fields[i] == "base64" or fields[i] == "b64":
             if len(fields) <= i + 1:
                 error = True
+                break
             arguments.append(_b64_decode(fields[i + 1]))
             i += 2
         elif fields[i] == "base32" or fields[i] == "b32":
             if len(fields) <= i + 1:
                 error = True
+                break
             arguments.append(_b32_decode(fields[i + 1]))
             i += 2
         elif fields[i].startswith("base64(") or fields[i].startswith("b64("):
             if fields[i][-1] != ")":
                 error = True
+                break
             data = fields[i].split("(")[1][:-1]
             arguments.append(_b64_decode(data))
             i += 1
         elif fields[i].startswith("base32(") or fields[i].startswith("b32("):
             if fields[i][-1] != ")":
                 error = True
+                break
             data = fields[i].split("(")[1][:-1]
             arguments.append(_b32_decode(data))
             i += 1
@@ -174,6 +171,7 @@ def _parse_byte_arguments(fields: List[str]) -> List[str]:
         else:
             error = True
             i += 1
+            break
     if error:
         line = " ".join(fields)
         raise ParseError(f"incorrect byte format {line}")

--- a/tests/parsing/multiple_retsub.teal
+++ b/tests/parsing/multiple_retsub.teal
@@ -1,0 +1,18 @@
+#pragma version 5
+b main
+push_zero:
+    int 0
+    retsub
+is_even:
+    int 2
+    %
+    bz return_1
+    callsub push_zero
+    retsub
+return_1:
+    int 1
+    retsub
+main:
+    int 4
+    callsub is_even
+    return

--- a/tests/parsing/subroutine_jump_back.teal
+++ b/tests/parsing/subroutine_jump_back.teal
@@ -1,0 +1,12 @@
+#pragma version 5
+b main
+getmod:
+    %
+    retsub
+is_odd:
+    int 2
+    b getmod
+main:
+    int 5
+    callsub is_odd
+    return

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -1,0 +1,101 @@
+from typing import List, Tuple
+import pytest
+
+
+from tealer.teal.basic_blocks import BasicBlock
+from tealer.teal.instructions import instructions
+from tealer.teal.parse_teal import parse_teal
+
+from tests.utils import cmp_cfg, construct_cfg
+
+
+MULTIPLE_RETSUB = """
+#pragma version 5
+b main
+is_even:
+    int 2
+    %
+    bz return_1
+    int 0
+    retsub
+return_1:
+    int 1
+    retsub
+main:
+    int 4
+    callsub is_even
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(5),
+    instructions.B("main"),
+    instructions.Label("is_even"),
+    instructions.Int(2),
+    instructions.Modulo(),
+    instructions.BZ("return_1"),
+    instructions.Int(0),
+    instructions.Retsub(),
+    instructions.Label("return_1"),
+    instructions.Int(1),
+    instructions.Retsub(),
+    instructions.Label("main"),
+    instructions.Int(4),
+    instructions.Callsub("is_even"),
+    instructions.Return(),
+]
+
+ins_partitions = [(0, 2), (2, 6), (6, 8), (8, 11), (11, 14), (14, 15)]
+bbs_links = [(0, 4), (4, 1), (1, 2), (1, 3), (2, 5), (3, 5)]
+
+
+MULTIPLE_RETSUB_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+
+SUBROUTINE_BACK_JUMP = """
+#pragma version 5
+b main
+getmod:
+    %
+    retsub
+is_odd:
+    int 2
+    b getmod
+main:
+    int 5
+    callsub is_odd
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(5),
+    instructions.B("main"),
+    instructions.Label("getmod"),
+    instructions.Modulo(),
+    instructions.Retsub(),
+    instructions.Label("is_odd"),
+    instructions.Int(2),
+    instructions.B("getmod"),
+    instructions.Label("main"),
+    instructions.Int(5),
+    instructions.Callsub("is_odd"),
+    instructions.Return(),
+]
+
+ins_partitions = [(0, 2), (2, 5), (5, 8), (8, 11), (11, 12)]
+bbs_links = [(0, 3), (3, 2), (2, 1), (1, 4)]
+
+SUBROUTINE_BACK_JUMP_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+
+ALL_TESTS = [
+    (MULTIPLE_RETSUB, MULTIPLE_RETSUB_CFG),
+    (SUBROUTINE_BACK_JUMP, SUBROUTINE_BACK_JUMP_CFG),
+]
+
+
+@pytest.mark.parametrize("test", ALL_TESTS)  # type: ignore
+def test_cfg_construction(test: Tuple[str, List[BasicBlock]]) -> None:
+    code, cfg = test
+    teal = parse_teal(code.strip())
+    assert cmp_cfg(teal.bbs, cfg)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -29,6 +29,8 @@ TARGETS = [
     "tests/parsing/teal5-mixed.teal",
     "tests/parsing/teal-instructions-with-versions.teal",
     "tests/parsing/teal-fields-with-versions.teal",
+    "tests/parsing/multiple_retsub.teal",
+    "tests/parsing/subroutine_jump_back.teal",
 ]
 
 TEST_CODE = """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,93 @@
+from typing import List, Tuple
+
+from tealer.teal.basic_blocks import BasicBlock
+from tealer.teal.instructions.instructions import Instruction
+
+
+def cmp_instructions(ins1: Instruction, ins2: Instruction) -> bool:
+    return str(ins1) == str(ins2)
+
+
+def order_basic_blocks(bbs: List[BasicBlock]) -> List[BasicBlock]:
+    key = lambda bb: bb.entry_instr.line
+    return sorted(bbs, key=key)
+
+
+def cmp_basic_blocks(b1: BasicBlock, b2: BasicBlock) -> bool:
+    if len(b1.instructions) != len(b2.instructions):
+        return False
+
+    for ins1, ins2 in zip(b1.instructions, b2.instructions):
+        if not cmp_instructions(ins1, ins2):
+            return False
+
+    return True
+
+
+def cmp_cfg(bbs1: List[BasicBlock], bbs2: List[BasicBlock]) -> bool:
+    if len(bbs1) != len(bbs2):
+        return False
+    bbs1, bbs2 = map(order_basic_blocks, (bbs1, bbs2))
+
+    for bb1, bb2 in zip(bbs1, bbs2):
+
+        if not cmp_basic_blocks(bb1, bb2):
+            return False
+
+        if len(bb1.prev) != len(bb2.prev):
+            return False
+
+        if len(bb1.next) != len(bb2.next):
+            return False
+
+        bbs_prev_1, bbs_prev_2 = map(order_basic_blocks, (bb1.prev, bb2.prev))
+
+        for bbp1, bbp2 in zip(bbs_prev_1, bbs_prev_2):
+            if bbp1.entry_instr.line != bbp2.entry_instr.line:
+                return False
+
+        bbs_next_1, bbs_next_2 = map(order_basic_blocks, (bb1.next, bb2.next))
+        for bbn1, bbn2 in zip(bbs_next_1, bbs_next_2):
+            if bbn1.entry_instr.line != bbn2.entry_instr.line:
+                return False
+
+    return True
+
+
+def construct_cfg(
+    ins_list: List[Instruction],
+    ins_partitions: List[Tuple[int, int]],
+    bbs_links: List[Tuple[int, int]],
+) -> List[BasicBlock]:
+    """cfg construction helper function.
+
+    construct cfg using the list of instructions, basic block partitions
+    and their relation.
+
+    Args:
+            ins_list (List[Instruction]): list of instructions of the program.
+            ins_partitions (List[Tuple[int]]): list of tuple indicating starting and
+                    ending index into ins_list where ins_list[starting: ending] belong to a
+                    single basic_block.
+            bbs_links (List[Tuple[int]]): links two basic blocks (b1, b2). indexes of basic block
+                    corresponds to index in ins_partition. order of indexes is important as this adds
+                    a directed edge from b1 to b2.
+
+    Returns:
+            List[BasicBlock]: returns a list of basic blocks representing the CFG.
+    """
+    for idx, ins in enumerate(ins_list, start=1):
+        ins.line = idx
+
+    bbs = []
+    for start, end in ins_partitions:
+        bb = BasicBlock()
+        for ins in ins_list[start:end]:
+            bb.add_instruction(ins)
+        bbs.append(bb)
+
+    for idx1, idx2 in bbs_links:
+        bbs[idx1].add_next(bbs[idx2])
+        bbs[idx2].add_prev(bbs[idx1])
+
+    return bbs


### PR DESCRIPTION
Fix #31 

- use dfs to find all retsubs corresponding to a subroutine label and link retsubs and return points.
- add few testing utils to compare instructions, basic blocks and cfg.
- added tests for cfg recovery.