### PR TITLE
Add support for Tealv7

### DIFF
--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -328,6 +328,7 @@ parser_rules: List[Tuple[str, Callable[[str], Instruction]]] = [
     ("sha256", lambda _x: instructions.Sha256()),
     ("sha512_256", lambda _x: instructions.Sha512_256()),
     ("keccak256", lambda _x: instructions.Keccak256()),
+    ("ed25519verify_bare", lambda _x: instructions.Ed25519verify_bare()),
     ("ed25519verify", lambda _x: instructions.Ed25519verify()),
     ("ecdsa_verify", lambda x: instructions.Ecdsa_verify(x)),
     ("ecdsa_pk_decompress", lambda x: instructions.Ecdsa_pk_decompress(x)),
@@ -446,6 +447,14 @@ parser_rules: List[Tuple[str, Callable[[str], Instruction]]] = [
         lambda x: instructions.Substring(_parse_int(x.split(" ")[0]), _parse_int(x.split(" ")[1])),
     ),
     ("substring3", lambda x: instructions.Substring3()),
+    ("replace2 ", lambda x: instructions.Replace2(_parse_int(x))),
+    ("replace3", lambda _x: instructions.Replace3()),
+    ("replace", lambda x: instructions.Replace(None if x == "" else _parse_int(x))),
+    ("base64_decode ", lambda x: instructions.Base64_decode(x)),
+    ("json_ref ", lambda x: instructions.Json_ref(x)),
+    ("sha3_256", lambda _x: instructions.Sha3_256()),
+    ("vrf_verify ", lambda x: instructions.Vrf_verify(x)),
+    ("block ", lambda x: instructions.Block(x)),
 ]
 
 
