### PR TITLE
Add impact, confidence to list-detectors output table

### DIFF
--- a/tealer/utils/command_line.py
+++ b/tealer/utils/command_line.py
@@ -2,7 +2,11 @@ from typing import List, Type
 
 from prettytable import PrettyTable
 
-from tealer.detectors.abstract_detector import DETECTOR_TYPE_TXT, AbstractDetector
+from tealer.detectors.abstract_detector import (
+    DETECTOR_TYPE_TXT,
+    AbstractDetector,
+    classification_txt,
+)
 from tealer.printers.abstract_printer import AbstractPrinter
 
 
@@ -12,16 +16,20 @@ def output_detectors(detector_classes: List[Type[AbstractDetector]]) -> None:
         name = detector.NAME
         description = detector.DESCRIPTION
         detector_type = DETECTOR_TYPE_TXT[detector.TYPE]
-        detectors_list.append((name, description, detector_type))
-    table = PrettyTable(["Num", "Check", "What it Detects", "Type"])
+        detector_impact = classification_txt[detector.IMPACT]
+        detector_confidence = classification_txt[detector.CONFIDENCE]
+        detectors_list.append(
+            (name, description, detector_type, detector_impact, detector_confidence)
+        )
+    table = PrettyTable(["Num", "Check", "What it Detects", "Type", "Impact", "Confidence"])
 
     # Sort by type, name, and description
     detectors_list = sorted(
         detectors_list, key=lambda element: (element[2], element[0], element[1])
     )
     idx = 1
-    for (name, description, detector_type) in detectors_list:
-        table.add_row([idx, name, description, detector_type])
+    for (name, description, detector_type, impact, confidence) in detectors_list:
+        table.add_row([idx, name, description, detector_type, impact, confidence])
         idx = idx + 1
     print(table)
 

--- a/tealer/utils/command_line.py
+++ b/tealer/utils/command_line.py
@@ -16,20 +16,30 @@ def output_detectors(detector_classes: List[Type[AbstractDetector]]) -> None:
         name = detector.NAME
         description = detector.DESCRIPTION
         detector_type = DETECTOR_TYPE_TXT[detector.TYPE]
-        detector_impact = classification_txt[detector.IMPACT]
-        detector_confidence = classification_txt[detector.CONFIDENCE]
+        detector_impact = detector.IMPACT
+        detector_confidence = detector.CONFIDENCE
         detectors_list.append(
             (name, description, detector_type, detector_impact, detector_confidence)
         )
     table = PrettyTable(["Num", "Check", "What it Detects", "Type", "Impact", "Confidence"])
 
-    # Sort by type, name, and description
+    # Sort by type, impact, confidence, name, and description
     detectors_list = sorted(
-        detectors_list, key=lambda element: (element[2], element[0], element[1])
+        detectors_list,
+        key=lambda element: (element[2], element[3], element[4], element[0], element[1]),
     )
     idx = 1
     for (name, description, detector_type, impact, confidence) in detectors_list:
-        table.add_row([idx, name, description, detector_type, impact, confidence])
+        table.add_row(
+            [
+                idx,
+                name,
+                description,
+                detector_type,
+                classification_txt[impact],
+                classification_txt[confidence],
+            ]
+        )
         idx = idx + 1
     print(table)
 


### PR DESCRIPTION
Impact and confidence of detectors are not displayed while detectors are listed. 
This PR adds `impact`, `confidence` columns to `--list-detectors` output table.