### PR TITLE
Adds ExecutionPaths class to represent detector output

### DIFF
--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -8,7 +8,7 @@ from tealer.detectors import all_detectors
 from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal.parse_teal import parse_teal
 from tealer.utils.command_line import output_detectors
-from tealer.utils.output import ExecutionPaths, cfg_to_dot
+from tealer.utils.output import cfg_to_dot
 from tealer.exceptions import TealerException
 
 
@@ -76,10 +76,8 @@ def main() -> None:
                 teal.register_detector(Cls)
             results = teal.run_detectors()
             for r in results:
-                if isinstance(r, ExecutionPaths):
-                    r.write_to_files(Path("."))
-                else:
-                    print(*r, sep="\n")
+                r.write_to_files(Path("."))
+
         except TealerException as e:
             print(e)
             sys.exit(-1)

--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -8,7 +8,7 @@ from tealer.detectors import all_detectors
 from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal.parse_teal import parse_teal
 from tealer.utils.command_line import output_detectors
-from tealer.utils.output import cfg_to_dot
+from tealer.utils.output import ExecutionPaths, cfg_to_dot
 from tealer.exceptions import TealerException
 
 
@@ -76,7 +76,10 @@ def main() -> None:
                 teal.register_detector(Cls)
             results = teal.run_detectors()
             for r in results:
-                print(*r, sep="\n")
+                if isinstance(r, ExecutionPaths):
+                    r.write_to_files(Path("."))
+                else:
+                    print(*r, sep="\n")
         except TealerException as e:
             print(e)
             sys.exit(-1)

--- a/tealer/detectors/abstract_detector.py
+++ b/tealer/detectors/abstract_detector.py
@@ -2,9 +2,12 @@ import abc
 from typing import List, TYPE_CHECKING
 
 from tealer.utils.comparable_enum import ComparableEnum
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal
+    from tealer.teal.basic_blocks import BasicBlock
+    from tealer.utils.output import SupportedOutput
 
 
 class IncorrectDetectorInitialization(Exception):
@@ -75,7 +78,22 @@ class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public
                 f"WIKI_RECOMMENDATION is not initialized {self.__class__.__name__}"
             )
 
+    def generate_result(
+        self, paths: List[List["BasicBlock"]], description: str, filename: str
+    ) -> ExecutionPaths:
+        output = ExecutionPaths(self.teal.bbs, description, filename)
+
+        for path in paths:
+            output.add_path(path)
+
+        output.check = self.NAME
+        # output.impact = classification_txt[self.IMPACT]
+        # output.confidence = classification_txt[self.CONFIDENCE]
+        output.help = self.WIKI_RECOMMENDATION.strip()
+
+        return output
+
     @abc.abstractmethod
-    def detect(self) -> List[str]:
+    def detect(self) -> "SupportedOutput":
         """TODO Documentation"""
         return []

--- a/tealer/detectors/abstract_detector.py
+++ b/tealer/detectors/abstract_detector.py
@@ -96,4 +96,3 @@ class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public
     @abc.abstractmethod
     def detect(self) -> "SupportedOutput":
         """TODO Documentation"""
-        return []

--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.teal.basic_blocks import BasicBlock
@@ -15,7 +14,9 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import CloseRemainderTo
-from tealer.utils.output import execution_path_to_dot
+
+if TYPE_CHECKING:
+    from tealer.utils.output import SupportedOutput
 
 
 def _is_close_remainder_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -93,21 +94,14 @@ Always check that CloseRemainderTo transaction field is set to a ZeroAddress or 
         for next_bb in bb.next:
             self._check_close_account(next_bb, current_path, paths_without_check)
 
-    def detect(self) -> List[str]:
+    def detect(self) -> "SupportedOutput":
 
         paths_without_check: List[List[BasicBlock]] = []
         self._check_close_account(self.teal.bbs[0], [], paths_without_check)
 
-        all_results_txt: List[str] = []
-        idx = 1
-        for path in paths_without_check:
-            filename = Path(f"can_close_account_{idx}.dot")
-            idx += 1
-            description = "Lack of CloseRemainderTo check allows to close the account"
-            description += " and transfer all the funds to their controlled account."
-            description += f"\n\tCheck the path in {filename}\n"
-            all_results_txt.append(description)
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(execution_path_to_dot(self.teal.bbs, path))
+        description = "Lack of CloseRemainderTo check allows to close the account and"
+        description += " transfer all the funds to attacker controlled address."
 
-        return all_results_txt
+        filename = "can_close_account"
+
+        return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.teal.basic_blocks import BasicBlock
@@ -15,7 +14,9 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import AssetCloseTo
-from tealer.utils.output import execution_path_to_dot
+
+if TYPE_CHECKING:
+    from tealer.utils.output import SupportedOutput
 
 
 def _is_asset_close_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -89,21 +90,13 @@ Always check that AssetCloseTo transaction field is set to a ZeroAddress or inte
         for next_bb in bb.next:
             self._check_close_asset(next_bb, current_path, paths_without_check)
 
