### PR TITLE
Move basic blocks to dot conversion functions to separate utils file

### DIFF
--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -8,6 +8,7 @@ from tealer.detectors import all_detectors
 from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal.parse_teal import parse_teal
 from tealer.utils.command_line import output_detectors
+from tealer.utils.output import cfg_to_dot
 
 
 def parse_args() -> argparse.Namespace:
@@ -66,8 +67,7 @@ def main() -> None:
 
     if args.print_cfg:
         print("CFG exported: cfg.dot")
-        # teal.bbs_to_dot(Path("cfg.dot"))
-        teal.render_cfg(Path("cfg.dot"))
+        cfg_to_dot(teal.bbs, Path("cfg.dot"))
 
     else:
         for Cls in get_detectors():

--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -15,6 +15,7 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import CloseRemainderTo
+from tealer.utils.output import execution_path_to_dot
 
 
 def _is_close_remainder_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -106,6 +107,7 @@ Always check that CloseRemainderTo transaction field is set to a ZeroAddress or 
             description += " and transfer all the funds to their controlled account."
             description += f"\n\tCheck the path in {filename}\n"
             all_results_txt.append(description)
-            self.teal.bbs_to_dot(filename, path)
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.teal.bbs, path))
 
         return all_results_txt

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -15,6 +15,7 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import AssetCloseTo
+from tealer.utils.output import execution_path_to_dot
 
 
 def _is_asset_close_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -102,6 +103,7 @@ Always check that AssetCloseTo transaction field is set to a ZeroAddress or inte
             description += " holdings of the account."
             description += f"\n\tCheck the path in {filename}\n"
             all_results_txt.append(description)
-            self.teal.bbs_to_dot(filename, path)
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.teal.bbs, path))
 
         return all_results_txt

--- a/tealer/detectors/can_delete.py
+++ b/tealer/detectors/can_delete.py
@@ -6,6 +6,7 @@ from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import BZ, Instruction
 from tealer.teal.instructions.instructions import Return, Int, Txn, Eq, BNZ
 from tealer.teal.instructions.transaction_field import OnCompletion, ApplicationID
+from tealer.utils.output import execution_path_to_dot
 
 
 def _is_delete(ins1: Instruction, ins2: Instruction) -> bool:
@@ -146,6 +147,7 @@ Check if `txn OnCompletion == int DeleteApplication` and do appropriate actions 
             description = "Lack of OnCompletion check allows to delete the app\n"
             description += f"\tCheck the path in {filename}\n"
             all_results_txt.append(description)
-            self.teal.bbs_to_dot(filename, path)
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.teal.bbs, path))
 
         return all_results_txt

--- a/tealer/detectors/can_update.py
+++ b/tealer/detectors/can_update.py
@@ -6,6 +6,7 @@ from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import BZ, Instruction
 from tealer.teal.instructions.instructions import Return, Int, Txn, Eq, BNZ
 from tealer.teal.instructions.transaction_field import OnCompletion, ApplicationID
+from tealer.utils.output import execution_path_to_dot
 
 
 def _is_update(ins1: Instruction, ins2: Instruction) -> bool:
@@ -146,6 +147,7 @@ Check if `txn OnCompletion == int UpdateApplication` and do appropriate actions 
             description = "Lack of OnCompletion check allows to update the app\n"
             description += f"\tCheck the path in {filename}\n"
             all_results_txt.append(description)
-            self.teal.bbs_to_dot(filename, path)
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.teal.bbs, path))
 
         return all_results_txt

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -15,6 +15,7 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import Fee
+from tealer.utils.output import execution_path_to_dot
 
 
 def _is_fee_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -104,6 +105,7 @@ Always check that transaction fee which can be accessed using `txn Fee` in Teal 
             description = "Lack of fee check allows draining the funds of sender account"
             description += f"\n\tCheck the path in {filename}\n"
             all_results_txt.append(description)
-            self.teal.bbs_to_dot(filename, path)
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.teal.bbs, path))
 
         return all_results_txt

--- a/tealer/detectors/groupsize.py
+++ b/tealer/detectors/groupsize.py
@@ -6,6 +6,7 @@ from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.global_field import GroupSize
 from tealer.teal.instructions.instructions import Return, Int, Global
 from tealer.teal.teal import Teal
+from tealer.utils.output import execution_path_to_dot
 
 
 class Result:  # pylint: disable=too-few-public-methods