@@ -467,7 +476,6 @@ def parse_line(line: str) -> Optional[instructions.Instruction]:
         ParseError: raises ParseError if the instruction present in the given
             line is not correctly formatted and if is not valid.
     """
-
     if not line.strip():
         return None
 

--- a/tealer/teal/instructions/transaction_field.py
+++ b/tealer/teal/instructions/transaction_field.py
@@ -28,6 +28,25 @@ class TransactionField:
         return self.__class__.__qualname__
 
 
+class TransactionArrayField(TransactionField):
+    """Base class to represent array transaction fields.
+
+    Array transaction fields have an additional index parameter.
+    """
+
+    def __init__(self, idx: int):
+        super().__init__()
+        self._idx = idx
+
+    @property
+    def idx(self) -> int:
+        return self._idx
+
+    def __str__(self) -> str:
+        s = "" if self._idx < 0 else " " + str(self._idx)
+        return self.__class__.__qualname__ + s
+
+
 class Sender(TransactionField):
     """address of sender of this transaction."""
 
@@ -38,10 +57,6 @@ class Fee(TransactionField):
 
 class FirstValid(TransactionField):
     """minimum round number after which this transaction is valid."""
-
-
-class FirstValidTime(TransactionField):
-    """reserved for future use. causes program to fail if used."""
 
 
 class LastValid(TransactionField):
@@ -140,17 +155,12 @@ class OnCompletion(TransactionField):
         self._version: int = 2
 
 
-class ApplicationArgs(TransactionField):
+class ApplicationArgs(TransactionArrayField):
     """Arguments passed to the application in the ApplicationCall."""
 
     def __init__(self, idx: int):
-        super().__init__()
-        self._idx = idx
+        super().__init__(idx)
         self._version: int = 2
-
-    def __str__(self) -> str:
-        s = "" if self._idx < 0 else str(self._idx)
-        return "ApplicationArgs " + s
 
 
 class NumAppArgs(TransactionField):
@@ -161,17 +171,12 @@ class NumAppArgs(TransactionField):
         self._version: int = 2
 
 
-class Accounts(TransactionField):
+class Accounts(TransactionArrayField):
     """Accounts listed in the ApplicationCall transaction."""
 
     def __init__(self, idx: int):
-        super().__init__()
-        self._idx = idx
+        super().__init__(idx)
         self._version: int = 2
-
-    def __str__(self) -> str:
-        s = "" if self._idx < 0 else str(self._idx)
-        return "Accounts " + s
 
 
 class NumAccounts(TransactionField):
@@ -182,17 +187,12 @@ class NumAccounts(TransactionField):
         self._version: int = 2
 
 
-class Applications(TransactionField):
+class Applications(TransactionArrayField):
     """Foreign Apps listed in the ApplicationCall transaction."""
 
     def __init__(self, idx: int):
-        super().__init__()
-        self._idx = idx
+        super().__init__(idx)
         self._version: int = 3
-
-    def __str__(self) -> str:
-        s = "" if self._idx < 0 else str(self._idx)
-        return "Applications " + s
 
 
 class NumApplications(TransactionField):
@@ -203,17 +203,12 @@ class NumApplications(TransactionField):
         self._version: int = 3
 
 
-class Assets(TransactionField):
+class Assets(TransactionArrayField):
     """Foreign Assets listed in the ApplicationCall transaction."""
 
     def __init__(self, idx: int):
-        super().__init__()
-        self._idx = idx
+        super().__init__(idx)
         self._version: int = 3
-
-    def __str__(self) -> str:
-        s = "" if self._idx < 0 else str(self._idx)
-        return "Assets " + s
 
 
 class NumAssets(TransactionField):
@@ -416,17 +411,12 @@ class Nonparticipation(TransactionField):
         self._version: int = 5
 
 
-class Logs(TransactionField):
+class Logs(TransactionArrayField):
     """Log messages emitted by an application call(itxn only)."""
 
     def __init__(self, idx: int):
-        super().__init__()
-        self._idx = idx
+        super().__init__(idx)
         self._version: int = 5
-
-    def __str__(self) -> str:
-        s = "" if self._idx < 0 else str(self._idx)
-        return "Logs " + s
 
 
 class NumLogs(TransactionField):
@@ -467,3 +457,47 @@ class StateProofPK(TransactionField):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 6
+
+
+class FirstValidTime(TransactionField):
+    """(uint64) UNIX timestamp of block before txn.FirstValid. Fails if negative.
+
+    FirstValidTime is present from Teal v1 itself. However, execution would fail if this
+    field is used in versions less than v7.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._version: int = 7
+
+
+class NumApprovalProgramPages(TransactionField):
+    """(uint64) Number of Approval Program pages"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._version: int = 7
+
+
+class NumClearStateProgramPages(TransactionField):
+    """(uint64) Number of clear state program pages"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._version: int = 7
+
+
+class ApprovalProgramPages(TransactionArrayField):
+    """Approval Program as an array of pages"""
+
+    def __init__(self, idx: int):
+        super().__init__(idx)
+        self._version: int = 7
+
+
+class ClearStateProgramPages(TransactionArrayField):
+    """Approval Program as an array of pages"""
+
+    def __init__(self, idx: int):
+        super().__init__(idx)
+        self._version: int = 7

--- a/tests/parsing/teal-fields-with-versions.teal
+++ b/tests/parsing/teal-fields-with-versions.teal
@@ -1,11 +1,10 @@
-#pragma version 6
+#pragma version 7
 
 // Transaction Fields
 
 txn Sender          // (version: 1)
 txn Fee             // (version: 1)
 txn FirstValid      // (version: 1)
-txn FirstValidTime  // (version: 1)
 txn LastValid       // (version: 1)
 txn Note            // (version: 1)
 txn Lease           // (version: 1)
@@ -66,7 +65,11 @@ itxn CreatedAssetID             // (version: 5)
 itxn CreatedApplicationID       // (version: 5)
 txn LastLog                     // (version: 6)
 txn StateProofPK                // (version: 6)
-
+txn FirstValidTime              // (version: 7)
+txn NumApprovalProgramPages     // (version: 7)
+txn NumClearStateProgramPages   // (version: 7)
+txna ApprovalProgramPages 1     // (version: 7)
+txna ClearStateProgramPages 1   // (version: 7)
 
 // Global Fields
 global MinTxnFee                    // (version: 1)