-    def detect(self) -> List[str]:
+    def detect(self) -> "SupportedOutput":
 
         paths_without_check: List[List[BasicBlock]] = []
         self._check_close_asset(self.teal.bbs[0], [], paths_without_check)
 
-        all_results_txt: List[str] = []
-        idx = 1
-        for path in paths_without_check:
-            filename = Path(f"can_close_asset_{idx}.dot")
-            idx += 1
-            description = "Lack of AssetCloseTo check allows to close the asset"
-            description += " holdings of the account."
-            description += f"\n\tCheck the path in {filename}\n"
-            all_results_txt.append(description)
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(execution_path_to_dot(self.teal.bbs, path))
+        description = "Lack of AssetCloseTo check allows to close the asset holdings"
+        description += " of the account."
+        filename = "can_close_asset"
 
-        return all_results_txt
+        return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/can_delete.py
+++ b/tealer/detectors/can_delete.py
@@ -1,12 +1,13 @@
-from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import BZ, Instruction
 from tealer.teal.instructions.instructions import Return, Int, Txn, Eq, BNZ
 from tealer.teal.instructions.transaction_field import OnCompletion, ApplicationID
-from tealer.utils.output import execution_path_to_dot
+
+if TYPE_CHECKING:
+    from tealer.utils.output import SupportedOutput
 
 
 def _is_delete(ins1: Instruction, ins2: Instruction) -> bool:
@@ -134,20 +135,13 @@ Check if `txn OnCompletion == int DeleteApplication` and do appropriate actions 
         for next_bb in bb.next:
             self._check_delete(next_bb, current_path, paths_without_check)
 
-    def detect(self) -> List[str]:
+    def detect(self) -> "SupportedOutput":
 
         paths_without_check: List[List[BasicBlock]] = []
         self._check_delete(self.teal.bbs[0], [], paths_without_check)
 
-        all_results_txt: List[str] = []
-        idx = 1
-        for path in paths_without_check:
-            filename = Path(f"can_delete_{idx}.dot")
-            idx += 1
-            description = "Lack of OnCompletion check allows to delete the app\n"
-            description += f"\tCheck the path in {filename}\n"
-            all_results_txt.append(description)
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(execution_path_to_dot(self.teal.bbs, path))
+        description = "Lack of txn OnCompletion == int DeleteApplication check allows to"
+        description += " delete the application."
+        filename = "can_delete"
 
-        return all_results_txt
+        return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/can_update.py
+++ b/tealer/detectors/can_update.py
@@ -1,12 +1,13 @@
-from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import BZ, Instruction
 from tealer.teal.instructions.instructions import Return, Int, Txn, Eq, BNZ
 from tealer.teal.instructions.transaction_field import OnCompletion, ApplicationID
-from tealer.utils.output import execution_path_to_dot
+
+if TYPE_CHECKING:
+    from tealer.utils.output import SupportedOutput
 
 
 def _is_update(ins1: Instruction, ins2: Instruction) -> bool:
@@ -134,20 +135,13 @@ Check if `txn OnCompletion == int UpdateApplication` and do appropriate actions 
         for next_bb in bb.next:
             self._check_delete(next_bb, current_path, paths_without_check)
 
-    def detect(self) -> List[str]:
+    def detect(self) -> "SupportedOutput":
 
         paths_without_check: List[List[BasicBlock]] = []
         self._check_delete(self.teal.bbs[0], [], paths_without_check)
 
-        all_results_txt: List[str] = []
-        idx = 1
-        for path in paths_without_check:
-            filename = Path(f"can_update_{idx}.dot")
-            idx += 1
-            description = "Lack of OnCompletion check allows to update the app\n"
-            description += f"\tCheck the path in {filename}\n"
-            all_results_txt.append(description)
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(execution_path_to_dot(self.teal.bbs, path))
+        description = "Lack of txn OnCompletion == int UpdateApplication check allows to"
+        description += " update the application's approval and clear programs."
 
-        return all_results_txt
+        filename = "can_update"
+        return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.teal.basic_blocks import BasicBlock
@@ -15,7 +14,9 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import Fee
-from tealer.utils.output import execution_path_to_dot
+
+if TYPE_CHECKING:
+    from tealer.utils.output import SupportedOutput
 
 
 def _is_fee_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -93,19 +94,12 @@ Always check that transaction fee which can be accessed using `txn Fee` in Teal 
         for next_bb in bb.next:
             self._check_fee(next_bb, current_path, paths_without_check)
 