@@ -85,6 +86,7 @@ class MissingGroupSize(AbstractDetector):  # pylint: disable=too-few-public-meth
             )
 
             all_results_txt.append(description)
-            self.teal.bbs_to_dot(res.filename, res.all_bbs_in_paths)
+            with open(res.filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.teal.bbs, res.all_bbs_in_paths))
 
         return all_results_txt

--- a/tealer/detectors/rekeyto.py
+++ b/tealer/detectors/rekeyto.py
@@ -7,6 +7,7 @@ from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import Gtxn, Return, Int
 from tealer.teal.instructions.transaction_field import RekeyTo
+from tealer.utils.output import execution_path_to_dot
 
 
 class Result:
@@ -101,6 +102,7 @@ Add a check in the contract code verifying that `RekeyTo` property of any transa
                 "\tOr ensure it is used with stateless contracts that check for ReKeyTo\n"
             )
             all_results_txt.append(description)
-            self.teal.bbs_to_dot(res.filename, res.all_bbs_in_paths)
+            with open(res.filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.teal.bbs, res.all_bbs_in_paths))
 
         return all_results_txt

--- a/tealer/teal/basic_blocks.py
+++ b/tealer/teal/basic_blocks.py
@@ -8,6 +8,7 @@ class BasicBlock:
         self._instructions: List[Instruction] = []
         self._prev: List[BasicBlock] = []
         self._next: List[BasicBlock] = []
+        self._idx: int = 0
 
     def add_instruction(self, instruction: Instruction) -> None:
         self._instructions.append(instruction)
@@ -37,6 +38,14 @@ class BasicBlock:
     @property
     def next(self) -> List["BasicBlock"]:
         return self._next
+
+    @property
+    def idx(self) -> int:
+        return self._idx
+
+    @idx.setter
+    def idx(self, i: int) -> None:
+        self._idx = i
 
     def __str__(self) -> str:
         ret = ""

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -186,6 +186,13 @@ def _fourth_pass(instructions: List[Instruction]) -> None:
                     ins.bb.add_next(branch.bb)
 
 
+def _add_basic_blocks_idx(bbs: List[BasicBlock]) -> List[BasicBlock]:
+    bbs = sorted(bbs, key=lambda x: x.entry_instr.line)
+    for i, bb in enumerate(bbs):
+        bb.idx = i
+    return bbs
+
+
 def parse_teal(source_code: str) -> Teal:
     instructions: List[Instruction] = []  # Parsed instructions list
     labels: Dict[str, Instruction] = {}  # Global map of label names to label instructions
@@ -202,6 +209,7 @@ def parse_teal(source_code: str) -> Teal:
 
     _fourth_pass(instructions)
 
+    all_bbs = _add_basic_blocks_idx(all_bbs)
     mode = _detect_contract_type(instructions)
 
     version = 1

--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-from typing import List, Optional
-import html
+from typing import List
 
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import Instruction, ContractType
@@ -18,76 +16,6 @@ class Teal:
         self._bbs = bbs
         self._version = version
         self._mode = mode
