### PR TITLE
Adds functionality to identify subroutines defined in the contract

### DIFF
--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -14,7 +14,10 @@ if TYPE_CHECKING:
 def _check_common_things(
     thing_name: str, cls: Any, base_cls: Any, instance_list: List[Any]
 ) -> None:
-
+    """check if cls is subclass of base_cls and it's instance is not already
+    present in instance_list. if either of the conditions fail, then error is
+    raised.
+    """
     if not issubclass(cls, base_cls) or cls is base_cls:
         raise TealerException(
             f"You can't register {cls.__name__} as a {thing_name}."
@@ -45,18 +48,32 @@ class Teal:
 
     @property
     def instructions(self) -> List[Instruction]:
+        """List of instructions of the contract"""
         return self._instructions
 
     @property
     def bbs(self) -> List[BasicBlock]:
+        """CFG of the contract"""
         return self._bbs
 
     @property
     def subroutines(self) -> List[List["BasicBlock"]]:
+        """Returns list of subroutines.
+
+        Each subroutine is represented by the list of basic blocks that constitute
+        a that particular subroutine. Subroutines are supported from version Teal 4 onwards.
+        For Teal version 3 or less this property will return empty List.
+        """
         return self._subroutines
 
     @property
     def version(self) -> int:
+        """Teal version for this contract.
+
+        Version of the contract is based on whether the first instruction of the
+        contract is #pragma version instruction or not. if it is, then version will
+        be the teal version specified or else, version will be 1.
+        """
         return self._version
 
     @version.setter
@@ -65,6 +82,13 @@ class Teal:
 
     @property
     def mode(self) -> ContractType:
+        """Type of the contract: Stateless, Stateful or Any.
+
+        Mode is determined based on the instructions of the contract. if there are
+        any instructions that are only supported in one kind of contract then that
+        will be the contract type. if there aren't any such type of instructions, then
+        this will be "Any".
+        """
         return self._mode
 
     @mode.setter
@@ -73,10 +97,12 @@ class Teal:
 
     @property
     def detectors(self) -> List[AbstractDetector]:
+        """return list of registered detectors."""
         return self._detectors
 
     @property
     def printers(self) -> List[AbstractPrinter]:
+        """return list of registered printers."""
         return self._printers
 
     def register_detector(self, detector_class: Type[AbstractDetector]) -> None:

--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -26,17 +26,19 @@ def _check_common_things(
 
 
 class Teal:
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         instructions: List[Instruction],
         bbs: List[BasicBlock],
         version: int,
         mode: ContractType,
+        subroutines: List[List["BasicBlock"]],
     ):
         self._instructions = instructions
         self._bbs = bbs
         self._version = version
         self._mode = mode
+        self._subroutines = subroutines
 
         self._detectors: List[AbstractDetector] = []
         self._printers: List[AbstractPrinter] = []
@@ -48,6 +50,10 @@ class Teal:
     @property
     def bbs(self) -> List[BasicBlock]:
         return self._bbs
+
+    @property
+    def subroutines(self) -> List[List["BasicBlock"]]:
+        return self._subroutines
 
     @property
     def version(self) -> int:

--- a/tests/test_subroutine_identification.py
+++ b/tests/test_subroutine_identification.py
@@ -1,0 +1,116 @@
+from typing import List, Tuple
+import pytest
+
+
+from tealer.teal.basic_blocks import BasicBlock
+from tealer.teal.instructions import instructions
+from tealer.teal.parse_teal import parse_teal
+
+from tests.utils import cmp_cfg, construct_cfg
+
+
+MULTIPLE_RETSUB = """
+#pragma version 5
+b main
+push_zero:
+    int 0
+    retsub
+is_even:
+    int 2
+    %
+    bz return_1
+    callsub push_zero
+    retsub
+return_1:
+    int 1
+    retsub
+main:
+    int 4
+    callsub is_even
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(5),
+    instructions.B("main"),
+    instructions.Label("push_zero"),
+    instructions.Int(0),
+    instructions.Retsub(),
+    instructions.Label("is_even"),
+    instructions.Int(2),
+    instructions.Modulo(),
+    instructions.BZ("return_1"),
+    instructions.Callsub("push_zero"),
+    instructions.Retsub(),
+    instructions.Label("return_1"),
+    instructions.Int(1),
+    instructions.Retsub(),
+    instructions.Label("main"),
+    instructions.Int(4),
+    instructions.Callsub("is_even"),
+    instructions.Return(),
+]
+
+ins_partitions = [(0, 2), (2, 5), (5, 9), (9, 10), (10, 11), (11, 14), (14, 17), (17, 18)]
+bbs_links = [(0, 6), (6, 2), (2, 3), (2, 5), (3, 1), (1, 4), (4, 7), (5, 7)]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+MULTIPLE_RETSUB_SUBROUTINES = [
+    [bbs[1]],  # push_zero
+    [bbs[2], bbs[3], bbs[4], bbs[5]],  # is_even
+]
+
+
+SUBROUTINE_BACK_JUMP = """
+#pragma version 5
+b main
+getmod:
+    %
+    retsub
+is_odd:
+    int 2
+    b getmod
+main:
+    int 5
+    callsub is_odd
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(5),
+    instructions.B("main"),
+    instructions.Label("getmod"),
+    instructions.Modulo(),
+    instructions.Retsub(),
+    instructions.Label("is_odd"),
+    instructions.Int(2),
+    instructions.B("getmod"),
+    instructions.Label("main"),
+    instructions.Int(5),
+    instructions.Callsub("is_odd"),
+    instructions.Return(),
+]
+
+ins_partitions = [(0, 2), (2, 5), (5, 8), (8, 11), (11, 12)]
+bbs_links = [(0, 3), (3, 2), (2, 1), (1, 4)]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+SUBROUTINE_BACK_JUMP_SUBROUTINES = [[bbs[1], bbs[2]]]  # is_odd
+
+ALL_TESTS = [
+    (MULTIPLE_RETSUB, MULTIPLE_RETSUB_SUBROUTINES),
+    (SUBROUTINE_BACK_JUMP, SUBROUTINE_BACK_JUMP_SUBROUTINES),
+]
+
+
+@pytest.mark.parametrize("test", ALL_TESTS)  # type: ignore
+def test_subroutine_identification(test: Tuple[str, List[List[BasicBlock]]]) -> None:
+    code, expected_subroutines = test
+    teal = parse_teal(code.strip())
+    subroutines = teal.subroutines
+    assert len(subroutines) == len(expected_subroutines)
+    subroutines = sorted(subroutines, key=lambda x: x[0].idx)
+    expected_subroutines = sorted(expected_subroutines, key=lambda x: x[0].idx)
+
+    for sub, ex_sub in zip(subroutines, expected_subroutines):
+        assert cmp_cfg(sub, ex_sub)


### PR DESCRIPTION
Identifies and store subroutines in `subroutines` property of `Teal`. Identification uses basic graph traversal algorithm.
As subroutines are supported from version 4 onwards, contracts with lesser version will have empty list of subroutines.