### PR TITLE
Refactor detectors to reduce code duplicate

### DIFF
--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -8,44 +8,11 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.teal.global_field import ZeroAddress
-from tealer.teal.instructions.instructions import (
-    Addr,
-    Eq,
-    Global,
-    Instruction,
-    Int,
-    Neq,
-    Return,
-    Txn,
-)
 from tealer.teal.instructions.transaction_field import CloseRemainderTo
+from tealer.utils.analyses import detect_missing_txn_check
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
-
-
-def _is_close_remainder_check(ins1: Instruction, ins2: Instruction) -> bool:
-    """Util function to check if given instructions form CloseRemainderTo check.
-
-    Args:
-        ins1: First instruction of the execution sequence that is supposed
-            to form a comparison check for CloseRemainderTo transaction field.
-        ins2: Second instruction in the execution sequence, will be executed
-            right after :ins1:.
-
-    Returns:
-        True if the given instructions :ins1:, :ins2: form a CloseRemainderTo
-        check i.e True if :ins1: is txn CloseRemainderTo and :ins2: is
-        global ZeroAddress or addr .. .
-    """
-
-    if isinstance(ins1, Txn) and isinstance(ins1.field, CloseRemainderTo):
-        if isinstance(ins2, Global) and isinstance(ins2.field, ZeroAddress):
-            return True
-        if isinstance(ins2, Addr):
-            return True
-    return False
 
 
 class CanCloseAccount(AbstractDetector):  # pylint: disable=too-few-public-methods
@@ -94,59 +61,6 @@ if one of the receiver turns out to be malicious, they could set the CloseRemain
 Always check that CloseRemainderTo transaction field is set to a ZeroAddress or intended address if needed. 
 """
 
-    def _check_close_account(
-        self,
-        bb: BasicBlock,
-        current_path: List[BasicBlock],
-        paths_without_check: List[List[BasicBlock]],
-    ) -> None:
-        """Find execution paths with missing CloseRemainderTo check.
-
-        This function recursively explores the Control Flow Graph(CFG) of the
-        contract and reports execution paths with missing CloseRemainderTo
-        check.
-
-        This function is "in place", modifies arguments with the data it is
-        supposed to return.
-
-        Args:
-            bb: Current basic block being checked(whose execution is simulated.)
-            current_path: Current execution path being explored.
-            paths_without_check:
-                Execution paths with missing CloseRemainderTo check. This is a
-                "in place" argument. Vulnerable paths found by this function are
-                appended to this list.
-        """
-
-        if bb in current_path:
-            return
-
-        current_path = current_path + [bb]
-
-        stack: List[Instruction] = []
-
-        for ins in bb.instructions:
-
-            if isinstance(ins, Return):
-                if len(ins.prev) == 1:
-                    prev = ins.prev[0]
-                    if isinstance(prev, Int) and prev.value == 0:
-                        return
-
-                paths_without_check.append(current_path)
-                return
-
-            if isinstance(ins, (Eq, Neq)) and len(stack) >= 2:
-                one = stack[-1]
-                two = stack[-2]
-                if _is_close_remainder_check(one, two) or _is_close_remainder_check(two, one):
-                    return
-
-            stack.append(ins)
-
-        for next_bb in bb.next:
-            self._check_close_account(next_bb, current_path, paths_without_check)
-
     def detect(self) -> "SupportedOutput":
         """Detect execution paths with missing CloseRemainderTo check.
 