--- a/tests/parsing/teal-instructions-with-versions.teal
+++ b/tests/parsing/teal-instructions-with-versions.teal
@@ -1,4 +1,4 @@
-#pragma version 6
+#pragma version 7
 err                 // (version: 1, mode: Any)
 assert              // (version: 3, mode: Any)
 int 1               // (version: 1, mode: Any)
@@ -156,3 +156,15 @@ gitxna 1 ApplicationArgs 0      // (version: 6, mode: Stateful)
 gloadss                         // (version: 6, mode: Stateful)
 itxnas ApplicationArgs          // (version: 6, mode: Stateful)
 gitxnas 1 ApplicationArgs       // (version: 6, mode: Stateful)
+
+// version 7
+replace2 1                      // (version: 7, mode: Any)
+replace3                        // (version: 7, mode: Any)
+replace 1                       // (version: 7, mode: Any)
+replace                         // (version: 7, mode: Any)
+base64_decode StdEncoding       // (version: 7, mode: Any)
+json_ref JSONUint64             // (version: 7, mode: Any)
+ed25519verify_bare              // (version: 7, mode: Any)
+sha3_256                        // (version: 7, mode: Any)
+vrf_verify VrfAlgorand          // (version: 7, mode: Any)
+block BlkTimestamp              // (version: 7, mode: Any)

--- a/tests/parsing/teal1-instructions.teal
+++ b/tests/parsing/teal1-instructions.teal
@@ -1,0 +1,34 @@
+#pragma version 1
+sha256
+sha512_256
+keccak256
+err
+ed25519verify
++
+-
+/
+*
+<
+>
+<=
+>=
+&&
+||
+==
+!=
+!
+len
+itob
+btoi
+%
+|
+&
+^
+~
+mulw
+intcblock 1
+intc 1
+intc_0
+intc_1
+intc_2
+intc_3

--- a/tests/parsing/teal7-instructions.teal
+++ b/tests/parsing/teal7-instructions.teal
@@ -1,0 +1,83 @@
+#pragma version 7
+// new ecdsa curve: ecdsa_verify v, v can be Secp256r1 from Teal v7
+
+ecdsa_verify Secp256r1
+
+// new transaction field: FirstValidTime, NumApprovalProgramPages, NumClearStateProgramPages
+
+txn FirstValidTime
+gtxn 0 FirstValidTime
+
+txn NumApprovalProgramPages
+gtxn 0 NumApprovalProgramPages 
+
+txn NumClearStateProgramPages
+gtxn 0 NumClearStateProgramPages
+
+// new array transaction fields: ApprovalProgramPages, ClearStateProgramPages
+
+txna ApprovalProgramPages 0
+txna ClearStateProgramPages 0
+
+gtxna 1 ApprovalProgramPages 0
+gtxna 2 ClearStateProgramPages 1
+
+gtxnsa ApprovalProgramPages 0
+gtxnsa ClearStateProgramPages 1
+
+gtxnsas ApprovalProgramPages
+gtxnsas ClearStateProgramPages
+
+
+// new ins: replace2 s
+
+byte "abcd"
+byte "ef"
+replace2 2
+
+// new ins: replace3
+
+byte "abcd"
+int 2
+byte "ef"
+replace3
+
+// new ins: replace
+
+byte "abcd"
+byte "ef"
+replace 2
+
+byte "abcd"
+int 2
+byte "ef"
+replace
+
+
+// new ins: base64_decode e
+
+byte "AAAA"
+base64_decode StdEncoding
+
+// new ins: json_ref r
+json_ref JSONUint64
+
+// new ins: ed25519verify_bare
+byte "A"
+byte "B"
+byte "C"
+ed25519verify_bare
+
+// new_ins: sha3_256
+byte "A"
+sha3_256
+
+// new_ins: vrf_verify s
+byte "A"
+byte "B"
+byte "C"
+vrf_verify VrfAlgorand
+
+// new_ins: block f
+int 100
+block BlkTimestamp

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -5,8 +5,10 @@ import pytest
 from tealer.teal.parse_teal import parse_teal
 from tealer.teal.instructions.parse_instruction import parse_line, ParseError
 from tealer.teal.instructions import instructions
