### PR TITLE
Add documentation to tealer.teal.instructions modules

### DIFF
--- a/tealer/teal/instructions/__init__.py
+++ b/tealer/teal/instructions/__init__.py
@@ -1,0 +1,33 @@
+"""Contains functions, classes for parsing and representing teal instructions.
+
+For representing teal code, this module contains classes for teal
+instructions, transaction fields, App parameter fields, Asset parameter
+fields and Asset holding fields.
+
+This module also contains implementations of parsers for instructions,
+global fields, transaction fields, App parameter fields,
+Asset parameter fields and Asset holding fields.
+
+Modules:
+    app_params_field: Defines classes to represent app parameter fields.
+
+    asset_holding_field: Defines classes to represent asset holding fields.
+
+    asset_params_field: Defines classes to represent asset parameter fields.
+
+    instructions: Defines classes to represent teal instructions.
+
+    parse_app_params_field: Parser for app parameter fields.
+
+    parse_asset_holding_field: Parser for asset holding fields.
+
+    parse_asset_params_field: Parser for asset parameter fields.
+
+    parse_global_field: Parser for global fields.
+
+    parse_instruction: Parser for teal instructions.
+
+    parse_transaction_field: Parser for transaction fields.
+
+    transaction_field: Defines classes to represent transaction fields.
+"""

--- a/tealer/teal/instructions/app_params_field.py
+++ b/tealer/teal/instructions/app_params_field.py
@@ -1,3 +1,14 @@
+"""Defines classes to represent app_params_get fields.
+
+``app_params_get`` instruction is used to access parameter fields
+of an application in the contract.
+
+Each field that can be accessed using app_params_get is represented
+by a class in tealer. All the classes representing the fields must
+inherit from AppParamsField class.
+
+"""
+
 # pylint: disable=too-few-public-methods
 class AppParamsField:
     """Base class to represent App fields."""
@@ -7,6 +18,7 @@ class AppParamsField:
 
     @property
     def version(self) -> int:
+        """Teal version this field is introduced in and supported from."""
         return self._version
 
     def __str__(self) -> str:
@@ -14,11 +26,11 @@ class AppParamsField:
 
 
 class AppApprovalProgram(AppParamsField):
-    """Bytecode of approval program."""
+    """Bytecode of approval program of the App."""
 
 
 class AppClearStateProgram(AppParamsField):
-    """Bytecode of clear state program."""
+    """Bytecode of clear state program of the App."""
 
 
 class AppGlobalNumUint(AppParamsField):
@@ -42,7 +54,7 @@ class AppExtraProgramPages(AppParamsField):
 
 
 class AppCreator(AppParamsField):
-    """Creator address."""
+    """Address of Creator(deployer) of the application."""
 
 
 class AppAddress(AppParamsField):

--- a/tealer/teal/instructions/asset_holding_field.py
+++ b/tealer/teal/instructions/asset_holding_field.py
@@ -1,12 +1,24 @@
+"""Defines classes to represent asset_holding_get fields.
+
+``asset_holding_get`` instruction is used to access holding fields
+of an asset for the given account.
+
+Each field that can be accessed using asset_holding_get is represented
+by a class in tealer. All the classes representing the fields must inherit
+from AssetHoldingField class.
+
+"""
+
 # pylint: disable=too-few-public-methods
 class AssetHoldingField:
-    """Base class to represent asset holding field."""
+    """Base class to represent asset_holding_get field."""
 
     def __init__(self) -> None:
         self._version: int = 2
 
     @property
     def version(self) -> int:
+        """Teal version this field is introduced in and supported from."""
         return self._version
 
     def __str__(self) -> str:

--- a/tealer/teal/instructions/asset_params_field.py
+++ b/tealer/teal/instructions/asset_params_field.py
@@ -1,3 +1,14 @@
+"""Defines classes to represent asset_params_get fields.
+
+``asset_params_get`` instruction is used to access parameter fields
+of an asset.
+
+Each field that can be accessed using asset_params_get is represented
+by a class in tealer. All the classes representing the fields must inherit
+from AssetParamsField class.
+
+"""
+
 # pylint: disable=too-few-public-methods
 class AssetParamsField:
     """Base class to represent asset_params_get field."""
@@ -7,6 +18,7 @@ class AssetParamsField:
 
     @property
     def version(self) -> int:
+        """Teal version this field is introduced in and supported from."""
         return self._version
 
     def __str__(self) -> str:
@@ -42,19 +54,35 @@ class AssetMetadataHash(AssetParamsField):
 
 
 class AssetManager(AssetParamsField):
-    """Manager address, only account that can authorize transactions to re-configure or destroy an asset."""
+    """Manager address of the asset.
+
+    Manager account is the only account that can authorize transactions
+    to re-configure or destroy an asset.
+    """
 
 
 class AssetReserve(AssetParamsField):
