### PR TITLE
Adds function for finding paths missing self rekeying check 

### DIFF
--- a/tealer/detectors/rekeyto.py
+++ b/tealer/detectors/rekeyto.py
@@ -8,11 +8,23 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.teal.instructions.instructions import Gtxn, Return, Int
+from tealer.teal.instructions.instructions import Gtxn, Return, Int, Txn, Global, Addr, Eq, Neq
 from tealer.teal.instructions.transaction_field import RekeyTo
+from tealer.teal.global_field import ZeroAddress
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
+    from tealer.teal.instructions.instructions import Instruction
+
+
+def _is_rekey_check(ins1: "Instruction", ins2: "Instruction") -> bool:
+    """check if ins1 is txn RekeyTo and ins2 is global ZeroAddress or addr ..."""
+    if isinstance(ins1, Txn) and isinstance(ins1.field, RekeyTo):
+        if isinstance(ins2, Global) and isinstance(ins2.field, ZeroAddress):
+            return True
+        if isinstance(ins2, Addr):
+            return True
+    return False
 
 
 class MissingRekeyTo(AbstractDetector):
@@ -39,7 +51,48 @@ Attacker creates a payment transaction using the contract with `rekey-to` set to
 Add a check in the contract code verifying that `RekeyTo` property of any transaction is set to `ZeroAddress`.
 """
 
-    def check_rekey_to(  # pylint: disable=too-many-arguments
+    def _check_rekey_to_contract(
+        self,
+        bb: "BasicBlock",
+        current_path: List["BasicBlock"],
+        paths_without_check: List[List["BasicBlock"]],
+    ) -> None:
+        """find execution paths with missing `txn RekeyTo (== | !=) (global ZeroAddress | Addr ..)`
+
+        This function checks for rekeying of this contract i.e whether the contract is checking for
+        rekeying of itself.
+
+        """
+        # check for loops
+        if bb in current_path:
+            return
+
+        current_path = current_path + [bb]
+
+        stack: List["Instruction"] = []
+
+        for ins in bb.instructions:
+            if isinstance(ins, Return):
+                if len(ins.prev) == 1:
+                    prev = ins.prev[0]
+                    if isinstance(prev, Int) and prev.value == 0:
+                        return
+
+                paths_without_check.append(current_path)
+                return
+
+            if isinstance(ins, (Eq, Neq)) and len(stack) >= 2:
+                one = stack[-1]
+                two = stack[-2]
+                if _is_rekey_check(one, two) or _is_rekey_check(two, one):
+                    return
+
+            stack.append(ins)
+
+        for next_bb in bb.next:
+            self._check_rekey_to_contract(next_bb, current_path, paths_without_check)
+
+    def check_rekey_to_group(  # pylint: disable=too-many-arguments
         self,
         bb: BasicBlock,
         group_tx: Dict[int, Set[BasicBlock]],
@@ -47,6 +100,15 @@ Add a check in the contract code verifying that `RekeyTo` property of any transa
         current_path: List[BasicBlock],
         paths_without_check: List[List[BasicBlock]],
     ) -> None:
+        """find execution paths with missing rekey checks of other transactions in the group.
+
+        This check finds paths which doesn't check RekeyTo field of other transactions in the group.
+        Information about index of other transactions in the group is calculated using Gtxn instruction.
+        Suppose, if there's an instruction `Gtxn 2 Sender`, then 2 is the index of other transaction
+        in the group and function checks for instruction `Gtxn 2 RekeyTo` and reports execution paths
+        missing that check. This is repeated for all indexes of group transactions found.
+
+        """
         # check for loops
         if bb in current_path:
             return
@@ -74,15 +136,33 @@ Add a check in the contract code verifying that `RekeyTo` property of any transa
                 paths_without_check.append(current_path)
 
         for next_bb in bb.next:
-            self.check_rekey_to(next_bb, group_tx, idx_fitlered, current_path, paths_without_check)
+            self.check_rekey_to_group(
+                next_bb, group_tx, idx_fitlered, current_path, paths_without_check
+            )
 
     def detect(self) -> "SupportedOutput":
 
         paths_without_check: List[List[BasicBlock]] = []
-        self.check_rekey_to(self.teal.bbs[0], defaultdict(set), set(), [], paths_without_check)
+        self.check_rekey_to_group(
+            self.teal.bbs[0], defaultdict(set), set(), [], paths_without_check
+        )
+
+        self._check_rekey_to_contract(self.teal.bbs[0], [], paths_without_check)
+
+        # paths might repeat as cfg traversed twice, once for each check
+        paths_without_check_unique = []
+        added_paths = []
+        for path in paths_without_check:
+            short = " -> ".join(map(str, [bb.idx for bb in path]))
+            if short in added_paths:
+                continue
+            paths_without_check_unique.append(path)
+            added_paths.append(short)
 
         description = "Lack of txn RekeyTo check allows rekeying the account to"
-        description += " attacker controlled address and control the account directly"
+        description += " attacker controlled address and control the account directly."
+        description += "\nExecution paths with missing rekeyTo check of the current transaction and"
+        description += "missing rekeyTo check of other transactions in the group."
         filename = "missing_rekeyto_check"
 
-        return self.generate_result(paths_without_check, description, filename)
+        return self.generate_result(paths_without_check_unique, description, filename)

--- a/tests/detectors/rekeyto.py
+++ b/tests/detectors/rekeyto.py
@@ -140,7 +140,110 @@ MISSING_REKEYTO_LOOP_VULNERABLE_PATHS = [
 ]
 
 
+MISSING_REKEYTO_STATELESS = """
+#pragma version 2
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+bz wrongreceiver
+txn Fee
+int 10000
+<
+bz highfee
+txn CloseRemainderTo
+global ZeroAddress
+==
+bz closing_account
+txn AssetCloseTo
+global ZeroAddress
+==
+bz closing_asset
+global GroupSize
+int 1
+==
+bz unexpected_group_size
+int 1
+return
+wrongreceiver:
+highfee:
+closing_account:
+closing_asset:
+unexpected_group_size:
+    err
+"""
+
+ins_list = [
+    instructions.Pragma(2),
+    instructions.Txn(transaction_field.Receiver()),
+    instructions.Addr("6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM"),
+    instructions.Eq(),
+    instructions.BZ("wrongreceiver"),
+    instructions.Txn(transaction_field.Fee()),
+    instructions.Int(10000),
+    instructions.Less(),
+    instructions.BZ("highfee"),
+    instructions.Txn(transaction_field.CloseRemainderTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_account"),
+    instructions.Txn(transaction_field.AssetCloseTo()),
+    instructions.Global(global_field.ZeroAddress()),
+    instructions.Eq(),
+    instructions.BZ("closing_asset"),
+    instructions.Global(global_field.GroupSize()),
+    instructions.Int(1),
+    instructions.Eq(),
+    instructions.BZ("unexpected_group_size"),
+    instructions.Int(1),
+    instructions.Return(),
+    instructions.Label("wrongreceiver"),
+    instructions.Label("highfee"),
+    instructions.Label("closing_account"),
+    instructions.Label("closing_asset"),
+    instructions.Label("unexpected_group_size"),
+    instructions.Err(),
+]
+
+ins_partitions = [
+    (0, 5),
+    (5, 9),
+    (9, 13),
+    (13, 17),
+    (17, 21),
+    (21, 23),
+    (23, 24),
+    (24, 25),
+    (25, 26),
+    (26, 27),
+    (27, 29),
+]
+
+bbs_links = [
+    (0, 1),
+    (0, 6),
+    (1, 2),
+    (1, 7),
+    (2, 3),
+    (2, 8),
+    (3, 4),
+    (3, 9),
+    (4, 5),
+    (4, 10),
+    (6, 7),
+    (7, 8),
+    (8, 9),
+    (9, 10),
+]
+
+bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+MISSING_REKEYTO_STATELESS_VULNERABLE_PATHS = [
+    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5]],
+]
+
+
 missing_rekeyto_tests = [
     (MISSING_REKEYTO, MissingRekeyTo, MISSING_REKEYTO_VULNERABLE_PATHS),
     (MISSING_REKEYTO_LOOP, MissingRekeyTo, MISSING_REKEYTO_LOOP_VULNERABLE_PATHS),
+    (MISSING_REKEYTO_STATELESS, MissingRekeyTo, MISSING_REKEYTO_STATELESS_VULNERABLE_PATHS),
 ]


### PR DESCRIPTION
Present rekeyTo finds paths with missing RekeyTo field check of other transactions in the group.
This PR adds function which finds paths with missing checks for self rekeying i.e whether contract is checking RekeyTo field of the transaction that resulted in this contract execution.
Only unique paths are reported after paths found by the two checks are combined. 