### PR TITLE
Don't drop unsupported instructions from the CFG

### DIFF
--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -178,6 +178,27 @@ class Instruction:
         return self.__class__.__qualname__.lower()
 
 
+class UnsupportedInstruction(Instruction):
+    """
+    Instruction that is not supported by Tealer.
+
+    The unsupported instruction will be printed in the CFG verbatim
+    and specifically marked as UNSUPPORTED.
+    """
+
+    def __init__(self, verbatim_line: str):
+        super().__init__()
+        self._verbatim_line = verbatim_line
+
+    def __str__(self) -> str:
+        return f"UNSUPPORTED {self._verbatim_line}"
+
+    @property
+    def verbatim_line(self) -> str:
+        """unsupported instruction as read from input"""
+        return self._verbatim_line
+
+
 class Pragma(Instruction):
     """Pragma version instruction to store version of the teal program.
 

--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -493,5 +493,5 @@ def parse_line(line: str) -> Optional[instructions.Instruction]:
             return ins
     if line:
         print(f"Not found {line}")
-        return None
+        return instructions.UnsupportedInstruction(line)
     return None

--- a/tests/parsing/teal6-acct_params_get.teal
+++ b/tests/parsing/teal6-acct_params_get.teal
@@ -1,0 +1,8 @@
+#pragma version 6
+int 0
+acct_params_get AcctBalance
+!
+// a comment
+assert
+int 0
+==

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -32,6 +32,7 @@ TARGETS = [
     "tests/parsing/teal-fields-with-versions.teal",
     "tests/parsing/multiple_retsub.teal",
     "tests/parsing/subroutine_jump_back.teal",
+    "tests/parsing/teal6-acct_params_get.teal",
 ]
 
 TEST_CODE = """


### PR DESCRIPTION
On encountering an unrecognized instruction when building the CFG, Tealer reports it as "Not found" on stdout, but does not include it into the CFG. I find it rather confusing, since no error is reported and the graph just skips the unsupported instruction.

I see two alternative ways of correcting this behavior:
* Rise an exception on encountering an unsupported instruction
* **Implemented in this PR** Proceed normally, but include the unsupported instruction into the CFG and mark it appropriately.

## Example
Consider TEALv6 program that uses the `acct_params_get` instruction, which is not supported by Tealer:

```
#pragma version 6
int 0
acct_params_get AcctBalance
!
// a comment
assert
int 0
==
```
### Output before the patch
![cfg (1)](https://user-images.githubusercontent.com/8296326/166433561-a81eb817-3158-4e73-91cf-f2775b4bf9ab.svg)
We see that line 3 is dropped from the CFG. This is the behavior of Tealer on both `main` and `dev`.

### Output after the patch
![cfg](https://user-images.githubusercontent.com/8296326/166433127-e40f2c09-a446-4e80-a454-2644163ba0df.svg)
Now line 3 is not dropped, but the instruction is marked as "UNSUPPOTED". Line 5 that contains a comment is still dropped, as expected.