+from tealer.teal.instructions import transaction_field
 
 TARGETS = [
+    "tests/parsing/teal1-instructions.teal",
     "tests/parsing/transaction_fields.teal",
     "tests/parsing/global_fields.teal",
     "tests/parsing/instructions.teal",
@@ -35,12 +37,14 @@ TARGETS = [
     "tests/parsing/subroutine_jump_back.teal",
     "tests/parsing/teal6-acct_params_get.teal",
     "tests/parsing/teal6-instructions.teal",    
+    "tests/parsing/teal7-instructions.teal",
 ]
 
 TEST_CODE = """
 intcblock 0xf 017 15
 intcblock
 int pay
+pushint 1
 byte base64 AA
 byte b64 AA
 byte base64(AA)
@@ -56,6 +60,13 @@ bytecblock b32(AA) base64 AA 0x00 "00"
 bytecblock
 byte "not label: // not comment either"
 labelwithqoute": // valid
+gtxn 1 Sender
+gtxna 1 Applications 0
+extract 0 1
+gtxnas 1 Applications
+gitxn 1 Sender
+replace 1
+replace2 1
 """
 
 invalid_instructions = """
@@ -112,6 +123,7 @@ def test_parsing_2() -> None:
         instructions.Intcblock([15, 15, 15]),
         instructions.Intcblock([]),
         instructions.Int("pay"),
+        instructions.PushInt(1),
         instructions.Byte("0x00"),
         instructions.Byte("0x00"),
         instructions.Byte("0x00"),
@@ -127,11 +139,19 @@ def test_parsing_2() -> None:
         instructions.Bytecblock([]),
         instructions.Byte('"not label: // not comment either"'),
         instructions.Label('labelwithqoute"'),
+        instructions.Gtxn(1, transaction_field.Sender),
+        instructions.Gtxna(1, transaction_field.Applications(0)),
+        instructions.Extract(0, 1),
+        instructions.Gtxnas(1, transaction_field.Applications(-1)),
+        instructions.Gitxn(1, transaction_field.Sender),
+        instructions.Replace(1),
+        instructions.Replace2(1),
     ]
     t = [
         (instructions.Intcblock, ("_constants",)),
         (instructions.Intcblock, ("_constants",)),
         (instructions.Int, ("value",)),
+        (instructions.PushInt, ("value",)),
         (instructions.Byte, ("_bytes",)),
         (instructions.Byte, ("_bytes",)),
         (instructions.Byte, ("_bytes",)),
@@ -147,6 +167,13 @@ def test_parsing_2() -> None:
         (instructions.Bytecblock, ("_constants",)),
         (instructions.Byte, ("_bytes",)),
         (instructions.Label, ("label",)),
+        (instructions.Gtxn, ("idx",)),
+        (instructions.Gtxna, ("idx",)),
+        (instructions.Extract, ("start_position", "length")),
+        (instructions.Gtxnas, ("idx",)),
+        (instructions.Gitxn, ("idx",)),
+        (instructions.Replace, ("start_position", "is_replace2", "is_replace3")),
+        (instructions.Replace2, ("start_position",)),
     ]
 
     for (b1, b2, (target, attributes)) in zip(ins1, ins2, t):
@@ -163,10 +190,95 @@ def test_unsupported_instructions() -> None:
     for line in unsupported_instructions.strip().splitlines():
         ins = parse_line(line)
         assert isinstance(ins, instructions.UnsupportedInstruction)
+        assert str(ins) == f"UNSUPPORTED {line.strip()}"
+        assert ins.verbatim_line == line.strip()
+
 
 def test_field_properties() -> None:
     ins = parse_line("gitxnas 1 ApplicationArgs")
-    assert isinstance(ins, instructions.Gitxnas) and ins.idx == 1
+    assert isinstance(ins, instructions.Gitxnas) and ins.idx == 1 and isinstance(ins.field, transaction_field.TransactionArrayField) and ins.field.idx == -1
 
     ins = parse_line("gitxna 1 ApplicationArgs 0")
-    assert isinstance(ins, instructions.Gitxna) and ins.idx == 1
+    assert isinstance(ins, instructions.Gitxna) and ins.idx == 1 and isinstance(ins.field, transaction_field.TransactionArrayField) and ins.field.idx == 0
+
+
+def test_instruction_properties() -> None:
+    TEST_CODE = """
+    int 1 // comment
+    int 2
+    """
+    teal = parse_teal(TEST_CODE)
+    ins1 = teal.instructions[0]
+    ins2 = teal.instructions[1]
+    assert ins1.prev == []
+    assert ins1.next == [ins2]
+    assert ins2.prev == [ins1]
+    assert ins2.next == []
+    assert ins1.comment == "// comment"
+
+    # cannot set return point of callsub instruction multiple times
+    ins = parse_line("callsub main")
+    assert isinstance(ins, instructions.Callsub) and ins.return_point is None
+    
+    ins.return_point = parse_line("int 1")
+    with pytest.raises(Exception):
+        ins.return_point = parse_line("int 1") # cannot set multiple times
+
+    # accessing replace instruction start_position fails if it is None i.e if there's no immediate argument.
+    # it should be checked that whether given replace instruction is semantically equivalent to replace2 or replace3.
+    ins = parse_line("replace 1")
+    assert isinstance(ins, instructions.Replace) and ins.is_replace2 and ins.start_position == 1
+    
+    ins = parse_line("replace")
+    assert isinstance(ins, instructions.Replace) and ins.is_replace3
+    with pytest.raises(Exception):
+        print(ins.start_position)
+
+
+def test_cost_values() -> None:
+    TEST_CODE = """
+    sha256
+    sha512_256
+    keccak256
+    ecdsa_verify Secp256k1
+    ecdsa_pk_decompress Secp256k1
+    ecdsa_pk_recover Secp256k1
+    b%
+    b&
+    b|
+    b+
+    b-
+    b/
+    b*
+    b^
+    b~
+    divmodw
+    expw
+    sqrt
+    bsqrt
+    base64_decode URLEncoding
+    json_ref JSONUint64
+    ed25519verify_bare
+    vrf_verify VrfAlgorand
+    """
+    for line in TEST_CODE.strip().splitlines():
+        # when cost parameter accessed, it checks that instruction object's BasicBlock is not none. if it is none, then
+        # cost property raises exception. These tests are included to cover those brances.
+        with pytest.raises(ValueError):
+            print(line)
+            parse_line(line).cost
+    
+    # cost should return 0 if the contract version is less than instruction supported version
+    TEST_CODE = """
+    ecdsa_verify Secp256k1
+    ecdsa_pk_decompress Secp256k1
+    ecdsa_pk_recover Secp256k1
+    bsqrt
+    base64_decode URLEncoding
+    json_ref JSONUint64
+    ed25519verify_bare
+    """
+    teal = parse_teal(TEST_CODE)
+    for ins in teal.instructions:
+        print("DSDF", ins, ins.cost)
+        assert ins.cost == 0


### PR DESCRIPTION
### Additions

Instructions:
  - Replace2 (replace2 s)
  - Replace3 (replace3)
  - Replace (replace {s})
  - Base64_decode (base64_decode)
  - Json_ref (json_ref r)
  - Ed25519verify_bare (ed25519verify_bare)
  - Sha3_256 (sha3_256)
  - Vrf_verify (vrf_verify s)
  - Block (block f)

Transaction Fields:
  - NumApprovalProgramPages
  - NumClearStateProgramPages

Array Transaction Fields:
  - ApprovalProgramPages
  - ClearStateProgramPages

Other:
- Support of Secp256r1 curve for ecdsa_verify instruction