### PR TITLE
Add Impact and Confidence to detectors

### DIFF
--- a/tealer/detectors/abstract_detector.py
+++ b/tealer/detectors/abstract_detector.py
@@ -24,11 +24,33 @@ DETECTOR_TYPE_TXT = {
 }
 
 
+class DetectorClassification(ComparableEnum):
+    HIGH = 0
+    MEDIUM = 1
+    LOW = 2
+    INFORMATIONAL = 3
+    OPTIMIZATION = 4
+
+    UNIMPLEMENTED = 999
+
+
+classification_txt = {
+    DetectorClassification.OPTIMIZATION: "Optimization",
+    DetectorClassification.INFORMATIONAL: "Informational",
+    DetectorClassification.LOW: "Low",
+    DetectorClassification.MEDIUM: "Medium",
+    DetectorClassification.HIGH: "High",
+}
+
+
 class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-methods
 
     NAME = ""  # detector name
     DESCRIPTION = ""
     TYPE = DetectorType.UNDEFINED
+
+    IMPACT: DetectorClassification = DetectorClassification.UNIMPLEMENTED
+    CONFIDENCE: DetectorClassification = DetectorClassification.UNIMPLEMENTED
 
     WIKI_TITLE = ""
     WIKI_DESCRIPTION = ""
@@ -71,6 +93,26 @@ class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public
         if not self.WIKI_RECOMMENDATION:
             raise IncorrectDetectorInitialization(
                 f"WIKI_RECOMMENDATION is not initialized {self.__class__.__name__}"
+            )
+
+        if self.IMPACT not in [
+            DetectorClassification.LOW,
+            DetectorClassification.MEDIUM,
+            DetectorClassification.HIGH,
+            DetectorClassification.INFORMATIONAL,
+            DetectorClassification.OPTIMIZATION,
+        ]:
+            raise IncorrectDetectorInitialization(
+                f"IMPACT is not initialized {self.__class__.__name__}"
+            )
+
+        if self.CONFIDENCE not in [
+            DetectorClassification.LOW,
+            DetectorClassification.MEDIUM,
+            DetectorClassification.HIGH,
+        ]:
+            raise IncorrectDetectorInitialization(
+                f"CONFIDENCE is not initialized {self.__class__.__name__}"
             )
 
     @abc.abstractmethod

--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import List
 
-from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.detectors.abstract_detector import (
+    AbstractDetector,
+    DetectorClassification,
+    DetectorType,
+)
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.global_field import ZeroAddress
 from tealer.teal.instructions.instructions import (
@@ -30,6 +34,9 @@ class CanCloseAccount(AbstractDetector):  # pylint: disable=too-few-public-metho
     NAME = "canCloseAccount"
     DESCRIPTION = "Detect paths that can close out the sender account"
     TYPE = DetectorType.STATELESS
+
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Can Close Account"
     WIKI_DESCRIPTION = "Detect paths that can close out the sender account"

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import List
 
-from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.detectors.abstract_detector import (
+    AbstractDetector,
+    DetectorClassification,
+    DetectorType,
+)
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.global_field import ZeroAddress
 from tealer.teal.instructions.instructions import (
@@ -30,6 +34,9 @@ class CanCloseAsset(AbstractDetector):  # pylint: disable=too-few-public-methods
     NAME = "canCloseAsset"
     DESCRIPTION = "Detect paths that can close the asset holdings of the sender"
     TYPE = DetectorType.STATELESS
+
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Can Close Asset"
     WIKI_DESCRIPTION = "Detect paths that can close the asset holdings of the sender"

--- a/tealer/detectors/can_delete.py
+++ b/tealer/detectors/can_delete.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import List
 
-from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.detectors.abstract_detector import (
+    AbstractDetector,
+    DetectorClassification,
+    DetectorType,
+)
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import BZ, Instruction
 from tealer.teal.instructions.instructions import Return, Int, Txn, Eq, BNZ
@@ -41,6 +45,9 @@ class CanDelete(AbstractDetector):  # pylint: disable=too-few-public-methods
     NAME = "canDelete"
     DESCRIPTION = "Detect paths that can delete the application"
     TYPE = DetectorType.STATEFULL
+
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Can Delete Application"
     WIKI_DESCRIPTION = "Detect paths that can delete the application"

--- a/tealer/detectors/can_update.py
+++ b/tealer/detectors/can_update.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import List
 
-from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.detectors.abstract_detector import (
+    AbstractDetector,
+    DetectorClassification,
+    DetectorType,
+)
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import BZ, Instruction
 from tealer.teal.instructions.instructions import Return, Int, Txn, Eq, BNZ
@@ -41,6 +45,9 @@ class CanUpdate(AbstractDetector):  # pylint: disable=too-few-public-methods
     NAME = "canUpdate"
     DESCRIPTION = "Detect paths that can update the application"
     TYPE = DetectorType.STATEFULL
+
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Can Update Application"
     WIKI_DESCRIPTION = "Detect paths that can update the application"

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import List
 
-from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.detectors.abstract_detector import (
+    AbstractDetector,
+    DetectorClassification,
+    DetectorType,
+)
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import (
     Eq,
@@ -27,6 +31,9 @@ class MissingFeeCheck(AbstractDetector):  # pylint: disable=too-few-public-metho
     NAME = "feeCheck"
     DESCRIPTION = "Detect paths with a missing Fee check"
     TYPE = DetectorType.STATELESS
+
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Missing Fee check"
     WIKI_DESCRIPTION = "Detect paths with a missing Fee check"

--- a/tealer/detectors/groupsize.py
+++ b/tealer/detectors/groupsize.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import List
 
-from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.detectors.abstract_detector import (
+    AbstractDetector,
+    DetectorClassification,
+    DetectorType,
+)
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.global_field import GroupSize
 from tealer.teal.instructions.instructions import Return, Int, Global
@@ -24,6 +28,9 @@ class MissingGroupSize(AbstractDetector):  # pylint: disable=too-few-public-meth
     NAME = "groupSize"
     DESCRIPTION = "Detect paths with a missing GroupSize check"
     TYPE = DetectorType.STATEFULLGROUP
+
+    IMPACT = DetectorClassification.MEDIUM
+    CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Missing GroupSize check"
     WIKI_DESCRIPTION = "Detect paths with a missing GroupSize check"

--- a/tealer/detectors/rekeyto.py
+++ b/tealer/detectors/rekeyto.py
@@ -3,7 +3,11 @@ from copy import copy
 from pathlib import Path
 from typing import Dict, Set, List
 
-from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.detectors.abstract_detector import (
+    AbstractDetector,
+    DetectorClassification,
+    DetectorType,
+)
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import Gtxn, Return, Int
 from tealer.teal.instructions.transaction_field import RekeyTo
@@ -28,6 +32,9 @@ class MissingRekeyTo(AbstractDetector):
     NAME = "rekeyTo"
     DESCRIPTION = "Detect paths with a missing RekeyTo check"
     TYPE = DetectorType.STATEFULLGROUP
+
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Can Rekey Contract"
     WIKI_DESCRIPTION = "Detect paths with a missing RekeyTo check"


### PR DESCRIPTION
Possible impact values are `high, medium, low, informational and optimization` whereas confidence values are `high, medium and low`.

All of the present detectors have confidence, impact set to `high` with exception for groupsize impact, it is set to `medium`.