-    """Reserve address, where non-minted assets will reside."""
+    """Reserve address of the asset.
+
+    Non-minted assets will reside in Reserve address instead of creator
+    address if specified.
+    """
 
 
 class AssetFreeze(AssetParamsField):
-    """Freeze account, which is allowed to freeze or unfreeze the asset holding for an account."""
+    """Freeze address of the asset.
+
+    The freeze account is allowed to freeze or unfreeze the asset holdings
+    for a specific account.
+    """
 
 
 class AssetClawback(AssetParamsField):
-    """Clawback address, which can transfer assets from and to any asset holder."""
+    """Clawback address of the asset.
+
+    The clawback address represents an account that is allowed to transfer
+    assets from and to any asset holder.
+    """
 
 
 class AssetCreator(AssetParamsField):

--- a/tealer/teal/instructions/parse_app_params_field.py
+++ b/tealer/teal/instructions/parse_app_params_field.py
@@ -1,3 +1,21 @@
+"""Parser for fields of app_params_get.
+
+Each ``app_params_get`` field is represented as a class. Parsing
+the field is creating the class instance representing the field given
+it's string representation.
+
+Fields of ``app_params_get`` doesn't have immediate arguments
+and have very simple structure. All fields map one-to-one with
+their string representation. As a result, app parameter fields are
+parsed by first constructing a map(dict) from their string
+representation to corresponding class representing the field and
+using that to find the correct class for the given field.
+
+Attributes:
+    APP_PARAMS_FIELD_TXT_TO_OBJECT: Map(dict) from string representation
+        of app parameter field to the corresponding class.
+"""
+
 from tealer.teal.instructions.app_params_field import (
     AppParamsField,
     AppApprovalProgram,
@@ -10,6 +28,7 @@ from tealer.teal.instructions.app_params_field import (
     AppCreator,
     AppAddress,
 )
+
 
 APP_PARAMS_FIELD_TXT_TO_OBJECT = {
     "AppParamsField": AppParamsField,
@@ -26,4 +45,13 @@ APP_PARAMS_FIELD_TXT_TO_OBJECT = {
 
 
 def parse_app_params_field(field: str) -> AppParamsField:
+    """Parse fields of ``app_params_get``.
+
+    Args:
+        field: string representation of the field.
+
+    Returns:
+        object of class corresponding to the given app_params_get field.
+    """
+
     return APP_PARAMS_FIELD_TXT_TO_OBJECT[field]()

--- a/tealer/teal/instructions/parse_asset_holding_field.py
+++ b/tealer/teal/instructions/parse_asset_holding_field.py
@@ -1,3 +1,21 @@
+"""Parser for fields of asset_holding_get.
+
+Each ``asset_holding_get`` field is represented as a class. Parsing
+the field is creating the class instance representing the field given
+it's string representation.
+
+Fields of ``asset_holding_get`` doesn't have immediate arguments
+and have very simple structure. All fields map one-to-one with
+their string representation. As a result, asset holding fields are
+parsed by first constructing a map(dict) from their string
+representation to corresponding class representing the field and
+using that to find the correct class for the given field.
+
+Attributes:
+    ASSET_HOLDING_FIELD_TXT_TO_OBJECT: Map(dict) from string representation
+        of asset holding field to the corresponding class.
+"""
+
 from tealer.teal.instructions.asset_holding_field import (
     AssetHoldingField,
     AssetBalance,
@@ -8,4 +26,13 @@ ASSET_HOLDING_FIELD_TXT_TO_OBJECT = {"AssetBalance": AssetBalance, "AssetFrozen"
 
 
 def parse_asset_holding_field(field: str) -> AssetHoldingField:
+    """Parse fields of ``asset_holding_get``.
+
+    Args:
+        field: string representation of the field.
+
+    Returns:
+        object of class corresponding to the given asset_holding_get field.
+    """
+
     return ASSET_HOLDING_FIELD_TXT_TO_OBJECT[field]()

--- a/tealer/teal/instructions/parse_asset_params_field.py
+++ b/tealer/teal/instructions/parse_asset_params_field.py
@@ -1,3 +1,21 @@
+"""Parser for fields of asset_params_get.
+
+Each ``asset_params_get`` field is represented as a class. Parsing
+the field is creating the class instance representing the field given
+it's string representation.
+
+Fields of ``asset_params_get`` doesn't have immediate arguments
+and have very simple structure. All fields map one-to-one with
+their string representation. As a result, asset parameter fields are
+parsed by first constructing a map(dict) from their string
+representation to corresponding class representing the field and
+using that to find the correct class for the given field.
+
+Attributes:
+    ASSET_PARAMS_FIELD_TXT_TO_OBJECT: Map(dict) from string representation
+        of asset parameter field to the corresponding class.
+"""
+
 from tealer.teal.instructions.asset_params_field import (
     AssetParamsField,
     AssetTotal,
@@ -31,4 +49,13 @@ ASSET_PARAMS_FIELD_TXT_TO_OBJECT = {
 
 
 def parse_asset_params_field(field: str) -> AssetParamsField:
+    """Parse fields of ``asset_params_get``.
+
+    Args:
+        field: string representation of the field.
+
+    Returns:
+        object of class corresponding to the given asset_params_get field.
+    """
+
     return ASSET_PARAMS_FIELD_TXT_TO_OBJECT[field]()

--- a/tealer/teal/instructions/parse_global_field.py
+++ b/tealer/teal/instructions/parse_global_field.py
@@ -1,3 +1,21 @@
+"""Parser for global fields.
+
+Each ``global`` field is represented as a class. Parsing
+the field is creating the class instance representing the field given
+it's string representation.
+
+Fields of ``global`` doesn't have immediate arguments
+and have very simple structure. All fields map one-to-one with
+their string representation. As a result, global fields are
+parsed by first constructing a map(dict) from their string
+representation to corresponding class representing the field and
+using that to find the correct class for the given field.
+
+Attributes:
+    GLOBAL_FIELD_TXT_TO_OBJECT: Map(dict) from string representation
+        of global field to the corresponding class.
+"""
+
 from tealer.teal.global_field import (
     GroupSize,
     ZeroAddress,
@@ -31,4 +49,13 @@ GLOBAL_FIELD_TXT_TO_OBJECT = {
 
 
 def parse_global_field(field: str) -> GlobalField:
+    """Parse global fields.
+
+    Args:
+        field: string representation of the field.
+
+    Returns:
+        object of class corresponding to the given global field.
+    """
+
     return GLOBAL_FIELD_TXT_TO_OBJECT[field]()

--- a/tealer/teal/instructions/parse_transaction_field.py
+++ b/tealer/teal/instructions/parse_transaction_field.py
@@ -1,3 +1,22 @@
+"""Parser for transaction fields.
+
+Each transaction field is represented as a class. Parsing the field
+is creating the class instance representing the field given it's
+string representation.
+
+Most of the transaction fields doesn't have immediate arguments
+and their string representation consists of single sequence of characters.
+Few transaction fields are arrays and have single immediate argument
+which is the index into the array. Transaction fields with single immediate
+argument are parsed case by case. For other fields, a map(dict) from the
+string representation of transaction field to corresponding class is
+constructed and are parsed by a simple lookup.
+
+Attributes:
+    TX_FIELD_TXT_TO_OBJECT: Map(dict) from string representation
+        of transaction field to the corresponding class.
+"""
+
 from tealer.teal.instructions import transaction_field
 
 TX_FIELD_TXT_TO_OBJECT = {
@@ -62,6 +81,20 @@ TX_FIELD_TXT_TO_OBJECT = {
 
 
 def _parse_int(x: str) -> int:
+    """Parse teal integers.
+
+    Teal supports three formats to write integers, hex, octal and
+    decimal. hexadecimal numbers start with the prefix 0x and octal
+    numbers have prefix 0.
+
+    Args:
+        x: string representation of the teal integer.
+
+    Returns:
+        python integer equal to the value represented by the given
+        teal integer.
+    """
+
     if x.startswith("0x"):
         return int(x[2:], 16)
     if x.startswith("0"):
@@ -70,6 +103,17 @@ def _parse_int(x: str) -> int:
 
 
 def parse_transaction_field(tx_field: str, use_stack: bool) -> transaction_field.TransactionField:
+    """Parse transaction fields.
+
+    Args:
+        tx_field: string representation of the field.
+        use_stack: boolean representing whether the array transaction field
+            takes it's index from stack instead of as immediate argument.
+
+    Returns:
+        object of class corresponding to the given transaction field.
+    """
+
     if tx_field.startswith("Accounts"):
         return transaction_field.Accounts(
             -1 if use_stack else _parse_int(tx_field[len("Accounts ") :])

--- a/tealer/teal/instructions/transaction_field.py
+++ b/tealer/teal/instructions/transaction_field.py
@@ -1,3 +1,13 @@
+"""Defines classes to represent transaction fields.
+
+Teal supports access to fields of the transaction that invoked the
+execution of this contract through multiple instructions.
+
+Each transaction field is represented by a class in tealer. All the
+classes representing the fields must inherit from TransactionField class.
+
+"""
+
 # pylint: disable=too-few-public-methods
 
 # https://developer.algorand.org/docs/reference/teal/opcodes/#txn
@@ -11,6 +21,7 @@ class TransactionField:
 
     @property
     def version(self) -> int:
+        """Teal version this field is introduced in and supported from."""
         return self._version
 
     def __str__(self) -> str:


### PR DESCRIPTION
Docstrings are added to most of the functions, classes defined in instructions subpackage.

Only code changes are name changes of functions, arguments, properties. They are also very few(3 or so) and are very small changes. 