-    def detect(self) -> List[str]:
+    def detect(self) -> "SupportedOutput":
         paths_without_check: List[List[BasicBlock]] = []
         self._check_fee(self.teal.bbs[0], [], paths_without_check)
 
-        all_results_txt: List[str] = []
-        idx = 1
-        for path in paths_without_check:
-            filename = Path(f"missing_fee_check_{idx}.dot")
-            idx += 1
-            description = "Lack of fee check allows draining the funds of sender account"
-            description += f"\n\tCheck the path in {filename}\n"
-            all_results_txt.append(description)
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(execution_path_to_dot(self.teal.bbs, path))
+        description = "Lack of fee check allows draining the funds of sender account,"
+        description += "contract account or signer of delegate contract."
+        filename = "missing_fee_check"
 
-        return all_results_txt
+        return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/rekeyto.py
+++ b/tealer/detectors/rekeyto.py
@@ -1,27 +1,14 @@
 from collections import defaultdict
 from copy import copy
-from pathlib import Path
-from typing import Dict, Set, List
+from typing import Dict, Set, List, TYPE_CHECKING
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import Gtxn, Return, Int
 from tealer.teal.instructions.transaction_field import RekeyTo
-from tealer.utils.output import execution_path_to_dot
 
-
-class Result:
-    def __init__(self, filename: Path, bbs: List[BasicBlock], path_initial: List[BasicBlock]):
-        self.filename = filename
-        self.bbs = bbs
-        self.paths = [path_initial]
-
-    def add_path(self, path: List[BasicBlock]) -> None:
-        self.paths.append(path)
-
-    @property
-    def all_bbs_in_paths(self) -> List[BasicBlock]:
-        return [p for sublist in self.paths for p in sublist]
+if TYPE_CHECKING:
+    from tealer.utils.output import SupportedOutput
 
 
 class MissingRekeyTo(AbstractDetector):
@@ -51,7 +38,7 @@ Add a check in the contract code verifying that `RekeyTo` property of any transa
         group_tx: Dict[int, Set[BasicBlock]],
         idx_fitlered: Set[int],
         current_path: List[BasicBlock],
-        all_results: Dict[str, Result],
+        paths_without_check: List[List[BasicBlock]],
     ) -> None:
         # check for loops
         if bb in current_path:
@@ -77,32 +64,18 @@ Add a check in the contract code verifying that `RekeyTo` property of any transa
                     if isinstance(prev, Int) and prev.value == 0:
                         return
 
-                for idx, bbs in group_tx.items():
-                    bbs_list = sorted(bbs, key=lambda x: x.instructions[0].line)
-                    filename = Path(f"rekeyto_tx_{idx}.dot")
-
-                    if idx not in all_results:
-                        all_results[str(idx)] = Result(filename, bbs_list + [bb], current_path)
-                    else:
-                        all_results[str(idx)].add_path(current_path)
+                paths_without_check.append(current_path)
 
         for next_bb in bb.next:
-            self.check_rekey_to(next_bb, group_tx, idx_fitlered, current_path, all_results)
+            self.check_rekey_to(next_bb, group_tx, idx_fitlered, current_path, paths_without_check)
 
-    def detect(self) -> List[str]:
+    def detect(self) -> "SupportedOutput":
 
-        all_results: Dict[str, Result] = {}
-        self.check_rekey_to(self.teal.bbs[0], defaultdict(set), set(), [], all_results)
+        paths_without_check: List[List[BasicBlock]] = []
+        self.check_rekey_to(self.teal.bbs[0], defaultdict(set), set(), [], paths_without_check)
 
-        all_results_txt: List[str] = []
-        for idx, res in all_results.items():
-            description = f"Potential lack of RekeyTo check on transaction {idx}\n"
-            description += f"\tFix the paths in {res.filename}\n"
-            description += (
-                "\tOr ensure it is used with stateless contracts that check for ReKeyTo\n"
-            )
-            all_results_txt.append(description)
-            with open(res.filename, "w", encoding="utf-8") as f:
-                f.write(execution_path_to_dot(self.teal.bbs, res.all_bbs_in_paths))
+        description = "Lack of txn RekeyTo check allows rekeying the account to"
+        description += " attacker controlled address and control the account directly"
+        filename = "missing_rekeyto_check"
 
-        return all_results_txt
+        return self.generate_result(paths_without_check, description, filename)

--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Type
+from typing import List, Any, Type, TYPE_CHECKING
 
 from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.printers.abstract_printer import AbstractPrinter
@@ -6,6 +6,9 @@ from tealer.printers.abstract_printer import AbstractPrinter
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import Instruction, ContractType
 from tealer.exceptions import TealerException
