### PR TITLE
Adds tests for detectors

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -50,3 +50,7 @@ jobs:
     - name: Run cfg recovery tests
       run: |
         pytest tests/test_cfg.py
+
+    - name: Run detectors tests
+      run: |
+        pytest tests/test_detectors.py

--- a/tests/detectors/can_close_account.py
+++ b/tests/detectors/can_close_account.py
@@ -1,0 +1,228 @@
+from tealer.teal.instructions import instructions, transaction_field
+from tealer.detectors.all_detectors import CanCloseAccount
+from tealer.teal import global_field
+
+from tests.utils import construct_cfg
+
+
+CAN_CLOSE_ACCOUNT = """
+#pragma version 2
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver 
+txn Fee
+int 10000
+<
+bz highfee
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn AssetCloseTo
+global ZeroAddress
+==
+bz closing_asset
+global GroupSize
+int 1
+==
+bz unexpected_group_size
+int 1
+return
+wrongreceiver:
+highfee:
+rekeying:
+closing_asset:
+unexpected_group_size:
+    err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.Fee()),
+    instructions.Int(10000),
+    instructions.Less(),
+    instructions.BZ("highfee"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.AssetCloseTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_asset"),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(1),
+    instructions.Eq(),
+    instructions.BZ("unexpected_group_size"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("highfee"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_asset"),
+    instructions.Label("unexpected_group_size"),
+    instructions.Err(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+]
+bbs_links = [(0, 1), (0, 6), (1, 2), (1, 7), (2, 3), (2, 8), (3, 4), (3, 9), (4, 5), (4, 10)]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_CLOSE_ACCOUNT_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5]],
+]
+
+
+CAN_CLOSE_ACCOUNT_LOOP = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver
+txn Fee
+int 10000
+<
+bz highfee
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn AssetCloseTo
+global ZeroAddress
+==
+bz closing_asset
+global GroupSize
+int 1
+==
+bz unexpected_group_size
+int 0
+b loop
+wrongreceiver:
+highfee:
+rekeying:
+closing_asset:
+unexpected_group_size:
+    err
+loop:
+    dup
+    int 5
+    <
+    bz end
+    int 1
+    +
+    b loop
+end:
+    int 1
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(4),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.Fee()),
+    instructions.Int(10000),
+    instructions.Less(),
+    instructions.BZ("highfee"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.AssetCloseTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_asset"),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(1),
+    instructions.Eq(),
+    instructions.BZ("unexpected_group_size"),
+    instructions.Int(0),
+    instructions.B("loop"),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("highfee"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_asset"),
+    instructions.Label("unexpected_group_size"),
+    instructions.Err(),
+    instructions.Label("loop"),
+    instructions.Dup(),
+    instructions.Int(5),
+    instructions.Less(),
+    instructions.BZ("end"),
+    instructions.Int(1),
+    instructions.Add(),
+    instructions.B("loop"),
+    instructions.Label("end"),
+    instructions.Int(1),
+    instructions.Return(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+    (29, 34),
+    (34, 37),
+    (37, 40),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+    (5, 11),
+    (11, 12),
+    (11, 13),
+    (12, 11),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_CLOSE_ACCOUNT_LOOP_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5], bbs[11], bbs[13]],
+]
+
+
+can_close_account_tests = [
+    (CAN_CLOSE_ACCOUNT, CanCloseAccount, CAN_CLOSE_ACCOUNT_VULNERABLE_PATHS),
+    (CAN_CLOSE_ACCOUNT_LOOP, CanCloseAccount, CAN_CLOSE_ACCOUNT_LOOP_VULNERABLE_PATHS),
+]

--- a/tests/detectors/can_close_asset.py
+++ b/tests/detectors/can_close_asset.py
@@ -1,0 +1,243 @@
+from tealer.teal.instructions import instructions, transaction_field
+from tealer.detectors.all_detectors import CanCloseAsset
+from tealer.teal import global_field
+
+from tests.utils import construct_cfg
+
+
+CAN_CLOSE_ASSET = """
+#pragma version 2
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver 
+txn Fee
+int 10000
+<
+bz highfee
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn CloseRemainderTo
+global ZeroAddress
+==
+bz closing_account
+global GroupSize
+int 1
+==
+bz unexpected_group_size
+int 1
+return
+wrongreceiver:
+highfee:
+rekeying:
+closing_account:
+unexpected_group_size:
+    err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.Fee()),
+    instructions.Int(10000),
+    instructions.Less(),
+    instructions.BZ("highfee"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.CloseRemainderTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_account"),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(1),
+    instructions.Eq(),
+    instructions.BZ("unexpected_group_size"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("highfee"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_account"),
+    instructions.Label("unexpected_group_size"),
+    instructions.Err(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+]
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_CLOSE_ASSET_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5]],
+]
+
+
+CAN_CLOSE_ASSET_LOOP = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver 
+txn Fee
+int 10000
+<
+bz highfee
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn CloseRemainderTo
+global ZeroAddress
+==
+bz closing_account
+global GroupSize
+int 1
+==
+bz unexpected_group_size
+int 0
+b loop
+wrongreceiver:
+highfee:
+rekeying:
+closing_account:
+unexpected_group_size:
+    err
+loop:
+    dup
+    int 5
+    <
+    bz end
+    int 1
+    +
+    b loop
+end:
+    int 1
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(4),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.Fee()),
+    instructions.Int(10000),
+    instructions.Less(),
+    instructions.BZ("highfee"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.CloseRemainderTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_account"),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(1),
+    instructions.Eq(),
+    instructions.BZ("unexpected_group_size"),
+    instructions.Int(0),
+    instructions.B("loop"),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("highfee"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_account"),
+    instructions.Label("unexpected_group_size"),
+    instructions.Err(),
+    instructions.Label("loop"),
+    instructions.Dup(),
+    instructions.Int(5),
+    instructions.Less(),
+    instructions.BZ("end"),
+    instructions.Int(1),
+    instructions.Add(),
+    instructions.B("loop"),
+    instructions.Label("end"),
+    instructions.Int(1),
+    instructions.Return(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+    (29, 34),
+    (34, 37),
+    (37, 40),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+    (5, 11),
+    (11, 12),
+    (11, 13),
+    (12, 11),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_CLOSE_ASSET_LOOP_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5], bbs[11], bbs[13]]
+]
+
+
+can_close_asset_tests = [
+    (CAN_CLOSE_ASSET, CanCloseAsset, CAN_CLOSE_ASSET_VULNERABLE_PATHS),
+    (CAN_CLOSE_ASSET_LOOP, CanCloseAsset, CAN_CLOSE_ASSET_LOOP_VULNERABLE_PATHS),
+]

