### PR TITLE
Adds wiki exploit scenario and recommendation to groupSize detector

### DIFF
--- a/tealer/detectors/groupsize.py
+++ b/tealer/detectors/groupsize.py
@@ -26,10 +26,20 @@ class MissingGroupSize(AbstractDetector):  # pylint: disable=too-few-public-meth
     WIKI_TITLE = "Missing GroupSize check"
     WIKI_DESCRIPTION = "Detect paths with a missing GroupSize check"
     WIKI_EXPLOIT_SCENARIO = """
-**TODO**
+Consider the system consisting of two contracts, designed in such a way that first contract should be called by the
+first transaction of the group and second one by the second transaction. first contract handles all the verification,
+second contract approves the transfer of certain amount of assets if first contract approves its transaction.
+ofcourse, second contract verifies that first transaction in the group is call to the first contract.
+
+Possible exploit scenario is if second contract **only** verifies that first transaction is a call to first contract and
+doesn't check the group size to the expected value of `2`. The attacker could add an additional transaction(s) which are
+copy of second transaction i.e transfer of assets. As all the transactions to second contract only verify the first transaction,
+the attacker may possibly transfer all the assets by appending transactions which are each a copy of second transaction.
+
+Attacker can get upto 14 times(max atomic group size 16) more than the intended amount.
 """
     WIKI_RECOMMENDATION = """
-**TODO**
+Always verify that group size(number of transactions in atomic group) is equal to what logic is expecting.
 """
 
     def __init__(self, teal: Teal):


### PR DESCRIPTION
Exploit Scenario :-
```
Consider the system consisting of two contracts, designed in such a way that first contract should be called by the
first transaction of the group and second one by the second transaction. first contract handles all the verification,
second contract approves the transfer of certain amount of assets if first contract approves its transaction.
ofcourse, second contract verifies that first transaction in the group is call to the first contract.

Possible exploit scenario is if second contract **only** verifies that first transaction is a call to first contract and
doesn't check the group size to the expected value of `2`. The attacker could add an additional transaction(s) which are
copy of second transaction i.e transfer of assets. As all the transactions to second contract only verify the first transaction,
the attacker may possibly transfer all the assets by appending transactions which are each a copy of second transaction.

Attacker can get upto 14 times(max atomic group size 16) more than the intended amount.
```

Recommendation :-
`Always verify that group size(number of transactions in atomic group) is equal to what logic is expecting.`