-
-    @staticmethod
-    def render_instruction(i: Instruction) -> str:
-        ins_str = html.escape(str(i), quote=True)
-        comment_str = "no comment for this line" if i.comment == "" else i.comment
-        comment_str = html.escape(comment_str, quote=True)
-        # the 'href' attribute is set to bogus because graphviz wants it in SVG
-        tooltip = f'TOOLTIP="{comment_str}" HREF="bogus"'
-        cell_i = f'<TD {tooltip} ALIGN="LEFT" PORT="{i.line}">{i.line}. {ins_str}</TD>'
-        return f"<TR>{cell_i}</TR>\n"
-
-    @staticmethod
-    def render_bb(idx: int, bb: BasicBlock) -> str:
-        table_prefix = '<<TABLE ALIGN="LEFT">\n'
-        table_suffix = "</TABLE>> labelloc=top shape=plain\n"
-        table_rows = ""
-        graph_edges = ""
-        for i in bb.instructions:
-            table_rows += Teal.render_instruction(i)
-        for next_bb in bb.next:
-            exit_loc = bb.exit_instr.line
-            entry_loc = next_bb.entry_instr.line
-            graph_edges += f"{id(bb)}:{exit_loc}:s -> {id(next_bb)}:{entry_loc}:n;\n"
-        table = table_prefix + table_rows + table_suffix
-        return f"{id(bb)}[label={table} xlabel={idx}]" + graph_edges
-
-    def render_cfg(self, filename: Path) -> None:
-        dot_output = "digraph g{\n ranksep = 1 \n overlap = scale \n"
-
-        for idx, bb in enumerate(self._bbs):
-            dot_output += Teal.render_bb(idx, bb)
-
-        dot_output += "}"
-
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write(dot_output)
-
-    def instructions_to_dot(self, filename: Path) -> None:
-        dot_output = "digraph g{\n"
-
-        for ins in self._instructions:
-            label = str(ins)
-            label = label.replace('"', '\\"')  # because of byte "A"
-            label = f"{ins.line}: {label}"
-            dot_output += f'{id(ins)}[label="{label}", shape=box];\n'
-            for next_ins in ins.next:
-                dot_output += f"{id(ins)} -> {id(next_ins)};\n"
-
-        dot_output += "}"
-
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write(dot_output)
-
-    def bbs_to_dot(self, filename: Path, highlited: Optional[List[BasicBlock]] = None) -> None:
-        dot_output = "digraph g{\n"
-
-        for bb in self._bbs:
-            label = str(bb)
-            label = label.replace('"', '\\"')  # because of byte "A"
-            if highlited and bb in highlited:
-                dot_output += f'{id(bb)}[label="{label}", shape=box,color=red];\n'
-            else:
-                dot_output += f'{id(bb)}[label="{label}", shape=box];\n'
-            for next_bb in bb.next:
-                dot_output += f"{id(bb)} -> {id(next_bb)};\n"
-
-        dot_output += "}"
-
-        with open(filename, "w", encoding="utf-8") as f:
-            f.write(dot_output)
 
     @property
     def instructions(self) -> List[Instruction]:

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -1,0 +1,63 @@
+import html
+from pathlib import Path
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tealer.teal.basic_blocks import BasicBlock
+    from tealer.teal.instructions.instructions import Instruction
+
+
+def _instruction_to_dot(ins: "Instruction") -> str:
+    ins_str = html.escape(str(ins), quote=True)
+    comment_str = "no comment for this line" if ins.comment == "" else ins.comment
+    comment_str = html.escape(comment_str, quote=True)
+    # the 'href' attribute is set to bogus because graphviz wants it in SVG
+    tooltip = f'TOOLTIP="{comment_str}" HREF="bogus"'
+    cell_i = f'<TD {tooltip} ALIGN="LEFT" PORT="{ins.line}">{ins.line}. {ins_str}</TD>'
+    return f"<TR>{cell_i}</TR>\n"
+
+
+def _bb_to_dot(bb: "BasicBlock") -> str:
+    table_prefix = '<<TABLE ALIGN="LEFT">\n'
+    table_suffix = "</TABLE>> labelloc=top shape=plain\n"
+    table_rows = ""
+    graph_edges = ""
+    for ins in bb.instructions:
+        table_rows += _instruction_to_dot(ins)
+    for next_bb in bb.next:
+        exit_loc = bb.exit_instr.line
+        entry_loc = next_bb.entry_instr.line
+        graph_edges += f"{bb.idx}:{exit_loc}:s -> {next_bb.idx}:{entry_loc}:n;\n"
+    table = table_prefix + table_rows + table_suffix
+    return f"{bb.idx}[label={table} xlabel={bb.idx}]" + graph_edges
+
+
+def cfg_to_dot(bbs: List["BasicBlock"], filename: Path) -> None:
+    dot_output = "digraph g{\n ranksep = 1 \n overlap = scale \n"
+
+    for bb in bbs:
+        dot_output += _bb_to_dot(bb)
+
+    dot_output += "}"
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(dot_output)
+
+
+def execution_path_to_dot(cfg: List["BasicBlock"], path: List["BasicBlock"]) -> str:
+    dot_output = "digraph g{\n"
+
+    for bb in cfg:
+        label = str(bb)
+        label = html.escape(label, quote=True)
+        if bb in path:
+            dot_output += f'{bb.idx}[label="{label}", shape=box, color=red];\n'
+        else:
+            dot_output += f'{bb.idx}[label="{label}", shape=box];\n'
+
+        for next_bb in bb.next:
+            dot_output += f"{bb.idx} -> {next_bb.idx};\n"
+
+    dot_output += "}"
+
+    return dot_output


### PR DESCRIPTION
Added `idx` property to BasicBlock Class which represents index of the basic block when ordered based on the entry instruction line number.
Separated all the dot conversion functions to `utils/output.py`.