--- a/tests/detectors/can_delete.py
+++ b/tests/detectors/can_delete.py
@@ -1,0 +1,258 @@
+from tealer.teal.instructions import instructions
+from tealer.teal.instructions import transaction_field
+from tealer.detectors.all_detectors import CanDelete
+
+from tests.utils import construct_cfg
+
+
+CAN_DELETE = """
+#pragma version 2
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    txn OnCompletion
+    int NoOp
+    ==
+    bnz handle_noop
+    txn OnCompletion
+    int OptIn
+    ==
+    bnz handle_optin
+    txn OnCompletion
+    int CloseOut
+    ==
+    bnz handle_closeout
+    txn OnCompletion
+    int UpdateApplication
+    ==
+    bnz handle_updateapp
+    int 1
+    return
+handle_noop:
+handle_optin:
+handle_closeout:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Int(0),
+    instructions.Txn(transaction_field.ApplicationID()),
+    instructions.Eq(),
+    instructions.BZ("not_creation"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("not_creation"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("NoOp"),
+    instructions.Eq(),
+    instructions.BNZ("handle_noop"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("OptIn"),
+    instructions.Eq(),
+    instructions.BNZ("handle_optin"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("CloseOut"),
+    instructions.Eq(),
+    instructions.BNZ("handle_closeout"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("UpdateApplication"),
+    instructions.Eq(),
+    instructions.BNZ("handle_updateapp"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("handle_noop"),
+    instructions.Label("handle_optin"),
+    instructions.Label("handle_closeout"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("handle_updateapp"),
+    instructions.Err(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 7),
+    (7, 12),
+    (12, 16),
+    (16, 20),
+    (20, 24),
+    (24, 26),
+    (26, 27),
+    (27, 28),
+    (28, 31),
+    (31, 33),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 2),
+    (2, 3),
+    (2, 7),
+    (3, 4),
+    (3, 8),
+    (4, 5),
+    (4, 9),
+    (5, 6),
+    (5, 10),
+    (7, 8),
+    (8, 9),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_DELETE_VULNERABLE_PATHS = [
+    [bbs[0], bbs[2], bbs[3], bbs[4], bbs[5], bbs[6]],
+]
+
+
+CAN_DELETE_LOOP = """
+#pragma version 4
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    txn OnCompletion
+    int NoOp
+    ==
+    bnz handle_noop
+    txn OnCompletion
+    int OptIn
+    ==
+    bnz handle_optin
+    txn OnCompletion
+    int CloseOut
+    ==
+    bnz handle_closeout
+    txn OnCompletion
+    int UpdateApplication
+    ==
+    bnz handle_updateapp
+    b loop
+handle_noop:
+handle_optin:
+handle_closeout:
+int 1
+return
+handle_updateapp:
+err
+loop:
+    load 0
+    int 5
+    <
+    bz end
+    load 0
+    int 1
+    +
+    store 0
+    b loop
+end:
+    int 1
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(4),
+    instructions.Int(0),
+    instructions.Txn(transaction_field.ApplicationID()),
+    instructions.Eq(),
+    instructions.BZ("not_creation"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("not_creation"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("NoOp"),
+    instructions.Eq(),
+    instructions.BNZ("handle_noop"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("OptIn"),
+    instructions.Eq(),
+    instructions.BNZ("handle_optin"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("CloseOut"),
+    instructions.Eq(),
+    instructions.BNZ("handle_closeout"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("UpdateApplication"),
+    instructions.Eq(),
+    instructions.BNZ("handle_updateapp"),
+    instructions.B("loop"),
+    instructions.Label("handle_noop"),
+    instructions.Label("handle_optin"),
+    instructions.Label("handle_closeout"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("handle_updateapp"),
+    instructions.Err(),
+    instructions.Label("loop"),
+    instructions.Load(0),
+    instructions.Int(5),
+    instructions.Less(),
+    instructions.BZ("end"),
+    instructions.Load(0),
+    instructions.Int(1),
+    instructions.Add(),
+    instructions.Store(0),
+    instructions.B("loop"),
+    instructions.Label("end"),
+    instructions.Int(1),
+    instructions.Return(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 7),
+    (7, 12),
+    (12, 16),
+    (16, 20),
+    (20, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 30),
+    (30, 32),
+    (32, 37),
+    (37, 42),
+    (42, 45),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 2),
+    (2, 3),
+    (2, 7),
+    (3, 4),
+    (3, 8),
+    (4, 5),
+    (4, 9),
+    (5, 6),
+    (5, 10),
+    (7, 8),
+    (8, 9),
+    (6, 11),
+    (11, 12),
+    (11, 13),
+    (12, 11),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_DELETE_LOOP_VULNERABLE_PATHS = [
+    [bbs[0], bbs[2], bbs[3], bbs[4], bbs[5], bbs[6], bbs[11], bbs[13]],
+]
+
+
+can_delete_tests = [
+    (CAN_DELETE, CanDelete, CAN_DELETE_VULNERABLE_PATHS),
+    (CAN_DELETE_LOOP, CanDelete, CAN_DELETE_LOOP_VULNERABLE_PATHS),
+]

--- a/tests/detectors/can_update.py
+++ b/tests/detectors/can_update.py
@@ -1,0 +1,258 @@
+from tealer.teal.instructions import instructions
+from tealer.teal.instructions import transaction_field
+from tealer.detectors.all_detectors import CanUpdate
+
+from tests.utils import construct_cfg
+
+
+CAN_UPDATE = """
+#pragma version 2
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    txn OnCompletion
+    int NoOp
+    ==
+    bnz handle_noop
+    txn OnCompletion
+    int OptIn
+    ==
+    bnz handle_optin
+    txn OnCompletion
+    int CloseOut
+    ==
+    bnz handle_closeout
+    txn OnCompletion
+    int DeleteApplication
+    ==
+    bnz handle_deleteapp
+    int 1
+    return
+handle_noop:
+handle_optin:
+handle_closeout:
+int 1
+return
+handle_deleteapp:
+err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Int(0),
+    instructions.Txn(transaction_field.ApplicationID()),
+    instructions.Eq(),
+    instructions.BZ("not_creation"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("not_creation"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("NoOp"),
+    instructions.Eq(),
+    instructions.BNZ("handle_noop"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("OptIn"),
+    instructions.Eq(),
+    instructions.BNZ("handle_optin"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("CloseOut"),
+    instructions.Eq(),
+    instructions.BNZ("handle_closeout"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("DeleteApplication"),
+    instructions.Eq(),
+    instructions.BNZ("handle_deleteapp"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("handle_noop"),
+    instructions.Label("handle_optin"),
+    instructions.Label("handle_closeout"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("handle_deleteapp"),
+    instructions.Err(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 7),
+    (7, 12),
+    (12, 16),
+    (16, 20),
+    (20, 24),
+    (24, 26),
+    (26, 27),
+    (27, 28),
+    (28, 31),
+    (31, 33),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 2),
+    (2, 3),
+    (2, 7),
+    (3, 4),
+    (3, 8),
+    (4, 5),
+    (4, 9),
+    (5, 6),
+    (5, 10),
+    (7, 8),
+    (8, 9),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_UPDATE_VULNERABLE_PATHS = [
+    [bbs[0], bbs[2], bbs[3], bbs[4], bbs[5], bbs[6]],
+]
+
+
+CAN_UPDATE_LOOP = """
+#pragma version 4
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    txn OnCompletion
+    int NoOp
+    ==
+    bnz handle_noop
+    txn OnCompletion
+    int OptIn
+    ==
+    bnz handle_optin
+    txn OnCompletion
+    int CloseOut
+    ==
+    bnz handle_closeout
+    txn OnCompletion
+    int DeleteApplication
+    ==
+    bnz handle_deleteapp
+    b loop
+handle_noop:
+handle_optin:
+handle_closeout:
+int 1
+return
+handle_deleteapp:
+err
+loop:
+    load 0
+    int 5
+    <
+    bz end
+    load 0
+    int 1
+    +
+    store 0
+    b loop
+end:
+    int 1
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(4),
+    instructions.Int(0),
+    instructions.Txn(transaction_field.ApplicationID()),
+    instructions.Eq(),
+    instructions.BZ("not_creation"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("not_creation"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("NoOp"),
+    instructions.Eq(),
+    instructions.BNZ("handle_noop"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("OptIn"),
+    instructions.Eq(),
+    instructions.BNZ("handle_optin"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("CloseOut"),
+    instructions.Eq(),
+    instructions.BNZ("handle_closeout"),
+    instructions.Txn(transaction_field.OnCompletion()),
+    instructions.Int("DeleteApplication"),
+    instructions.Eq(),
+    instructions.BNZ("handle_deleteapp"),
+    instructions.B("loop"),
+    instructions.Label("handle_noop"),
+    instructions.Label("handle_optin"),
+    instructions.Label("handle_closeout"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("handle_deleteapp"),
+    instructions.Err(),
+    instructions.Label("loop"),
+    instructions.Load(0),
+    instructions.Int(5),
+    instructions.Less(),
+    instructions.BZ("end"),
+    instructions.Load(0),
+    instructions.Int(1),
+    instructions.Add(),
+    instructions.Store(0),
+    instructions.B("loop"),
+    instructions.Label("end"),
+    instructions.Int(1),
+    instructions.Return(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 7),
+    (7, 12),
+    (12, 16),
+    (16, 20),
+    (20, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 30),
+    (30, 32),
+    (32, 37),
+    (37, 42),
+    (42, 45),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 2),
+    (2, 3),
+    (2, 7),
+    (3, 4),
+    (3, 8),
+    (4, 5),
+    (4, 9),
+    (5, 6),
+    (5, 10),
+    (7, 8),
+    (8, 9),
+    (6, 11),
+    (11, 12),
+    (11, 13),
+    (12, 11),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+CAN_UPDATE_LOOP_VULNERABLE_PATHS = [
+    [bbs[0], bbs[2], bbs[3], bbs[4], bbs[5], bbs[6], bbs[11], bbs[13]],
+]
+
+
+can_update_tests = [
+    (CAN_UPDATE, CanUpdate, CAN_UPDATE_VULNERABLE_PATHS),
+    (CAN_UPDATE_LOOP, CanUpdate, CAN_UPDATE_LOOP_VULNERABLE_PATHS),
+]

--- a/tests/detectors/fee_check.py
+++ b/tests/detectors/fee_check.py
@@ -1,0 +1,240 @@
+from tealer.teal.instructions import instructions, transaction_field
+from tealer.detectors.all_detectors import MissingFeeCheck
+from tealer.teal import global_field
+
+from tests.utils import construct_cfg
+
+
+MISSING_FEE_CHECK = """
+#pragma version 2
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver 
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn CloseRemainderTo
+global ZeroAddress
+==
+bz closing_account
+txn AssetCloseTo
+global ZeroAddress
+==
+bz closing_asset
+global GroupSize
+int 1
+==
+bz unexpected_group_size
+int 1
+return
+wrongreceiver:
+rekeying:
+closing_account:
+closing_asset:
+unexpected_group_size:
+    err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.CloseRemainderTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_account"),
+    instructions.Txn(transaction_field.AssetCloseTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_asset"),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(1),
+    instructions.Eq(),
+    instructions.BZ("unexpected_group_size"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_account"),
+    instructions.Label("closing_asset"),
+    instructions.Label("unexpected_group_size"),
+    instructions.Err(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+MISSING_FEE_CHECK_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5]],
+]
+
+
+MISSING_FEE_CHECK_LOOP = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver 
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn CloseRemainderTo
+global ZeroAddress
+==
+bz closing_account
+txn AssetCloseTo
+global ZeroAddress
+==
+bz closing_asset
+global GroupSize
+int 1
+==
+bz unexpected_group_size
+int 0
+b loop
+wrongreceiver:
+rekeying:
+closing_account:
+closing_asset:
+unexpected_group_size:
+    err
+loop:
+    dup
+    int 5
+    <
+    bz end
+    int 1
+    +
+    b loop
+end:
+    int 1
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(4),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.CloseRemainderTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_account"),
+    instructions.Txn(transaction_field.AssetCloseTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_asset"),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(1),
+    instructions.Eq(),
+    instructions.BZ("unexpected_group_size"),
+    instructions.Int(0),
+    instructions.B("loop"),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_account"),
+    instructions.Label("closing_asset"),
+    instructions.Label("unexpected_group_size"),
+    instructions.Err(),
+    instructions.Label("loop"),
+    instructions.Dup(),
+    instructions.Int(5),
+    instructions.Less(),
+    instructions.BZ("end"),
+    instructions.Int(1),
+    instructions.Add(),
+    instructions.B("loop"),
+    instructions.Label("end"),
+    instructions.Int(1),
+    instructions.Return(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+    (29, 34),
+    (34, 37),
+    (37, 40),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (5, 11),
+    (11, 12),
+    (11, 13),
+    (12, 11),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+MISSING_FEE_CHECK_LOOP_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5], bbs[11], bbs[13]]
+]
+
+
+missing_fee_check_tests = [
+    (MISSING_FEE_CHECK, MissingFeeCheck, MISSING_FEE_CHECK_VULNERABLE_PATHS),
+    (MISSING_FEE_CHECK_LOOP, MissingFeeCheck, MISSING_FEE_CHECK_LOOP_VULNERABLE_PATHS),
+]

--- a/tests/detectors/groupsize.py
+++ b/tests/detectors/groupsize.py
@@ -1,0 +1,242 @@
+from tealer.teal.instructions import instructions, transaction_field
+from tealer.detectors.all_detectors import MissingGroupSize
+from tealer.teal import global_field
+
+from tests.utils import construct_cfg
+
+
+MISSING_GROUP_SIZE = """
+#pragma version 2
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver
+txn Fee
+int 10000
+<
+bz highfee
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn CloseRemainderTo
+global ZeroAddress
+==
+bz closing_account
+txn AssetCloseTo
+global ZeroAddress
+==
+bz closing_asset
+int 1
+return
+wrongreceiver:
+highfee:
+rekeying:
+closing_account:
+closing_asset:
+    err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.Fee()),
+    instructions.Int(10000),
+    instructions.Less(),
+    instructions.BZ("highfee"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.CloseRemainderTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_account"),
+    instructions.Txn(transaction_field.AssetCloseTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_asset"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("highfee"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_account"),
+    instructions.Label("closing_asset"),
+    instructions.Err(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+MISSING_GROUP_SIZE_VULNERABLE_PATHS = [[bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5]]]
+
+
+MISSING_GROUP_SIZE_LOOP = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver 
+txn Fee
+int 10000
+<
+bz highfee
+txn RekeyTo
+global ZeroAddress
+==
+bz rekeying
+txn CloseRemainderTo
+global ZeroAddress
+==
+bz closing_account
+txn AssetCloseTo
+global ZeroAddress
+==
+bz closing_asset
+int 0
+b loop
+wrongreceiver:
+highfee:
+rekeying:
+closing_account:
+closing_asset:
+    err
+loop:
+    dup
+    int 5
+    <
+    bz end
+    int 1
+    +
+    b loop
+end:
+    int 1
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(4),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.Fee()),
+    instructions.Int(10000),
+    instructions.Less(),
+    instructions.BZ("highfee"),
+    instructions.Txn(transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("rekeying"),
+    instructions.Txn(transaction_field.CloseRemainderTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_account"),
+    instructions.Txn(transaction_field.AssetCloseTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_asset"),
+    instructions.Int(0),
+    instructions.B("loop"),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("highfee"),
+    instructions.Label("rekeying"),
+    instructions.Label("closing_account"),
+    instructions.Label("closing_asset"),
+    instructions.Err(),
+    instructions.Label("loop"),
+    instructions.Dup(),
+    instructions.Int(5),
+    instructions.Less(),
+    instructions.BZ("end"),
+    instructions.Int(1),
+    instructions.Add(),
+    instructions.B("loop"),
+    instructions.Label("end"),
+    instructions.Int(1),
+    instructions.Return(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+    (29, 34),
+    (34, 37),
+    (37, 40),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+    (5, 11),
+    (11, 12),
+    (11, 13),
+    (12, 11),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+MISSING_GROUP_SIZE_LOOP_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5], bbs[11], bbs[13]],
+]
+
+
+missing_group_size_tests = [
+    (MISSING_GROUP_SIZE, MissingGroupSize, MISSING_GROUP_SIZE_VULNERABLE_PATHS),
+    (MISSING_GROUP_SIZE_LOOP, MissingGroupSize, MISSING_GROUP_SIZE_LOOP_VULNERABLE_PATHS),
+]

--- a/tests/detectors/rekeyto.py
+++ b/tests/detectors/rekeyto.py
@@ -1,0 +1,146 @@
+from tealer.teal.instructions import instructions, transaction_field
+from tealer.teal import global_field
+from tealer.detectors.all_detectors import MissingRekeyTo
+
+from tests.utils import construct_cfg
+
+
+MISSING_REKEYTO = """
+#pragma version 2
+global GroupSize
+int 2
+gtxn 0 TypeEnum
+int axfer
+==
+&&
+gtxn 1 TypeEnum
+int pay
+==
+&&
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+&&
+bz failed
+int 1
+return
+failed:
+    err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(2),
+    instructions.Gtxn(0, transaction_field.TypeEnum()),
+    instructions.Int("axfer"),
+    instructions.Eq(),
+    instructions.And(),
+    instructions.Gtxn(1, transaction_field.TypeEnum()),
+    instructions.Int("pay"),
+    instructions.Eq(),
+    instructions.And(),
+    instructions.Gtxn(0, transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.And(),
+    instructions.BZ("failed"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("failed"),
+    instructions.Err(),
+]
+
+ins_partitions = [(0, 16), (16, 18), (18, 20)]
+bbs_links = [(0, 1), (0, 2)]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+MISSING_REKEYTO_VULNERABLE_PATHS = [
+    [
+        bbs[0],
+        bbs[1],
+    ],  # doesn't check for 2nd transaction. missing Gtxn 1 RekeyTo == Global ZeroAddress
+]
+
+
+MISSING_REKEYTO_LOOP = """
+#pragma version 4
+global GroupSize
+int 2
+gtxn 0 TypeEnum
+int axfer
+==
+&&
+gtxn 1 TypeEnum
+int pay
+==
+&&
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+&&
+bz failed
+b loop
+failed:
+    err
+loop:
+    dup
+    int 5
+    <
+    bz end
+    int 1
+    +
+    b loop
+end:
+    int 1
+    return
+"""
+
+ins_list = [
+    instructions.Pragma(4),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(2),
+    instructions.Gtxn(0, transaction_field.TypeEnum()),
+    instructions.Int("axfer"),
+    instructions.Eq(),
+    instructions.And(),
+    instructions.Gtxn(1, transaction_field.TypeEnum()),
+    instructions.Int("pay"),
+    instructions.Eq(),
+    instructions.And(),
+    instructions.Gtxn(0, transaction_field.RekeyTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.And(),
+    instructions.BZ("failed"),
+    instructions.B("loop"),
+    instructions.Label("failed"),
+    instructions.Err(),
+    instructions.Label("loop"),
+    instructions.Dup(),
+    instructions.Int(5),
+    instructions.Less(),
+    instructions.BZ("end"),
+    instructions.Int(1),
+    instructions.Add(),
+    instructions.B("loop"),
+    instructions.Label("end"),
+    instructions.Int(1),
+    instructions.Return(),
+]
+
+ins_partitions = [(0, 16), (16, 17), (17, 19), (19, 24), (24, 27), (27, 30)]
+bbs_links = [(0, 1), (0, 2), (1, 3), (3, 4), (3, 5), (4, 3)]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+MISSING_REKEYTO_LOOP_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[3], bbs[5]]  # missing Gtxn 1 RekeyTo == Global ZeroAddress.
+]
+
+
+missing_rekeyto_tests = [
+    (MISSING_REKEYTO, MissingRekeyTo, MISSING_REKEYTO_VULNERABLE_PATHS),
+    (MISSING_REKEYTO_LOOP, MissingRekeyTo, MISSING_REKEYTO_LOOP_VULNERABLE_PATHS),
+]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1,0 +1,38 @@
+from typing import Tuple, List, Type
+import pytest
+
+from tealer.teal.basic_blocks import BasicBlock
+from tealer.detectors.abstract_detector import AbstractDetector
+from tealer.teal.parse_teal import parse_teal
+
+from tests.detectors.groupsize import missing_group_size_tests
+from tests.detectors.fee_check import missing_fee_check_tests
+from tests.detectors.can_close_account import can_close_account_tests
+from tests.detectors.can_close_asset import can_close_asset_tests
+from tests.detectors.can_delete import can_delete_tests
+from tests.detectors.can_update import can_update_tests
+from tests.detectors.rekeyto import missing_rekeyto_tests
+
+from tests.utils import cmp_cfg
+
+
+ALL_TESTS = [
+    *missing_group_size_tests,
+    *missing_fee_check_tests,
+    *can_close_account_tests,
+    *can_close_asset_tests,
+    *can_delete_tests,
+    *can_update_tests,
+    *missing_rekeyto_tests,
+]
+
+
+@pytest.mark.parametrize("test", ALL_TESTS)
+def test_detectors(test: Tuple[str, Type[AbstractDetector], List[List[BasicBlock]]]) -> None:
+    code, detector, expected_paths = test
+    teal = parse_teal(code.strip())
+    teal.register_detector(detector)
+    result = teal.run_detectors()[0]
+    assert len(result.paths) == len(expected_paths)
+    for path, ex_path in zip(result.paths, expected_paths):
+        assert cmp_cfg(path, ex_path)


### PR DESCRIPTION
Tests use manually constructed CFGs and vulnerable execuation paths for comparison, instead of using json output and deepdiff.
Tests are added for detectors `MissingGroupSize`, `MissingFeeCheck`, `CanCloseAccount`, `CanCloseAsset`, `CanUpdate`, `CanDelete` and `MissingRekeyTo`.
Each detector have two tests, one containing loop in the vulnerable path and one without it.