+
+if TYPE_CHECKING:
+    from tealer.utils.output import SupportedOutput
 
 
 def _check_common_things(
@@ -82,7 +85,7 @@ class Teal:
         instance = printer_class(self)
         self._printers.append(instance)
 
-    def run_detectors(self) -> List:
+    def run_detectors(self) -> List["SupportedOutput"]:
         results = [d.detect() for d in self._detectors]
 
         return results

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -1,6 +1,6 @@
 import html
 from pathlib import Path
-from typing import List, TYPE_CHECKING, Dict, Union
+from typing import List, TYPE_CHECKING, Dict
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
@@ -186,4 +186,4 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
         return result
 
 
-SupportedOutput = Union[List[str], ExecutionPaths]
+SupportedOutput = ExecutionPaths

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -1,6 +1,6 @@
 import html
 from pathlib import Path
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Dict, Union
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
@@ -61,3 +61,129 @@ def execution_path_to_dot(cfg: List["BasicBlock"], path: List["BasicBlock"]) -> 
     dot_output += "}"
 
     return dot_output
+
+
+class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
+    """Detector output class to store list of vulnerable paths"""
+
+    def __init__(self, cfg: List["BasicBlock"], description: str, filename: str):
+        self._cfg = cfg
+        self._description = description
+        self._filename = filename
+        self._paths: List[List["BasicBlock"]] = []
+        self._check: str = ""
+        # self._impact: str = ""
+        # self._confidence: str = ""
+        self._help: str = ""
+
+    def add_path(self, path: List["BasicBlock"]) -> None:
+        self._paths.append(path)
+
+    @property
+    def paths(self) -> List[List["BasicBlock"]]:
+        return self._paths
+
+    @property
+    def cfg(self) -> List["BasicBlock"]:
+        return self._cfg
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def check(self) -> str:
+        return self._check
+
+    @check.setter
+    def check(self, c: str) -> None:
+        self._check = c
+
+    # @property
+    # def impact(self) -> str:
+    #     return self._impact
+
+    # @impact.setter
+    # def impact(self, i: str) -> None:
+    #     self._impact = i
+
+    # @property
+    # def confidence(self) -> str:
+    #     return self._confidence
+
+    # @confidence.setter
+    # def confidence(self, c: str) -> None:
+    #     self._confidence = c
+
+    @property
+    def help(self) -> str:
+        return self._help
+
+    @help.setter
+    def help(self, h: str) -> None:
+        self._help = h
+
+    def write_to_files(self, dest: Path, all_paths_in_one: bool = False) -> None:
+        # print(f"\ncheck: {self.check}, impact: {self.impact}, confidence: {self.confidence}")
+        print(f"\ncheck: {self.check}")
+        print(self.description)
+        if len(self.paths) == 0:
+            print("\tdetector didn't find any vulnerable paths.")
+            return
+
+        print("\tfollowing are the vulnerable paths found")
+        if not all_paths_in_one:
+
+            for idx, path in enumerate(self._paths, start=1):
+
+                short = " -> ".join(map(str, [bb.idx for bb in path]))
+                print(f"\n\t\t path: {short}")
+
+                filename = dest / Path(f"{self._filename}_{idx}.dot")
+                print(f"\t\t check file: {filename}")
+
+                with open(filename, "w", encoding="utf-8") as f:
+                    f.write(execution_path_to_dot(self.cfg, path))
+        else:
+            bbs_to_highlight = []
+
+            for path in self._paths:
+                short = " -> ".join(map(str, [bb.idx for bb in path]))
+                print(f"\t\t path: {short}")
+                for bb in path:
+                    if bb not in bbs_to_highlight:
+                        bbs_to_highlight.append(bb)
+
+            filename = dest / Path(f"{self._filename}.dot")
+            print(f"\t\t check file: {filename}")
+
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(execution_path_to_dot(self.cfg, bbs_to_highlight))
+
+    def to_json(self) -> Dict:
+        result = {
+            "type": "ExecutionPaths",
+            "count": len(self.paths),
+            "description": self.description,
+            "check": self.check,
+            # "impact": self.impact,
+            # "confidence": self.confidence,
+            "help": self.help,
+        }
+        paths = []
+        for path in self.paths:
+            short = " -> ".join(map(str, [bb.idx for bb in path]))
+            blocks = []
+            for bb in path:
+                block = []
+                for ins in bb.instructions:
+                    block.append(f"{ins.line}: {ins}")
+                blocks.append(block)
+
+            paths.append({"short": short, "blocks": blocks})
+
+        result["paths"] = paths
+        return result
+
+
+SupportedOutput = Union[List[str], ExecutionPaths]


### PR DESCRIPTION
`ExecutionPaths` represents list of vulnerable paths found by a detector. It has helper methods `write_to_files` and `to_json` to write the output to files and to convert it to json representation.
This PR also changes all present available detectors to use ExecutionPaths to return their output instead of directly writing to dot files.