@@ -157,7 +71,7 @@ Always check that CloseRemainderTo transaction field is set to a ZeroAddress or 
         """
 
         paths_without_check: List[List[BasicBlock]] = []
-        self._check_close_account(self.teal.bbs[0], [], paths_without_check)
+        detect_missing_txn_check(CloseRemainderTo, self.teal.bbs[0], [], paths_without_check)
 
         description = "Lack of CloseRemainderTo check allows to close the account and"
         description += " transfer all the funds to attacker controlled address."

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -8,44 +8,11 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.teal.global_field import ZeroAddress
-from tealer.teal.instructions.instructions import (
-    Addr,
-    Eq,
-    Global,
-    Instruction,
-    Int,
-    Neq,
-    Return,
-    Txn,
-)
 from tealer.teal.instructions.transaction_field import AssetCloseTo
+from tealer.utils.analyses import detect_missing_txn_check
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
-
-
-def _is_asset_close_check(ins1: Instruction, ins2: Instruction) -> bool:
-    """Util function to check if given instructions form AssetCloseTo check.
-
-    Args:
-        ins1: First instruction of the execution sequence that is supposed
-            to form a comparison check for AssetCloseTo transaction field.
-        ins2: Second instruction in the execution sequence, will be executed
-            right after :ins1:.
-
-    Returns:
-        True if the given instructions :ins1:, :ins2: form a AssetCloseTo
-        check i.e True if :ins1: is txn AssetCloseTo and :ins2: is
-        global ZeroAddress or addr.
-    """
-
-    if isinstance(ins1, Txn) and isinstance(ins1.field, AssetCloseTo):
-        if isinstance(ins2, Global) and isinstance(ins2.field, ZeroAddress):
-            return True
-        if isinstance(ins2, Addr):
-            return True
-    return False
 
 
 class CanCloseAsset(AbstractDetector):  # pylint: disable=too-few-public-methods
@@ -90,59 +57,6 @@ receiver sets the AssetCloseTo transaction field of a Asset Transfer Transaction
 Always check that AssetCloseTo transaction field is set to a ZeroAddress or intended address if needed.
 """
 
-    def _check_close_asset(
-        self,
-        bb: BasicBlock,
-        current_path: List[BasicBlock],
-        paths_without_check: List[List[BasicBlock]],
-    ) -> None:
-        """Find execution paths with missing AssetCloseTo check.
-
-        This function recursively explores the Control Flow Graph(CFG) of the
-        contract and reports execution paths with missing AssetCloseTo
-        check.
-
-        This function is "in place", modifies arguments with the data it is
-        supposed to return.
-
-        Args:
-            bb: Current basic block being checked(whose execution is simulated.)
-            current_path: Current execution path being explored.
-            paths_without_check:
-                Execution paths with missing AssetCloseTo check. This is a
-                "in place" argument. Vulnerable paths found by this function are
-                appended to this list.
-        """
-
-        if bb in current_path:
-            return
-
-        current_path = current_path + [bb]
-
-        stack: List[Instruction] = []
-
-        for ins in bb.instructions:
-
-            if isinstance(ins, Return):
-                if len(ins.prev) == 1:
-                    prev = ins.prev[0]
-                    if isinstance(prev, Int) and prev.value == 0:
-                        return
-
-                paths_without_check.append(current_path)
-                return
-
-            if isinstance(ins, (Eq, Neq)) and len(stack) >= 2:
-                one = stack[-1]
-                two = stack[-2]
-                if _is_asset_close_check(one, two) or _is_asset_close_check(two, one):
-                    return
-
-            stack.append(ins)
-
-        for next_bb in bb.next:
-            self._check_close_asset(next_bb, current_path, paths_without_check)
-
     def detect(self) -> "SupportedOutput":
         """Detect execution paths with missing AssetCloseTo check.
 
@@ -153,7 +67,7 @@ Always check that AssetCloseTo transaction field is set to a ZeroAddress or inte
         """
 
         paths_without_check: List[List[BasicBlock]] = []
-        self._check_close_asset(self.teal.bbs[0], [], paths_without_check)
+        detect_missing_txn_check(AssetCloseTo, self.teal.bbs[0], [], paths_without_check)
 
         description = "Lack of AssetCloseTo check allows to close the asset holdings"
         description += " of the account."

