### PR TITLE
Use group size constraints on group indices

### DIFF
--- a/tealer/teal/basic_blocks.py
+++ b/tealer/teal/basic_blocks.py
@@ -163,3 +163,6 @@ class BasicBlock:  # pylint: disable=too-many-instance-attributes
         for ins in self._instructions:
             ret += f"{ins.line}: {ins}\n"
         return ret
+
+    def __repr__(self) -> str:
+        return f"B{self._idx}"

--- a/tests/transaction_context/test_group_indices.py
+++ b/tests/transaction_context/test_group_indices.py
@@ -126,12 +126,50 @@ end:
 
 LOOPS_GROUP_INDICES = [[2], [2], [], [2]]
 
+LOOPS_GROUP_SIZES = """
+#pragma version 5
+txn GroupIndex
+int 4
+!=
+assert
+global GroupSize
+int 6
+<=
+int 0
+loop:
+    dup
+    txn GroupIndex
+    int 3
+    >
+    bz end
+    int 1
+    +
+    txn GroupIndex
+    int 6
+    <
+    assert
+    b loop
+end:
+    int 2
+    txn GroupIndex
+    >
+    assert
+    int 5
+    global GroupSize
+    <=
+    assert
+    int 1
+    return
+"""
+
+LOOPS_GROUP_SIZES_GROUP_INDICES = [[3], [3], [], [3]]
 
 ALL_TESTS = [
     (MULTIPLE_RETSUB, MULTIPLE_RETSUB_GROUP_INDICES),
     (SUBROUTINE_BACK_JUMP, SUBROUTINE_BACK_JUMP_GROUP_INDICES),
     (BRANCHING, BRANCHING_GROUP_INDICES),
     (LOOPS, LOOPS_GROUP_INDICES),
+    (LOOPS_GROUP_SIZES, LOOPS_GROUP_SIZES_GROUP_INDICES),
 ]
 
 

--- a/tests/transaction_context/test_group_sizes.py
+++ b/tests/transaction_context/test_group_sizes.py
@@ -294,3 +294,25 @@ def test_group_sizes(test: Tuple[str, List[BasicBlock]]) -> None:
     for b1, b2 in zip(bbs, cfg):
         print(b1.transaction_context.group_sizes, b2.transaction_context.group_sizes)
         assert b1.transaction_context.group_sizes == b2.transaction_context.group_sizes
+
+
+MULTIPLE_RETSUB_CFG_GROUP_INDICES = [[0, 1], [0, 1], [0, 1], [0, 1], [0, 1], [0, 1]]
+SUBROUTINE_BACK_JUMP_GROUP_INDICES = [[0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2], [0, 1, 2]]
+BRANCHING_GROUP_INDICES = [[0, 1, 2, 3], [0], [], [0], [], [0, 1, 2, 3]]
+LOOPS_GROUP_INDICES = [[0, 1], [0, 1], [0, 1], [0, 1]]
+
+GROUP_INDICES_TESTS = [
+    (MULTIPLE_RETSUB, MULTIPLE_RETSUB_CFG_GROUP_INDICES),
+    (SUBROUTINE_BACK_JUMP, SUBROUTINE_BACK_JUMP_GROUP_INDICES),
+    (BRANCHING, BRANCHING_GROUP_INDICES),
+    (LOOPS, LOOPS_GROUP_INDICES),
+]
+@pytest.mark.parametrize("test", GROUP_INDICES_TESTS)  # type: ignore
+def test_group_indices(test: Tuple[str, List[List[int]]]) -> None:
+    code, group_indices_list = test
+    teal = parse_teal(code.strip())
+
+    bbs = order_basic_blocks(teal.bbs)
+    for b, group_indices in zip(bbs, group_indices_list):
+        print(b.transaction_context.group_indices, group_indices)
+        assert b.transaction_context.group_indices == group_indices


### PR DESCRIPTION
Group index is always less than the group size. Use the information on possible group sizes to calculate possible group indices: `possible_group_indices = set(range(0, max(possible_group_sizes))`