--- a/tealer/utils/analyses.py
+++ b/tealer/utils/analyses.py
@@ -1,0 +1,150 @@
+from typing import Type as TypingType, List
+
+from tealer.teal.basic_blocks import BasicBlock
+from tealer.teal.global_field import ZeroAddress
+from tealer.teal.instructions.instructions import (
+    Txn,
+    Global,
+    Instruction,
+    Addr,
+    Int,
+    Eq,
+    Neq,
+    Return,
+)
+from tealer.teal.instructions.transaction_field import TransactionField, OnCompletion
+
+
+def check_if_txn_field_against_address(
+    ins1: Instruction, ins2: Instruction, tx_field: TypingType[TransactionField]
+) -> bool:
+    """Check if the (ins1, ins2) is on the form
+    TXN [tx_field]
+    GLOBAL ZeroAddress | Addr
+
+    Args:
+        ins1: first instruction.
+        ins2: second instruction,,
+        tx_field: Type of transaction field that is checked against
+
+    Returns:
+        True if (ins1,ins2) is (TXN tx_field, Global ZeroAddress | Addr).
+    """
+    if isinstance(ins1, Txn) and isinstance(ins1.field, tx_field):
+        if isinstance(ins2, Global) and isinstance(ins2.field, ZeroAddress):
+            return True
+        if isinstance(ins2, Addr):
+            return True
+    return False
+
+
+def check_txn_field_address_equality(
+    ins: Instruction, stack: List[Instruction], tx_field: TypingType[TransactionField]
+) -> bool:
+    """Check if the (ins1), [ins2, ins3] is on the form
+    TXN [tx_field]
+    GLOBAL ZeroAddress | Addr
+    EQ|NEQ
+
+    or
+    GLOBAL ZeroAddress | Addr
+    TXN [tx_field]
+    EQ|NEQ
+
+    Args:
+        ins1: first instruction.
+        stack: list of additional instruction,
+        tx_field: Type of transaction field that is checked against
+
+    Returns:
+        True if (ins1), [ins2, ins3] follows the pattern.
+        False if stack does not have +two elements, or if the pattern is not followed
+    """
+    if isinstance(ins, (Eq, Neq)) and len(stack) >= 2:
+        one = stack[-1]
+        two = stack[-2]
+        if check_if_txn_field_against_address(
+            one, two, tx_field
+        ) or check_if_txn_field_against_address(two, one, tx_field):
+            return True
+    return False
+
+
+def detect_missing_txn_check(
+    tx_field: TypingType[TransactionField],
+    bb: BasicBlock,
+    current_path: List[BasicBlock],
+    paths_without_check: List[List[BasicBlock]],
+) -> None:
+    """Find execution paths with missing txn check. The check is on the form
+
+    TXN [tx_field]
+    GLOBAL ZeroAddress | Addr
+    EQ|NEQ
+
+    or
+    GLOBAL ZeroAddress | Addr
+    TXN [tx_field]
+    EQ|NEQ
+
+    The function starts from bb, and iterate until analyzing all the paths.
+    The results are saved in paths_without_check
+
+    Args:
+        bb: Current basic block being checked(whose execution is simulated.)
+        current_path: Basic block already explored.
+        paths_without_check:
+            This is a
+            "in place" argument. Vulnerable paths found by this function are
+            appended to this list.
+    """
+
+    # check for loops
+    if bb in current_path:
+        return
+
+    current_path = current_path + [bb]
+
+    stack: List["Instruction"] = []
+
+    for ins in bb.instructions:
+        if isinstance(ins, Return):
+            if len(ins.prev) == 1:
+                prev = ins.prev[0]
+                if isinstance(prev, Int) and prev.value == 0:
+                    return
+
+            paths_without_check.append(current_path)
+            return
+
+        if check_txn_field_address_equality(ins, stack, tx_field):
+            return
+
+        stack.append(ins)
+
+    for next_bb in bb.next:
+        detect_missing_txn_check(tx_field, next_bb, current_path, paths_without_check)
+
+
+def is_oncompletion_check(ins1: Instruction, ins2: Instruction, checked_values: List[str]) -> bool:
+    """Check if the instructions form OnCompletion check with value in the checked values.
+
+    OnCompletion transaction field stores the type of the application transaction
+    that invoked the contract execution.
+
+    Args:
+        ins1: First instruction of the execution sequence that is supposed
+            to form this comparison check .
+        ins2: Second instruction in the execution sequence, will be executed
+            right after :ins1:.
+        checked_values: List of values accepted on the on completion check
+
+    Returns:
+        True if the given instructions :ins1:, :ins2: form a OnCompletion check
+        using the checked values. True if :ins1: is txn OnCompletion and
+        :ins2: is int (checked_values).
+    """
+
+    if isinstance(ins1, Txn) and isinstance(ins1.field, OnCompletion):
+        return isinstance(ins2, Int) and ins2.value in checked_values
+    return False


### PR DESCRIPTION
A lot of the detectors' logic is re-used everywhere. I created `utils.analyses` to hold some of the shared logic. I think that there are other opportunities to reduce the code duplication.

In the short term, reducing the code duplicate will help to identify APIs that need to be built.

In the long term, this will ease code maintenance.