### PR TITLE
Add generic dataflow framework + example + stack value analysis

### DIFF
--- a/tealer/analyses/dataflow/abstract.py
+++ b/tealer/analyses/dataflow/abstract.py
@@ -1,0 +1,60 @@
+from abc import ABC, abstractmethod
+from typing import List, Any, TypeVar, Generic, TYPE_CHECKING
+
+from tealer.teal.basic_blocks import BasicBlock
+
+AbstractValues = TypeVar("AbstractValues")
+
+if TYPE_CHECKING:
+    from tealer.teal.teal import Teal
+
+
+class AbstractDataflow(ABC, Generic[AbstractValues]):
+    def __init__(self, teal: "Teal"):
+        self.teal = teal
+
+    @abstractmethod
+    def _merge_predecessor(self, bb: BasicBlock) -> AbstractValues:
+        pass
+
+    @abstractmethod
+    def _is_fix_point(self, bb: BasicBlock, values: AbstractValues) -> bool:
+        pass
+
+    @abstractmethod
+    def _transfer_function(self, bb: BasicBlock) -> AbstractValues:
+        pass
+
+    @abstractmethod
+    def _store_values_in(self, bb: BasicBlock, values: AbstractValues) -> None:
+        pass
+
+    @abstractmethod
+    def _store_values_out(self, bb: BasicBlock, values: AbstractValues) -> None:
+        pass
+
+    @abstractmethod
+    def _filter_successors(self, bb: BasicBlock) -> List[BasicBlock]:
+        pass
+
+    @abstractmethod
+    def result(self) -> Any:
+        pass
+
+    def explore(self, bb: BasicBlock, is_entry_node: bool = False) -> None:
+
+        values = self._merge_predecessor(bb)
+
+        if not is_entry_node and self._is_fix_point(bb, values):
+            return
+
+        self._store_values_in(bb, values)
+        values = self._transfer_function(bb)
+        self._store_values_out(bb, values)
+
+        successors = self._filter_successors(bb)
+        for successor in successors:
+            self.explore(successor)
+
+    def run_analysis(self) -> None:
+        self.explore(self.teal.bbs[0], is_entry_node=True)

--- a/tealer/analyses/dataflow/collect_instructions.py
+++ b/tealer/analyses/dataflow/collect_instructions.py
@@ -1,0 +1,102 @@
+from collections import defaultdict
+from typing import Union, Set, Any, List, Dict, TYPE_CHECKING
+
+from tealer.analyses.dataflow.abstract import AbstractDataflow
+from tealer.teal.basic_blocks import BasicBlock
+from tealer.teal.instructions.instructions import Instruction
+
+if TYPE_CHECKING:
+    from tealer.teal.teal import Teal
+
+MAX_ELEMS = 35
+
+
+class InstructionSet:
+    def __init__(self, values: Union[str, Instruction, Set[Instruction]]) -> None:
+
+        if isinstance(values, str):
+            assert values in ["TOP", "BOTTOM"]
+
+        if isinstance(values, set) and len(values) > MAX_ELEMS:
+            values = "TOP"
+        if isinstance(values, Instruction):
+            values = {values}
+
+        self.values: Union[str, Set[Instruction]] = values
+
+    @property
+    def is_top(self) -> bool:
+        return isinstance(self.values, str) and self.values == "TOP"
+
+    @property
+    def is_bottom(self) -> bool:
+        return isinstance(self.values, str) and self.values == "BOTTOM"
+
+    def union(self, instructions: "InstructionSet") -> "InstructionSet":
+        v0 = self.values
+        v1 = instructions.values
+        if v0 == "TOP" or v1 == "TOP":
+            return InstructionSet("TOP")
+
+        if v0 == "BOTTOM":
+            return InstructionSet(v1)
+
+        if v1 == "BOTTOM":
+            return InstructionSet(v0)
+
+        assert isinstance(v0, set)
+        assert isinstance(v1, set)
+
+        return InstructionSet(v0.union(v1))
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, InstructionSet):
+            if isinstance(self.values, str) and isinstance(other.values, str):
+                return self.values == other.values
+            if isinstance(self.values, set) and isinstance(other.values, set):
+                return self.values == other.values
+        return False
+
+    def __str__(self) -> str:
+        if isinstance(self.values, str):
+            return self.values
+        return "[" + ",".join([str(x) for x in self.values]) + "]"
+
+
+class CollectInstructions(AbstractDataflow[InstructionSet]):
+    def __init__(self, teal: "Teal") -> None:
+        super().__init__(teal)
+        self.bb_in: Dict[BasicBlock, InstructionSet] = defaultdict(lambda: InstructionSet("BOTTOM"))
+        self.bb_out: Dict[BasicBlock, InstructionSet] = defaultdict(
+            lambda: InstructionSet("BOTTOM")
+        )
+
+    def _merge_predecessor(self, bb: BasicBlock) -> InstructionSet:
+        s = InstructionSet("BOTTOM")
+        for bb_prev in bb.prev:
+            s = s.union(self.bb_out[bb_prev])
+
+        return s
+
+    def _is_fix_point(self, bb: BasicBlock, values: InstructionSet) -> bool:
+        return self.bb_in[bb] == values
+
+    def _transfer_function(self, bb: BasicBlock) -> InstructionSet:
+        bb_out = self.bb_in[bb]
+
+        for ins in bb.instructions:
+            bb_out = bb_out.union(InstructionSet(ins))
+
+        return bb_out
+
+    def _store_values_in(self, bb: BasicBlock, values: InstructionSet) -> None:
+        self.bb_in[bb] = values
+
+    def _store_values_out(self, bb: BasicBlock, values: InstructionSet) -> None:
+        self.bb_out[bb] = values
+
+    def _filter_successors(self, bb: BasicBlock) -> List[BasicBlock]:
+        return bb.next
+
+    def result(self) -> Dict[BasicBlock, InstructionSet]:
+        return self.bb_out

--- a/tealer/analyses/dataflow/stack_value.py
+++ b/tealer/analyses/dataflow/stack_value.py
@@ -1,0 +1,229 @@
+from collections import defaultdict
+from typing import Union, Set, Any, List, Dict, TYPE_CHECKING, Type, Callable, Tuple
+
+from tealer.analyses.dataflow.abstract import AbstractDataflow
+from tealer.teal.basic_blocks import BasicBlock
+from tealer.teal.global_field import GlobalField
+from tealer.teal.instructions import instructions
+from tealer.teal.instructions.instructions import Instruction
+from tealer.teal.instructions.transaction_field import TransactionField
+
+if TYPE_CHECKING:
+    from tealer.teal.teal import Teal
+
+MAX_ELEMS_PER_STACK_VALUE = 35
+MAX_STACK_DEPTH = 100
+
+
+# pylint: disable=too-few-public-methods
+class TOP:
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, TOP)
+
+    def __str__(self) -> str:
+        return "TOP"
+
+
+# pylint: disable=too-few-public-methods
+class BOTTOM:
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, BOTTOM)
+
+    def __str__(self) -> str:
+        return "BOTTOM"
+
+
+VALUES_TRACKED = Union[Set[Union[GlobalField, TransactionField, int, str]], TOP, BOTTOM]
+
+
+class StackValue:
+    """
+    StackValue represent an abstract value on the stack
+    It can be either a set of int/str/fields, or TOP/BOTTOM
+    The set's size is limited to MAX_ELEMS_PER_STACK_VALUE, if above, it becomes TOP
+
+    """
+
+    def __init__(self, values: VALUES_TRACKED):
+        if isinstance(values, set) and len(values) > MAX_ELEMS_PER_STACK_VALUE:
+            values = TOP()
+        self.values = values
+
+    def union(self, other_stack_value: "StackValue") -> "StackValue":
+        self_values = self.values
+        other_values = other_stack_value.values
+        if isinstance(self_values, TOP) or isinstance(other_values, TOP):
+            return StackValue(TOP())
+        if isinstance(self_values, BOTTOM):
+            return StackValue(other_values)
+        if isinstance(other_values, BOTTOM):
+            return StackValue(self_values)
+        assert isinstance(self_values, set)
+        assert isinstance(other_values, set)
+        return StackValue(self_values | other_values)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, StackValue):
+            return self.values == other.values
+        return False
+
+    def __str__(self) -> str:
+        values = self.values
+        if isinstance(values, (TOP, BOTTOM)):
+            return str(values)
+        assert isinstance(values, set)
+        return str({str(x) for x in values})
+
+
+class Stack:
+    """
+    Represent an abstract stack
+    The length is limited by MAX_STACK_DEPTH
+    self.values contains the abstract element
+
+    If there is two paths merged, where one path push 1 (concrete stack [1])
+    and the other push 3; (concrete stack [3])
+    then the abstract stack is
+    [ [1;3] ]x
+    Ie: the top can either be 1 or 3
+
+    If we pop beyond the known values, we return TOP().
+    As a result, if the most left elements are TOP in the stack, we can stop tracking them
+
+    If there is two paths merged, and the stack size has a different size, then
+    we use TOP for the elements in the difference. Ex:
+    - one path push 1; push 2; (concrete stack [2;1])
+    - and the other push 3; (concrete stack [3])
+    - then the abstract stack is
+    - [ [TOP] ; [1;3] ]
+    Ie: the top can either be 1 or 3, and the second one is TOP
+    Because the most left element of the stack can be removed, this can be simplied as
+    [ [1;3] ]
+
+
+
+    """
+
+    def __init__(self, values: List[StackValue]) -> None:
+        if len(values) > MAX_STACK_DEPTH:
+            values = values[:-MAX_STACK_DEPTH]
+
+        while values and values[0] == StackValue(TOP()):
+            values.pop()
+
+        self.values = values
+
+    def union(self, stack: "Stack") -> "Stack":
+
+        v1 = self.values
+        v2 = stack.values
+
+        min_length = min(len(v1), len(v2))
+        v1 = v1[:-min_length]
+        v2 = v2[:-min_length]
+
+        v3 = []
+        for i in range(min_length):
+            v3.append(v1[i].union(v2[i]))
+
+        return Stack(v3)
+
+    def pop(self, number: int) -> Tuple["Stack", List[StackValue]]:
+        if number == 0:
+            return Stack(self.values), []
+        if len(self.values) < number:
+            diff = number - len(self.values)
+            poped_values = list(self.values)
+            return Stack([]), [StackValue(TOP()) for _ in range(diff)] + poped_values
+
+        poped_values = self.values[:-number]
+        return Stack(self.values[: len(self.values) - number]), poped_values
+
+    def push(self, pushed_values: List[StackValue]) -> "Stack":
+        return Stack(self.values + pushed_values)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, Stack):
+            return self.values == other.values
+        return False
+
+    def __str__(self) -> str:
+        return str([str(x) for x in self.values])
+
+
+# pylint: disable=unused-argument
+def handle_int(ins: Instruction, stack: Stack) -> List[StackValue]:
+    assert isinstance(ins, instructions.Int)
+    return [StackValue({ins.value})]
+
+
+# pylint: disable=unused-argument
+def handle_pushint(ins: Instruction, stack: Stack) -> List[StackValue]:
+    assert isinstance(ins, instructions.PushInt)
+    return [StackValue({ins.value})]
+
+
+# pylint: disable=unused-argument
+def handle_txn(ins: Instruction, stack: Stack) -> List[StackValue]:
+    assert isinstance(ins, instructions.Txn)
+    return [StackValue({ins.field})]
+
+
+# pylint: disable=unused-argument
+def handle_global(ins: Instruction, stack: Stack) -> List[StackValue]:
+    assert isinstance(ins, instructions.Global)
+    return [StackValue({ins.field})]
+
+
+special_handling: Dict[Type[Instruction], Callable[[Instruction, Stack], List[StackValue]]] = {
+    instructions.Int: handle_int,
+    instructions.PushInt: handle_pushint,
+    instructions.Txn: handle_txn,
+    instructions.Global: handle_global,
+}
+
+
+class StackValueAnalysis(AbstractDataflow[Stack]):
+    def __init__(self, teal: "Teal") -> None:
+        super().__init__(teal)
+        self.bb_in: Dict[BasicBlock, Stack] = defaultdict(lambda: Stack([StackValue(BOTTOM())]))
+        self.bb_out: Dict[BasicBlock, Stack] = defaultdict(lambda: Stack([]))
+
+        self.ins_in: Dict[Instruction, Stack] = defaultdict(lambda: Stack([]))
+        self.ins_out: Dict[Instruction, Stack] = defaultdict(lambda: Stack([]))
+
+    def _merge_predecessor(self, bb: BasicBlock) -> Stack:
+        s = Stack([])
+        for bb_prev in bb.prev:
+            s = s.union(self.bb_out[bb_prev])
+        return s
+
+    def _is_fix_point(self, bb: BasicBlock, values: Stack) -> bool:
+        return self.bb_in[bb] == values
+
+    def _transfer_function(self, bb: BasicBlock) -> Stack:
+        bb_out = self.bb_in[bb]
+
+        for ins in bb.instructions:
+            self.ins_in[ins] = Stack(bb_out.values)
+            if type(ins) in special_handling:
+                pushed_elems = special_handling[type(ins)](ins, bb_out)
+            else:
+                pushed_elems = [StackValue(TOP()) for _ in range(ins.stack_push_size)]
+            bb_out, _ = bb_out.pop(ins.stack_pop_size)
+            bb_out = bb_out.push(pushed_elems)
+            self.ins_out[ins] = Stack(bb_out.values)
+
+        return bb_out
+
+    def _store_values_in(self, bb: BasicBlock, values: Stack) -> None:
+        self.bb_in[bb] = values
+
+    def _store_values_out(self, bb: BasicBlock, values: Stack) -> None:
+        self.bb_out[bb] = values
+
+    def _filter_successors(self, bb: BasicBlock) -> List[BasicBlock]:
+        return bb.next
+
+    def result(self) -> Dict[BasicBlock, Stack]:
+        return self.bb_out

--- a/tealer/teal/global_field.py
+++ b/tealer/teal/global_field.py
@@ -10,6 +10,9 @@ classes representing the fields must inherit from GlobalField class.
 """
 
 # pylint: disable=too-few-public-methods
+from typing import Any
+
+
 class GlobalField:
     """Base class representing a global field"""
 
@@ -21,8 +24,15 @@ class GlobalField:
         """Teal version this field is introduced in and supported from."""
         return self._version
 
+    def __eq__(self, other: Any) -> bool:
+        # pylint: disable=unidiomatic-typecheck
+        return type(other) == type(self)
+
     def __str__(self) -> str:
         return self.__class__.__qualname__
+
+    def __hash__(self) -> int:
+        return hash(str(self))
 
 
 class GroupSize(GlobalField):

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -164,6 +164,13 @@ class Instruction:  # pylint: disable=too-many-instance-attributes
         """Teal version this instruction is introduced in and supported from."""
         return self._version
 
+    def input_size(self) -> int:
+        return 0
+    
+    def output_size(self) -> int:
+        return 0
+
+
     @property
     def mode(self) -> ContractType:
         """Type of smart contract this instruction execution is supported in.
@@ -269,6 +276,9 @@ class Assert(Instruction):
         super().__init__()
         self._version: int = 3
 
+    def input_size(self) -> int:
+        return 1
+
 
 class Int(Instruction):
     """`int x` instruction pushes immediate value to the top of the stack.
@@ -297,6 +307,9 @@ class Int(Instruction):
 
     def __str__(self) -> str:
         return f"int {self._value}"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class PushInt(Instruction):
@@ -332,6 +345,9 @@ class PushInt(Instruction):
 
     def __str__(self) -> str:
         return f"pushint {self._value}"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Txn(Instruction):
@@ -388,6 +404,9 @@ class Txna(Instruction):
     def __str__(self) -> str:
         return f"txna {self._field}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Gtxn(Instruction):
     """`gtxn t f` pushes value of transaction field f of transaction t in the group.
@@ -418,6 +437,9 @@ class Gtxn(Instruction):
 
     def __str__(self) -> str:
         return f"gtxn {self._idx} {self._field}"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Gtxna(Instruction):
@@ -456,6 +478,9 @@ class Gtxna(Instruction):
     def __str__(self) -> str:
         return f"gtxna {self._idx} {self._field}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Gtxns(Instruction):
     """`gtxns f` pushes value of transaction field f of given transaction in the group.
@@ -483,6 +508,12 @@ class Gtxns(Instruction):
 
     def __str__(self) -> str:
         return f"Gtxns {self._field}"
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Gtxnsa(Instruction):
@@ -513,6 +544,12 @@ class Gtxnsa(Instruction):
     def __str__(self) -> str:
         return f"Gtxnsa {self._field}"
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Load(Instruction):
     """`load i` pushes the value at scratch space position i.
@@ -532,6 +569,9 @@ class Load(Instruction):
     def __str__(self) -> str:
         return f"load {self._idx}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Store(Instruction):
     """`store i` store value on top of the stack at scratch space position i.
@@ -550,6 +590,9 @@ class Store(Instruction):
 
     def __str__(self) -> str:
         return f"store {self._idx}"
+
+    def input_size(self) -> int:
+        return 1
 
 
 class Gload(Instruction):
@@ -577,6 +620,9 @@ class Gload(Instruction):
 
     def __str__(self) -> str:
         return f"gload {self._idx} {self._slot}"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Gloads(Instruction):
@@ -606,6 +652,12 @@ class Gloads(Instruction):
     def __str__(self) -> str:
         return f"gloads {self._slot}"
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Gaid(Instruction):
     """`gaid t` pushes the id of asset or application created in transaction t in the group.
@@ -630,6 +682,9 @@ class Gaid(Instruction):
     def __str__(self) -> str:
         return f"gaid {self._idx}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Gaids(Instruction):
     """`gaids` pushes the id of asset or application created in transaction X in the group.
@@ -650,6 +705,12 @@ class Gaids(Instruction):
         self._version: int = 4
         self._mode: ContractType = ContractType.STATEFULL
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Loads(Instruction):
     """`loads` pushes the value at scratch space position X.
@@ -666,6 +727,12 @@ class Loads(Instruction):
         super().__init__()
         self._version: int = 5
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Stores(Instruction):
     """`stores` store value on top of the stack (B) at scratch space position (A).
@@ -679,6 +746,9 @@ class Stores(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 5
+
+    def input_size(self) -> int:
+        return 2
 
 
 class Dig(Instruction):
@@ -700,6 +770,12 @@ class Dig(Instruction):
     def __str__(self) -> str:
         return f"dig {self._idx}"
 
+    def input_size(self) -> int:
+        return 1 + self._idx
+
+    def output_size(self) -> int:
+        return 2 + self._idx
+
 
 class Swap(Instruction):
     """`swap` swaps top two elements of the stack.
@@ -712,6 +788,12 @@ class Swap(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 3
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 2
 
 
 class GetBit(Instruction):
@@ -732,6 +814,12 @@ class GetBit(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 3
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class SetBit(Instruction):
@@ -754,6 +842,12 @@ class SetBit(Instruction):
         super().__init__()
         self._version: int = 3
 
+    def input_size(self) -> int:
+        return 3
+
+    def output_size(self) -> int:
+        return 1
+
 
 class GetByte(Instruction):
     """`getbyte` pushes the byte value of given element at given position.
@@ -770,6 +864,12 @@ class GetByte(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 3
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class SetByte(Instruction):
@@ -788,6 +888,12 @@ class SetByte(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 3
+
+    def input_size(self) -> int:
+        return 3
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Extract(Instruction):
@@ -827,6 +933,12 @@ class Extract(Instruction):
     def __str__(self) -> str:
         return f"extract {self._idx} {self._idy}"
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Extract3(Instruction):
     """`extract3` extracts the bytes from the given position of given length.
@@ -848,6 +960,12 @@ class Extract3(Instruction):
         super().__init__()
         self._version: int = 5
 
+    def input_size(self) -> int:
+        return 3
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Extract_uint16(Instruction):
     """`extract_uint16` converts the two bytes at given position as uint16.
@@ -867,6 +985,12 @@ class Extract_uint16(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 5
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Extract_uint32(Instruction):
@@ -888,6 +1012,12 @@ class Extract_uint32(Instruction):
         super().__init__()
         self._version: int = 5
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Extract_uint64(Instruction):
     """`extract_uint64` converts the eight bytes at given position as uint64.
@@ -907,6 +1037,12 @@ class Extract_uint64(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 5
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Sha256(Instruction):
@@ -939,6 +1075,12 @@ class Sha256(Instruction):
             return 7
         return 35
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Sha512_256(Instruction):
     """`sha512_256` calculate the sha512_256 hash of the given element.
@@ -969,6 +1111,12 @@ class Sha512_256(Instruction):
         if contract_version == 1:
             return 9
         return 45
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Keccak256(Instruction):
@@ -1001,6 +1149,12 @@ class Keccak256(Instruction):
             return 26
         return 130
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Ed25519verify(Instruction):
     """`ed25519verify` verifies the ed25519 signature for given public key and data.
@@ -1023,6 +1177,12 @@ class Ed25519verify(Instruction):
     def cost(self) -> int:
         """cost of executing ed25519verify instruction."""
         return 1900
+
+    def input_size(self) -> int:
+        return 3
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Ecdsa_verify(Instruction):
@@ -1080,6 +1240,12 @@ class Ecdsa_verify(Instruction):
     def __str__(self) -> str:
         return f"ecdsa_verify {self._idx}"
 
+    def input_size(self) -> int:
+        return 5
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Ecdsa_pk_decompress(Instruction):
     """`ecdsa_pk_decompress v` decompress elliptic curve point to it's components.
@@ -1124,6 +1290,12 @@ class Ecdsa_pk_decompress(Instruction):
 
     def __str__(self) -> str:
         return f"ecdsa_pk_decompress {self._idx}"
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 2
 
 
 class Ecdsa_pk_recover(Instruction):
@@ -1173,6 +1345,12 @@ class Ecdsa_pk_recover(Instruction):
     def __str__(self) -> str:
         return f"ecdsa_pk_recover {self._idx}"
 
+    def input_size(self) -> int:
+        return 4
+
+    def output_size(self) -> int:
+        return 2
+
 
 class Global(Instruction):
     """`global f` is used to access the value of global field f.
@@ -1202,6 +1380,12 @@ class Global(Instruction):
 class Dup(Instruction):
     """`dup` duplicates the top value on stack."""
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 2
+
 
 class Dup2(Instruction):
     """`dup2` duplicates the top two values of the stack."""
@@ -1209,6 +1393,12 @@ class Dup2(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 2
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 4
 
 
 class Select(Instruction):
@@ -1227,6 +1417,12 @@ class Select(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 3
+
+    def input_size(self) -> int:
+        return 3
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Cover(Instruction):
@@ -1274,6 +1470,12 @@ class Uncover(Instruction):
     def __str__(self) -> str:
         return f"uncover {self._idx}"
 
+    def input_size(self) -> int:
+        return 1 + self._idx
+
+    def output_size(self) -> int:
+        return 1 + self._idx
+
 
 class Concat(Instruction):
     """`concat` concatenates two bytearrays and pushes the result.
@@ -1293,6 +1495,12 @@ class Concat(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 2
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class InstructionWithLabel(Instruction):
@@ -1345,6 +1553,9 @@ class BZ(InstructionWithLabel):
     def __str__(self) -> str:
         return f"bz {self._label}"
 
+    def input_size(self) -> int:
+        return 1
+
 
 class BNZ(InstructionWithLabel):
     """`bnz target` branches to target if top of the stack is not zero.
@@ -1360,6 +1571,9 @@ class BNZ(InstructionWithLabel):
 
     def __str__(self) -> str:
         return f"bnz {self._label}"
+
+    def input_size(self) -> int:
+        return 1
 
 
 class Label(InstructionWithLabel):
@@ -1415,6 +1629,9 @@ class Return(Instruction):
         super().__init__()
         self._version: int = 2
 
+    def input_size(self) -> int:
+        return 1
+
 
 class Retsub(Instruction):
     """`retsub` returns from a subroutine using the callstack"""
@@ -1444,6 +1661,9 @@ class AppGlobalGet(Instruction):
     def __str__(self) -> str:
         return "app_global_get"
 
+    def input_size(self) -> int:
+        return 1
+
 
 class AppGlobalGetEx(Instruction):
     """`app_global_get_ex` allows reading the global state of the any application.
@@ -1471,6 +1691,12 @@ class AppGlobalGetEx(Instruction):
     def __str__(self) -> str:
         return "app_global_get_ex"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 2
+
 
 class AppGlobalPut(Instruction):
     """`app_global_put` allows modifying the global state of the current application.
@@ -1490,6 +1716,9 @@ class AppGlobalPut(Instruction):
 
     def __str__(self) -> str:
         return "app_global_put"
+
+    def input_size(self) -> int:
+        return 2
 
 
 class AppGlobalDel(Instruction):
@@ -1511,6 +1740,9 @@ class AppGlobalDel(Instruction):
 
     def __str__(self) -> str:
         return "app_global_del"
+
+    def input_size(self) -> int:
+        return 1
 
 
 class AppLocalGetEx(Instruction):
@@ -1542,6 +1774,12 @@ class AppLocalGetEx(Instruction):
     def __str__(self) -> str:
         return "app_local_get_ex"
 
+    def input_size(self) -> int:
+        return 3
+
+    def output_size(self) -> int:
+        return 2
+
 
 class AppLocalGet(Instruction):
     """`app_local_get` allows reading the local state of the current application.
@@ -1568,6 +1806,12 @@ class AppLocalGet(Instruction):
     def __str__(self) -> str:
         return "app_local_get"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class AppLocalPut(Instruction):
     """`app_local_put` allows modifying the local state of the current application.
@@ -1593,6 +1837,9 @@ class AppLocalPut(Instruction):
     def __str__(self) -> str:
         return "app_local_put"
 
+    def input_size(self) -> int:
+        return 3
+
 
 class AppLocalDel(Instruction):
     """`app_local_del` allows deleting a key from local state of the current application.
@@ -1616,6 +1863,9 @@ class AppLocalDel(Instruction):
 
     def __str__(self) -> str:
         return "app_local_del"
+
+    def input_size(self) -> int:
+        return 2
 
 
 class AssetHoldingGet(Instruction):
@@ -1654,6 +1904,12 @@ class AssetHoldingGet(Instruction):
     def __str__(self) -> str:
         return f"asset_holding_get {self._field}"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 2
+
 
 class AssetParamsGet(Instruction):
     """`asset_params_get i` allows reading params field of a given asset.
@@ -1687,6 +1943,12 @@ class AssetParamsGet(Instruction):
 
     def __str__(self) -> str:
         return f"asset_params_get {self._field}"
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 2
 
 
 class AppParamsGet(Instruction):
@@ -1722,6 +1984,12 @@ class AppParamsGet(Instruction):
     def __str__(self) -> str:
         return f"app_params_get {self._field}"
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 2
+
 
 class AppOptedIn(Instruction):
     """`app_opted_in` allows contract to check if given account has opted-in or not.
@@ -1749,6 +2017,12 @@ class AppOptedIn(Instruction):
     def __str__(self) -> str:
         return "app_opted_in"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Balance(Instruction):
     """`balance` reads the balance of an account in microalgos.
@@ -1771,6 +2045,12 @@ class Balance(Instruction):
         super().__init__()
         self._version: int = 2
         self._mode: ContractType = ContractType.STATEFULL
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class MinBalance(Instruction):
@@ -1796,6 +2076,12 @@ class MinBalance(Instruction):
     def __str__(self) -> str:
         return "min_balance"
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Itob(Instruction):
     """`itob` converts integer to big endian bytes.
@@ -1808,6 +2094,12 @@ class Itob(Instruction):
 
     """
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Btoi(Instruction):
     """`btoi` converts bytes as big endian to uint64.
@@ -1819,6 +2111,12 @@ class Btoi(Instruction):
         pushes uint64 value after the conversion.
 
     """
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Addr(Instruction):
@@ -1843,6 +2141,9 @@ class Addr(Instruction):
 class Pop(Instruction):
     """`pop` pops one element from the stack."""
 
+    def input_size(self) -> int:
+        return 1
+
 
 class Not(Instruction):
     """`!` not comparison operator.
@@ -1857,6 +2158,12 @@ class Not(Instruction):
 
     def __str__(self) -> str:
         return "!"
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Neq(Instruction):
@@ -1874,6 +2181,12 @@ class Neq(Instruction):
     def __str__(self) -> str:
         return "!="
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Eq(Instruction):
     """`==` equal to comparison operator.
@@ -1889,6 +2202,12 @@ class Eq(Instruction):
 
     def __str__(self) -> str:
         return "=="
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Greater(Instruction):
@@ -1906,6 +2225,12 @@ class Greater(Instruction):
     def __str__(self) -> str:
         return ">"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class GreaterE(Instruction):
     """`>=` greater than or equal to comparison operator.
@@ -1921,6 +2246,12 @@ class GreaterE(Instruction):
 
     def __str__(self) -> str:
         return ">="
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Less(Instruction):
@@ -1938,6 +2269,12 @@ class Less(Instruction):
     def __str__(self) -> str:
         return "<"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class LessE(Instruction):
     """`<=` less than or equal to comparison operator.
@@ -1953,6 +2290,12 @@ class LessE(Instruction):
 
     def __str__(self) -> str:
         return "<="
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class And(Instruction):
@@ -1970,6 +2313,12 @@ class And(Instruction):
     def __str__(self) -> str:
         return "&&"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Or(Instruction):
     """`||` logical and.
@@ -1985,6 +2334,12 @@ class Or(Instruction):
 
     def __str__(self) -> str:
         return "||"
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Add(Instruction):
@@ -2005,6 +2360,12 @@ class Add(Instruction):
     def __str__(self) -> str:
         return "+"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Sub(Instruction):
     """`-` arthimetic subtraction.
@@ -2023,6 +2384,12 @@ class Sub(Instruction):
 
     def __str__(self) -> str:
         return "-"
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Mul(Instruction):
@@ -2043,6 +2410,12 @@ class Mul(Instruction):
     def __str__(self) -> str:
         return "*"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Div(Instruction):
     """`/` arthimetic divison.
@@ -2061,6 +2434,12 @@ class Div(Instruction):
 
     def __str__(self) -> str:
         return "/"
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Modulo(Instruction):
@@ -2081,6 +2460,12 @@ class Modulo(Instruction):
     def __str__(self) -> str:
         return "%"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BitwiseOr(Instruction):
     """`|` bitwise or.
@@ -2096,6 +2481,12 @@ class BitwiseOr(Instruction):
 
     def __str__(self) -> str:
         return "|"
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class BitwiseAnd(Instruction):
@@ -2113,6 +2504,12 @@ class BitwiseAnd(Instruction):
     def __str__(self) -> str:
         return "&"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BitwiseXor(Instruction):
     """`^` bitwise xor.
@@ -2129,6 +2526,12 @@ class BitwiseXor(Instruction):
     def __str__(self) -> str:
         return "^"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BitwiseInvert(Instruction):
     """`~` bitwise invert.
@@ -2143,6 +2546,12 @@ class BitwiseInvert(Instruction):
 
     def __str__(self) -> str:
         return "~"
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class BitLen(Instruction):
@@ -2160,6 +2569,12 @@ class BitLen(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 4
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class BModulo(Instruction):
@@ -2206,6 +2621,12 @@ class BModulo(Instruction):
     def __str__(self) -> str:
         return "b%"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BNeq(Instruction):
     """`b!=` not equal comparison operator.
@@ -2228,6 +2649,12 @@ class BNeq(Instruction):
     def __str__(self) -> str:
         return "b!="
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BEq(Instruction):
     """`b==` equal to comparison operator.
@@ -2249,6 +2676,12 @@ class BEq(Instruction):
 
     def __str__(self) -> str:
         return "b=="
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class BBitwiseAnd(Instruction):
@@ -2292,6 +2725,12 @@ class BBitwiseAnd(Instruction):
     def __str__(self) -> str:
         return "b&"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BBitwiseOr(Instruction):
     """`b|` bitwise or.
@@ -2334,6 +2773,12 @@ class BBitwiseOr(Instruction):
     def __str__(self) -> str:
         return "b|"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BAdd(Instruction):
     """`b+` arthimetic addition.
@@ -2375,6 +2820,12 @@ class BAdd(Instruction):
 
     def __str__(self) -> str:
         return "b+"
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class BSubtract(Instruction):
@@ -2421,6 +2872,12 @@ class BSubtract(Instruction):
     def __str__(self) -> str:
         return "b-"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BDiv(Instruction):
     """`b/` arthimetic divison.
@@ -2466,6 +2923,12 @@ class BDiv(Instruction):
     def __str__(self) -> str:
         return "b/"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BMul(Instruction):
     """`b*` arthimetic multiplication.
@@ -2508,6 +2971,12 @@ class BMul(Instruction):
     def __str__(self) -> str:
         return "b*"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BGreaterE(Instruction):
     """`b>=` greater than or equal to comparison operator.
@@ -2529,6 +2998,12 @@ class BGreaterE(Instruction):
 
     def __str__(self) -> str:
         return "b>="
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class BGreater(Instruction):
@@ -2552,6 +3027,12 @@ class BGreater(Instruction):
     def __str__(self) -> str:
         return "b>"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BLessE(Instruction):
     """`b<=` less than or equal to comparison operator.
@@ -2574,6 +3055,12 @@ class BLessE(Instruction):
     def __str__(self) -> str:
         return "b<="
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BLess(Instruction):
     """`b<` less than comparison operator.
@@ -2595,6 +3082,12 @@ class BLess(Instruction):
 
     def __str__(self) -> str:
         return "b<"
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class BBitwiseXor(Instruction):
@@ -2638,6 +3131,12 @@ class BBitwiseXor(Instruction):
     def __str__(self) -> str:
         return "b^"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BBitwiseInvert(Instruction):
     """`b~` bitwise invert.
@@ -2678,6 +3177,12 @@ class BBitwiseInvert(Instruction):
             return 4
         return 0
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class BZero(Instruction):
     """`bzero` pushes byte array containing all zeroes.
@@ -2693,6 +3198,12 @@ class BZero(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 4
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Log(Instruction):
@@ -2711,6 +3222,9 @@ class Log(Instruction):
         super().__init__()
         self._version: int = 5
         self._mode: ContractType = ContractType.STATEFULL
+
+    def input_size(self) -> int:
+        return 1
 
 
 class Itxn_begin(Instruction):
@@ -2760,6 +3274,9 @@ class Itxn_field(Instruction):
     def __str__(self) -> str:
         return f"itxn_field {self._field}"
 
+    def input_size(self) -> int:
+        return 1
+
 
 class Itxn_submit(Instruction):
     """`itxn_submit` executes the current inner transaction.
@@ -2806,6 +3323,9 @@ class Itxn(Instruction):
     def __str__(self) -> str:
         return f"itxn {self._field}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Itxna(Instruction):
     """`itxna f i` pushes ith value of array transaction field f of last inner transaction.
@@ -2822,6 +3342,9 @@ class Itxna(Instruction):
         pushes value at index i of array transaction field f.
 
     """
+
+    def output_size(self) -> int:
+        return 1
 
     def __init__(self, field: TransactionField):
         super().__init__()
@@ -2869,6 +3392,12 @@ class Txnas(Instruction):
     def __str__(self) -> str:
         return f"txnas {self._field}"
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Gtxnas(Instruction):
     """`gtxnas t f` pushes a value of array transaction field f of transaction t in the group using top of the stack as index.
@@ -2908,6 +3437,12 @@ class Gtxnas(Instruction):
     def __str__(self) -> str:
         return f"Gtxnas {self._idx} {self._field}"
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Gtxnsas(Instruction):
     """`gtxnas f` pushes a value of array transaction field f of a transaction in the group.
@@ -2941,6 +3476,12 @@ class Gtxnsas(Instruction):
     def __str__(self) -> str:
         return f"gtxnsas {self._field}"
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Args(Instruction):
     """`args` pushes a LogicSig argument to stack using top of stack as index.
@@ -2958,6 +3499,12 @@ class Args(Instruction):
         self._version: int = 5
         self._mode: ContractType = ContractType.STATELESS
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Mulw(Instruction):
     """`mulw` multiplies two unit64 and pushes 128-bit long result.
@@ -2971,6 +3518,12 @@ class Mulw(Instruction):
         high (uint64): value of high 64 bits of result.
 
     """
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 2
 
 
 class Addw(Instruction):
@@ -2989,6 +3542,12 @@ class Addw(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 2
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 2
 
 
 class Divmodw(Instruction):
@@ -3035,6 +3594,12 @@ class Divmodw(Instruction):
             return 20
         return 0
 
+    def input_size(self) -> int:
+        return 4
+
+    def output_size(self) -> int:
+        return 4
+
 
 class Exp(Instruction):
     """`exp` allows calculating powers of a number.
@@ -3054,6 +3619,12 @@ class Exp(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 4
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Expw(Instruction):
@@ -3096,6 +3667,12 @@ class Expw(Instruction):
             return 10
         return 0
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 2
+
 
 class Shl(Instruction):
     """`shl` shifts left the given element by given bits.
@@ -3113,6 +3690,12 @@ class Shl(Instruction):
         super().__init__()
         self._version: int = 4
 
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Shr(Instruction):
     """`shl` shifts right the given element by given bits.
@@ -3129,6 +3712,12 @@ class Shr(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 4
+
+    def input_size(self) -> int:
+        return 2
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Sqrt(Instruction):
@@ -3166,6 +3755,12 @@ class Sqrt(Instruction):
             return 4
         return 0
 
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
+
 
 class Intcblock(Instruction):
     """`intcblock x ...` resets and replaces integer constants in constant storage space.
@@ -3202,6 +3797,9 @@ class Intc(Instruction):
     def __str__(self) -> str:
         return f"intc {self._idx}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Intc0(Instruction):
     """`intc_0` push integer constant 0 from constant storage space.
@@ -3213,6 +3811,9 @@ class Intc0(Instruction):
 
     def __str__(self) -> str:
         return "intc_0"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Intc1(Instruction):
@@ -3226,6 +3827,9 @@ class Intc1(Instruction):
     def __str__(self) -> str:
         return "intc_1"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Intc2(Instruction):
     """`intc_2` push integer constant 2 from constant storage space.
@@ -3237,6 +3841,9 @@ class Intc2(Instruction):
 
     def __str__(self) -> str:
         return "intc_2"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Intc3(Instruction):
@@ -3281,6 +3888,9 @@ class Bytec0(Instruction):
     def __str__(self) -> str:
         return "bytec_0"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Bytec1(Instruction):
     """`bytec_1` push byte constant 1 from constant storage space.
@@ -3292,6 +3902,9 @@ class Bytec1(Instruction):
 
     def __str__(self) -> str:
         return "bytec_1"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Bytec2(Instruction):
@@ -3305,6 +3918,9 @@ class Bytec2(Instruction):
     def __str__(self) -> str:
         return "bytec_2"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Bytec3(Instruction):
     """`bytec_3` push byte constant 3 from constant storage space.
@@ -3316,6 +3932,9 @@ class Bytec3(Instruction):
 
     def __str__(self) -> str:
         return "bytec_3"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Arg(Instruction):
@@ -3337,6 +3956,9 @@ class Arg(Instruction):
     def __str__(self) -> str:
         return f"arg {self._idx}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Arg0(Instruction):
     """`arg_0` pushes 0th LogicSig argument to stack.
@@ -3352,6 +3974,9 @@ class Arg0(Instruction):
 
     def __str__(self) -> str:
         return "arg_0"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Arg1(Instruction):
@@ -3369,6 +3994,9 @@ class Arg1(Instruction):
     def __str__(self) -> str:
         return "arg_1"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Arg2(Instruction):
     """`arg_2` pushes 2nd LogicSig argument to stack.
@@ -3385,6 +4013,9 @@ class Arg2(Instruction):
     def __str__(self) -> str:
         return "arg_2"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Arg3(Instruction):
     """`arg_3` pushes 3rd LogicSig argument to stack.
@@ -3400,6 +4031,9 @@ class Arg3(Instruction):
 
     def __str__(self) -> str:
         return "arg_3"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Byte(Instruction):
@@ -3422,6 +4056,9 @@ class Byte(Instruction):
 
     def __str__(self) -> str:
         return f"byte {self._bytes}"
+
+    def output_size(self) -> int:
+        return 1
 
 
 class PushBytes(Instruction):
@@ -3451,6 +4088,9 @@ class PushBytes(Instruction):
     def __str__(self) -> str:
         return f"pushbytes {self._bytes}"
 
+    def output_size(self) -> int:
+        return 1
+
 
 class Len(Instruction):
     """`len` calculates the length of the given byte array.
@@ -3462,6 +4102,12 @@ class Len(Instruction):
         (uint64): pushes the length of the byte array X.
 
     """
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Bytecblock(Instruction):
@@ -3508,6 +4154,12 @@ class Substring(Instruction):
 
     def __str__(self) -> str:
         return f"substring {self._start} {self._stop}"
+
+    def input_size(self) -> int:
+        return 1
+
+    def output_size(self) -> int:
+        return 1
 
 
 class Substring3(Instruction):

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -374,7 +374,7 @@ class Txn(Instruction):
     def field(self) -> TransactionField:
         """Transaction field being accessed using the txn instruction."""
         return self._field
-    
+
     @property
     def stack_push_size(self) -> int:
         return 1
@@ -5387,7 +5387,7 @@ class Match(Instruction):
 
     @property
     def stack_pop_size(self) -> int:
-        return len(self._labels) + 1)
+        return len(self._labels) + 1
 
     @property
     def labels(self) -> List[str]:

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -164,12 +164,13 @@ class Instruction:  # pylint: disable=too-many-instance-attributes
         """Teal version this instruction is introduced in and supported from."""
         return self._version
 
-    def input_size(self) -> int:
-        return 0
-    
-    def output_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 0
 
+    @property
+    def stack_push_size(self) -> int:
+        return 0
 
     @property
     def mode(self) -> ContractType:
@@ -276,7 +277,8 @@ class Assert(Instruction):
         super().__init__()
         self._version: int = 3
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -308,7 +310,8 @@ class Int(Instruction):
     def __str__(self) -> str:
         return f"int {self._value}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -346,7 +349,8 @@ class PushInt(Instruction):
     def __str__(self) -> str:
         return f"pushint {self._value}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -404,7 +408,8 @@ class Txna(Instruction):
     def __str__(self) -> str:
         return f"txna {self._field}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -438,7 +443,8 @@ class Gtxn(Instruction):
     def __str__(self) -> str:
         return f"gtxn {self._idx} {self._field}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -478,7 +484,8 @@ class Gtxna(Instruction):
     def __str__(self) -> str:
         return f"gtxna {self._idx} {self._field}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -509,10 +516,12 @@ class Gtxns(Instruction):
     def __str__(self) -> str:
         return f"Gtxns {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -544,10 +553,12 @@ class Gtxnsa(Instruction):
     def __str__(self) -> str:
         return f"Gtxnsa {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -569,7 +580,8 @@ class Load(Instruction):
     def __str__(self) -> str:
         return f"load {self._idx}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -591,7 +603,8 @@ class Store(Instruction):
     def __str__(self) -> str:
         return f"store {self._idx}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -621,7 +634,8 @@ class Gload(Instruction):
     def __str__(self) -> str:
         return f"gload {self._idx} {self._slot}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -652,10 +666,12 @@ class Gloads(Instruction):
     def __str__(self) -> str:
         return f"gloads {self._slot}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -682,7 +698,8 @@ class Gaid(Instruction):
     def __str__(self) -> str:
         return f"gaid {self._idx}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -705,10 +722,12 @@ class Gaids(Instruction):
         self._version: int = 4
         self._mode: ContractType = ContractType.STATEFULL
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -727,10 +746,12 @@ class Loads(Instruction):
         super().__init__()
         self._version: int = 5
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -747,7 +768,8 @@ class Stores(Instruction):
         super().__init__()
         self._version: int = 5
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
 
@@ -770,10 +792,12 @@ class Dig(Instruction):
     def __str__(self) -> str:
         return f"dig {self._idx}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1 + self._idx
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2 + self._idx
 
 
@@ -789,10 +813,12 @@ class Swap(Instruction):
         super().__init__()
         self._version: int = 3
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -815,10 +841,12 @@ class GetBit(Instruction):
         super().__init__()
         self._version: int = 3
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -842,10 +870,12 @@ class SetBit(Instruction):
         super().__init__()
         self._version: int = 3
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 3
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -865,10 +895,12 @@ class GetByte(Instruction):
         super().__init__()
         self._version: int = 3
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -889,10 +921,12 @@ class SetByte(Instruction):
         super().__init__()
         self._version: int = 3
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 3
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -933,10 +967,12 @@ class Extract(Instruction):
     def __str__(self) -> str:
         return f"extract {self._idx} {self._idy}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -960,10 +996,12 @@ class Extract3(Instruction):
         super().__init__()
         self._version: int = 5
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 3
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -986,10 +1024,12 @@ class Extract_uint16(Instruction):
         super().__init__()
         self._version: int = 5
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1012,10 +1052,12 @@ class Extract_uint32(Instruction):
         super().__init__()
         self._version: int = 5
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1038,10 +1080,12 @@ class Extract_uint64(Instruction):
         super().__init__()
         self._version: int = 5
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1075,10 +1119,12 @@ class Sha256(Instruction):
             return 7
         return 35
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1112,10 +1158,12 @@ class Sha512_256(Instruction):
             return 9
         return 45
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1149,10 +1197,12 @@ class Keccak256(Instruction):
             return 26
         return 130
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1178,10 +1228,12 @@ class Ed25519verify(Instruction):
         """cost of executing ed25519verify instruction."""
         return 1900
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 3
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1240,10 +1292,12 @@ class Ecdsa_verify(Instruction):
     def __str__(self) -> str:
         return f"ecdsa_verify {self._idx}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 5
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1291,10 +1345,12 @@ class Ecdsa_pk_decompress(Instruction):
     def __str__(self) -> str:
         return f"ecdsa_pk_decompress {self._idx}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -1345,10 +1401,12 @@ class Ecdsa_pk_recover(Instruction):
     def __str__(self) -> str:
         return f"ecdsa_pk_recover {self._idx}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 4
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -1380,10 +1438,12 @@ class Global(Instruction):
 class Dup(Instruction):
     """`dup` duplicates the top value on stack."""
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -1394,10 +1454,12 @@ class Dup2(Instruction):
         super().__init__()
         self._version: int = 2
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 4
 
 
@@ -1418,10 +1480,12 @@ class Select(Instruction):
         super().__init__()
         self._version: int = 3
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 3
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1470,10 +1534,12 @@ class Uncover(Instruction):
     def __str__(self) -> str:
         return f"uncover {self._idx}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1 + self._idx
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1 + self._idx
 
 
@@ -1496,10 +1562,12 @@ class Concat(Instruction):
         super().__init__()
         self._version: int = 2
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1553,7 +1621,8 @@ class BZ(InstructionWithLabel):
     def __str__(self) -> str:
         return f"bz {self._label}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -1572,7 +1641,8 @@ class BNZ(InstructionWithLabel):
     def __str__(self) -> str:
         return f"bnz {self._label}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -1629,7 +1699,8 @@ class Return(Instruction):
         super().__init__()
         self._version: int = 2
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -1661,7 +1732,8 @@ class AppGlobalGet(Instruction):
     def __str__(self) -> str:
         return "app_global_get"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -1691,10 +1763,12 @@ class AppGlobalGetEx(Instruction):
     def __str__(self) -> str:
         return "app_global_get_ex"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -1717,7 +1791,8 @@ class AppGlobalPut(Instruction):
     def __str__(self) -> str:
         return "app_global_put"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
 
@@ -1741,7 +1816,8 @@ class AppGlobalDel(Instruction):
     def __str__(self) -> str:
         return "app_global_del"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -1774,10 +1850,12 @@ class AppLocalGetEx(Instruction):
     def __str__(self) -> str:
         return "app_local_get_ex"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 3
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -1806,10 +1884,12 @@ class AppLocalGet(Instruction):
     def __str__(self) -> str:
         return "app_local_get"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -1837,7 +1917,8 @@ class AppLocalPut(Instruction):
     def __str__(self) -> str:
         return "app_local_put"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 3
 
 
@@ -1864,7 +1945,8 @@ class AppLocalDel(Instruction):
     def __str__(self) -> str:
         return "app_local_del"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
 
@@ -1904,10 +1986,12 @@ class AssetHoldingGet(Instruction):
     def __str__(self) -> str:
         return f"asset_holding_get {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -1944,10 +2028,12 @@ class AssetParamsGet(Instruction):
     def __str__(self) -> str:
         return f"asset_params_get {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -1984,10 +2070,12 @@ class AppParamsGet(Instruction):
     def __str__(self) -> str:
         return f"app_params_get {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -2017,10 +2105,12 @@ class AppOptedIn(Instruction):
     def __str__(self) -> str:
         return "app_opted_in"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2046,10 +2136,12 @@ class Balance(Instruction):
         self._version: int = 2
         self._mode: ContractType = ContractType.STATEFULL
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2076,10 +2168,12 @@ class MinBalance(Instruction):
     def __str__(self) -> str:
         return "min_balance"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2094,10 +2188,12 @@ class Itob(Instruction):
 
     """
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2112,10 +2208,12 @@ class Btoi(Instruction):
 
     """
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2141,7 +2239,8 @@ class Addr(Instruction):
 class Pop(Instruction):
     """`pop` pops one element from the stack."""
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -2159,10 +2258,12 @@ class Not(Instruction):
     def __str__(self) -> str:
         return "!"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2181,10 +2282,12 @@ class Neq(Instruction):
     def __str__(self) -> str:
         return "!="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2203,10 +2306,12 @@ class Eq(Instruction):
     def __str__(self) -> str:
         return "=="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2225,10 +2330,12 @@ class Greater(Instruction):
     def __str__(self) -> str:
         return ">"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2247,10 +2354,12 @@ class GreaterE(Instruction):
     def __str__(self) -> str:
         return ">="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2269,10 +2378,12 @@ class Less(Instruction):
     def __str__(self) -> str:
         return "<"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2291,10 +2402,12 @@ class LessE(Instruction):
     def __str__(self) -> str:
         return "<="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2313,10 +2426,12 @@ class And(Instruction):
     def __str__(self) -> str:
         return "&&"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2335,10 +2450,12 @@ class Or(Instruction):
     def __str__(self) -> str:
         return "||"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2360,10 +2477,12 @@ class Add(Instruction):
     def __str__(self) -> str:
         return "+"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2385,10 +2504,12 @@ class Sub(Instruction):
     def __str__(self) -> str:
         return "-"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2410,10 +2531,12 @@ class Mul(Instruction):
     def __str__(self) -> str:
         return "*"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2435,10 +2558,12 @@ class Div(Instruction):
     def __str__(self) -> str:
         return "/"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2460,10 +2585,12 @@ class Modulo(Instruction):
     def __str__(self) -> str:
         return "%"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2482,10 +2609,12 @@ class BitwiseOr(Instruction):
     def __str__(self) -> str:
         return "|"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2504,10 +2633,12 @@ class BitwiseAnd(Instruction):
     def __str__(self) -> str:
         return "&"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2526,10 +2657,12 @@ class BitwiseXor(Instruction):
     def __str__(self) -> str:
         return "^"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2547,10 +2680,12 @@ class BitwiseInvert(Instruction):
     def __str__(self) -> str:
         return "~"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2570,10 +2705,12 @@ class BitLen(Instruction):
         super().__init__()
         self._version: int = 4
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2621,10 +2758,12 @@ class BModulo(Instruction):
     def __str__(self) -> str:
         return "b%"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2649,10 +2788,12 @@ class BNeq(Instruction):
     def __str__(self) -> str:
         return "b!="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2677,10 +2818,12 @@ class BEq(Instruction):
     def __str__(self) -> str:
         return "b=="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2725,10 +2868,12 @@ class BBitwiseAnd(Instruction):
     def __str__(self) -> str:
         return "b&"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2773,10 +2918,12 @@ class BBitwiseOr(Instruction):
     def __str__(self) -> str:
         return "b|"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2821,10 +2968,12 @@ class BAdd(Instruction):
     def __str__(self) -> str:
         return "b+"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2872,10 +3021,12 @@ class BSubtract(Instruction):
     def __str__(self) -> str:
         return "b-"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2923,10 +3074,12 @@ class BDiv(Instruction):
     def __str__(self) -> str:
         return "b/"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2971,10 +3124,12 @@ class BMul(Instruction):
     def __str__(self) -> str:
         return "b*"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -2999,10 +3154,12 @@ class BGreaterE(Instruction):
     def __str__(self) -> str:
         return "b>="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3027,10 +3184,12 @@ class BGreater(Instruction):
     def __str__(self) -> str:
         return "b>"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3055,10 +3214,12 @@ class BLessE(Instruction):
     def __str__(self) -> str:
         return "b<="
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3083,10 +3244,12 @@ class BLess(Instruction):
     def __str__(self) -> str:
         return "b<"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3131,10 +3294,12 @@ class BBitwiseXor(Instruction):
     def __str__(self) -> str:
         return "b^"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3177,10 +3342,12 @@ class BBitwiseInvert(Instruction):
             return 4
         return 0
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3199,10 +3366,12 @@ class BZero(Instruction):
         super().__init__()
         self._version: int = 4
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3223,7 +3392,8 @@ class Log(Instruction):
         self._version: int = 5
         self._mode: ContractType = ContractType.STATEFULL
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -3274,7 +3444,8 @@ class Itxn_field(Instruction):
     def __str__(self) -> str:
         return f"itxn_field {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
 
@@ -3323,7 +3494,8 @@ class Itxn(Instruction):
     def __str__(self) -> str:
         return f"itxn {self._field}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3343,7 +3515,8 @@ class Itxna(Instruction):
 
     """
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
     def __init__(self, field: TransactionField):
@@ -3392,10 +3565,12 @@ class Txnas(Instruction):
     def __str__(self) -> str:
         return f"txnas {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3437,10 +3612,12 @@ class Gtxnas(Instruction):
     def __str__(self) -> str:
         return f"Gtxnas {self._idx} {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3476,10 +3653,12 @@ class Gtxnsas(Instruction):
     def __str__(self) -> str:
         return f"gtxnsas {self._field}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3499,10 +3678,12 @@ class Args(Instruction):
         self._version: int = 5
         self._mode: ContractType = ContractType.STATELESS
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3519,10 +3700,12 @@ class Mulw(Instruction):
 
     """
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -3543,10 +3726,12 @@ class Addw(Instruction):
         super().__init__()
         self._version: int = 2
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -3594,10 +3779,12 @@ class Divmodw(Instruction):
             return 20
         return 0
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 4
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 4
 
 
@@ -3620,10 +3807,12 @@ class Exp(Instruction):
         super().__init__()
         self._version: int = 4
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3667,10 +3856,12 @@ class Expw(Instruction):
             return 10
         return 0
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 2
 
 
@@ -3690,10 +3881,12 @@ class Shl(Instruction):
         super().__init__()
         self._version: int = 4
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3713,10 +3906,12 @@ class Shr(Instruction):
         super().__init__()
         self._version: int = 4
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 2
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3755,10 +3950,12 @@ class Sqrt(Instruction):
             return 4
         return 0
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3797,7 +3994,8 @@ class Intc(Instruction):
     def __str__(self) -> str:
         return f"intc {self._idx}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3812,7 +4010,8 @@ class Intc0(Instruction):
     def __str__(self) -> str:
         return "intc_0"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3827,7 +4026,8 @@ class Intc1(Instruction):
     def __str__(self) -> str:
         return "intc_1"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3842,7 +4042,8 @@ class Intc2(Instruction):
     def __str__(self) -> str:
         return "intc_2"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3888,7 +4089,8 @@ class Bytec0(Instruction):
     def __str__(self) -> str:
         return "bytec_0"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3903,7 +4105,8 @@ class Bytec1(Instruction):
     def __str__(self) -> str:
         return "bytec_1"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3918,7 +4121,8 @@ class Bytec2(Instruction):
     def __str__(self) -> str:
         return "bytec_2"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3933,7 +4137,8 @@ class Bytec3(Instruction):
     def __str__(self) -> str:
         return "bytec_3"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3956,7 +4161,8 @@ class Arg(Instruction):
     def __str__(self) -> str:
         return f"arg {self._idx}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3975,7 +4181,8 @@ class Arg0(Instruction):
     def __str__(self) -> str:
         return "arg_0"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -3994,7 +4201,8 @@ class Arg1(Instruction):
     def __str__(self) -> str:
         return "arg_1"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -4013,7 +4221,8 @@ class Arg2(Instruction):
     def __str__(self) -> str:
         return "arg_2"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -4032,7 +4241,8 @@ class Arg3(Instruction):
     def __str__(self) -> str:
         return "arg_3"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -4057,7 +4267,8 @@ class Byte(Instruction):
     def __str__(self) -> str:
         return f"byte {self._bytes}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -4088,7 +4299,8 @@ class PushBytes(Instruction):
     def __str__(self) -> str:
         return f"pushbytes {self._bytes}"
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -4103,10 +4315,12 @@ class Len(Instruction):
 
     """
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -4155,10 +4369,12 @@ class Substring(Instruction):
     def __str__(self) -> str:
         return f"substring {self._start} {self._stop}"
 
-    def input_size(self) -> int:
+    @property
+    def stack_pop_size(self) -> int:
         return 1
 
-    def output_size(self) -> int:
+    @property
+    def stack_push_size(self) -> int:
         return 1
 
 
@@ -4213,6 +4429,14 @@ class AcctParamsGet(Instruction):
     def __str__(self) -> str:
         return f"acct_params_get {self._field}"
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 2
+
 
 class BSqrt(Instruction):
     """`bsqrt` floor square root.
@@ -4231,6 +4455,14 @@ class BSqrt(Instruction):
     def __init__(self) -> None:
         super().__init__()
         self._version: int = 6
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     @property
     def cost(self) -> int:
@@ -4289,6 +4521,14 @@ class Divw(Instruction):
         super().__init__()
         self._version: int = 6
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 3
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
 
 class Gitxn(Instruction):
     """`gitxn t f` pushes value of transaction field f of transaction t in the last inner group submitted.
@@ -4318,6 +4558,14 @@ class Gitxn(Instruction):
     def field(self) -> TransactionField:
         """Transaction field of the instruction being accessed."""
         return self._field
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return f"gitxn {self._idx} {self._field}"
@@ -4357,6 +4605,10 @@ class Gitxna(Instruction):
         """Array transaction field being accessed."""
         return self._field
 
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"gitxna {self._idx} {self._field}"
 
@@ -4376,6 +4628,14 @@ class Gloadss(Instruction):
         i.e if transaction is not executed before this transaction.
 
     """
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 2
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __init__(self) -> None:
         super().__init__()
@@ -4411,6 +4671,10 @@ class Itxnas(Instruction):
     def field(self) -> TransactionField:
         """Array transaction field being accessed."""
         return self._field
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return f"itxnas {self._field}"
@@ -4452,6 +4716,14 @@ class Gitxnas(Instruction):
         """Transaction field being accessed."""
         return self._field
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"Gitxnas {self._idx} {self._field}"
 
@@ -4487,6 +4759,14 @@ class Replace2(Instruction):
         """Replacement index."""
         return self._idx
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 2
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"replace2 {self._idx}"
 
@@ -4509,6 +4789,14 @@ class Replace3(Instruction):
         fails if B + len(C) exceeds len(A).
 
     """
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 3
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __init__(self) -> None:
         super().__init__()
@@ -4555,6 +4843,14 @@ class Replace(Instruction):
             raise TealerException("replace instruction does not have any immediates")
         return self._idx
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 3
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         if self._idx is not None:
             return f"replace {self._idx}"
@@ -4600,6 +4896,14 @@ class Base64_decode(Instruction):
             return 1
         return 0
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"base64_decode {self._encoding}"
 
@@ -4644,6 +4948,14 @@ class Json_ref(Instruction):
             return 25
         return 0
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 2
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"json_ref {self._type}"
 
@@ -4682,6 +4994,14 @@ class Ed25519verify_bare(Instruction):
             return 1900
         return 0
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 3
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
 
 class Sha3_256(Instruction):
     """`sha3_256` calculates sha3_256 hash of data.
@@ -4692,6 +5012,14 @@ class Sha3_256(Instruction):
     Pushes:
         pushes sha3_256 hash of value A ([32]byte).
     """
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __init__(self) -> None:
         super().__init__()
@@ -4739,6 +5067,14 @@ class Vrf_verify(Instruction):
             return 5700
         return 0
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 3
+
+    @property
+    def stack_push_size(self) -> int:
+        return 2
+
     def __str__(self) -> str:
         return f"vrf_verify {self._idx}"
 
@@ -4769,6 +5105,14 @@ class Block(Instruction):
         """block field"""
         return self._field
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"block {self._field}"
 
@@ -4794,6 +5138,14 @@ class Bury(Instruction):
         self._index: int = index
         self._version: int = 8
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"bury {self._index}"
 
@@ -4816,6 +5168,10 @@ class Popn(Instruction):
         self._nelements: int = n
         self._version: int = 8
 
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"popn {self._nelements}"
 
@@ -4834,6 +5190,10 @@ class Dupn(Instruction):
         super().__init__()
         self._count: int = count
         self._version: int = 8
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return f"dupn {self._count}"
@@ -4856,6 +5216,10 @@ class PushBytess(Instruction):
         self._bytes_list = bytes_list
         self._version: int = 8
 
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return " ".join(["pushbytess"] + self._bytes_list)
 
@@ -4876,6 +5240,10 @@ class PushInts(Instruction):
         super().__init__()
         self._int_list = int_list
         self._version: int = 8
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return " ".join(["pushints"] + list(map(str, self._int_list)))
@@ -4919,6 +5287,10 @@ class FrameDig(Instruction):
         self._index: int = index
         self._version: int = 8
 
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return f"frame_dig {self._index}"
 
@@ -4940,6 +5312,14 @@ class FrameBury(Instruction):
         super().__init__()
         self._index: int = index
         self._version: int = 8
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return f"frame_bury {self._index}"
@@ -4966,6 +5346,10 @@ class Switch(Instruction):
     @property
     def labels(self) -> List[str]:
         return self._labels
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return " ".join(["switch"] + self._labels)
@@ -4998,6 +5382,10 @@ class Match(Instruction):
         self._version: int = 8
 
     @property
+    def stack_pop_size(self) -> int:
+        return None
+
+    @property
     def labels(self) -> List[str]:
         return self._labels
 
@@ -5022,6 +5410,14 @@ class BoxCreate(Instruction):
         self._version: int = 8
         self._mode: ContractType = ContractType.STATEFULL
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 2
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return "box_create"
 
@@ -5039,6 +5435,14 @@ class BoxExtract(Instruction):
         super().__init__()
         self._version: int = 8
         self._mode: ContractType = ContractType.STATEFULL
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 3
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return "box_extract"
@@ -5058,6 +5462,14 @@ class BoxReplace(Instruction):
         self._version: int = 8
         self._mode: ContractType = ContractType.STATEFULL
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 3
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return "box_replace"
 
@@ -5075,6 +5487,14 @@ class BoxDel(Instruction):
         self._version: int = 8
         self._mode: ContractType = ContractType.STATEFULL
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 1
+
     def __str__(self) -> str:
         return "box_del"
 
@@ -5091,6 +5511,14 @@ class BoxLen(Instruction):
         super().__init__()
         self._version: int = 8
         self._mode: ContractType = ContractType.STATEFULL
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 2
 
     def __str__(self) -> str:
         return "box_len"
@@ -5110,6 +5538,14 @@ class BoxGet(Instruction):
         self._version: int = 8
         self._mode: ContractType = ContractType.STATEFULL
 
+    @property
+    def stack_pop_size(self) -> int:
+        return 1
+
+    @property
+    def stack_push_size(self) -> int:
+        return 2
+
     def __str__(self) -> str:
         return "box_get"
 
@@ -5127,6 +5563,10 @@ class BoxPut(Instruction):
         super().__init__()
         self._version: int = 8
         self._mode: ContractType = ContractType.STATEFULL
+
+    @property
+    def stack_pop_size(self) -> int:
+        return 2
 
     def __str__(self) -> str:
         return "box_put"

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -5383,7 +5383,7 @@ class Match(Instruction):
 
     @property
     def stack_pop_size(self) -> int:
-        return None
+        return len(self._labels) + 1)
 
     @property
     def labels(self) -> List[str]:

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -374,6 +374,10 @@ class Txn(Instruction):
     def field(self) -> TransactionField:
         """Transaction field being accessed using the txn instruction."""
         return self._field
+    
+    @property
+    def stack_push_size(self) -> int:
+        return 1
 
     def __str__(self) -> str:
         return f"txn {self._field}"

--- a/tealer/teal/instructions/transaction_field.py
+++ b/tealer/teal/instructions/transaction_field.py
@@ -11,6 +11,7 @@ classes representing the fields must inherit from TransactionField class.
 # pylint: disable=too-few-public-methods
 
 # https://developer.algorand.org/docs/reference/teal/opcodes/#txn
+from typing import Any
 
 
 class TransactionField:
@@ -23,6 +24,13 @@ class TransactionField:
     def version(self) -> int:
         """Teal version this field is introduced in and supported from."""
         return self._version
+
+    def __eq__(self, other: Any) -> bool:
+        # pylint: disable=unidiomatic-typecheck
+        return type(other) == type(self)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
 
     def __str__(self) -> str:
         return self.__class__.__qualname__

--- a/tests/test_dataflow/test_collect_instructions.py
+++ b/tests/test_dataflow/test_collect_instructions.py
@@ -1,0 +1,139 @@
+from typing import Tuple
+
+import pytest
+
+from tealer.analyses.dataflow.collect_instructions import CollectInstructions
+from tealer.teal.instructions.instructions import Return
+from tealer.teal.parse_teal import parse_teal
+
+MULTIPLE_RETSUB = """
+#pragma version 5
+b main
+is_even:
+    int 2
+    %
+    bz return_1
+    int 0
+    global GroupSize
+    int 2
+    ==
+    assert
+    retsub
+return_1:
+    global GroupSize
+    int 3
+    <
+    assert
+    int 1
+    retsub
+main:
+    global GroupSize
+    int 1
+    !=
+    assert
+    int 4
+    callsub is_even
+    return
+"""
+
+SUBROUTINE_BACK_JUMP = """
+#pragma version 5
+b main
+getmod:
+    %
+    retsub
+is_odd:
+    global GroupSize
+    int 4
+    <
+    assert
+    global GroupSize
+    int 2
+    !=
+    assert
+    int 2
+    b getmod
+main:
+    int 5
+    callsub is_odd
+    return
+"""
+
+BRANCHING = """
+#pragma version 4
+global GroupSize
+int 2
+>=
+assert
+global GroupSize
+int 4
+>
+bz fin
+global GroupSize
+int 1
+==
+bnz check_second_arg
+int 0
+return
+check_second_arg:
+txn ApplicationArgs 1
+btoi
+int 100
+>
+bnz fin
+int 0
+return
+fin:
+int 1
+return
+"""
+
+LOOPS = """
+#pragma version 5
+global GroupSize
+int 4
+!=
+assert
+int 0
+loop:
+    dup
+    global GroupSize
+    int 3
+    >=
+    bz end
+    int 1
+    +
+    global GroupSize
+    int 3
+    <
+    assert
+    b loop
+end:
+    int 2
+    global GroupSize
+    ==
+    assert
+    int 1
+    return
+"""
+
+ALL_TESTS = [(MULTIPLE_RETSUB, 27), (SUBROUTINE_BACK_JUMP, 20), (BRANCHING, 22), (LOOPS, 26)]
+
+
+@pytest.mark.parametrize("test", ALL_TESTS)
+def test_group_indices(test: Tuple[str, int]) -> None:
+    teal = parse_teal(test[0])
+
+    ci = CollectInstructions(teal)
+    ci.run_analysis()
+    bb_out = ci.result()
+
+    # We assume that the return node is always the last in instructions
+    # This might not hold if we change the parsing
+    return_node = teal.instructions[-1]
+    assert isinstance(return_node, Return)
+    assert return_node.bb
+
+    values = bb_out[return_node.bb].values
+    assert isinstance(values, set)
+    assert len(values) == test[1]

--- a/tests/test_dataflow/test_stack_value.py
+++ b/tests/test_dataflow/test_stack_value.py
@@ -1,0 +1,207 @@
+from typing import Tuple, Dict, List, Any
+
+import pytest
+
+from tealer.analyses.dataflow.stack_value import StackValueAnalysis, Stack, StackValue
+from tealer.teal import global_field
+from tealer.teal.instructions import instructions
+from tealer.teal.parse_teal import parse_teal
+
+MULTIPLE_RETSUB = """
+#pragma version 5
+b main
+is_even:
+    int 2
+    %
+    bz return_1
+    int 0
+    global GroupSize
+    int 2
+    ==
+    assert
+    retsub
+return_1:
+    global GroupSize
+    int 3
+    <
+    assert
+    int 1
+    retsub
+main:
+    global GroupSize
+    int 1
+    !=
+    assert
+    int 4æ
+    callsub is_even
+    return
+"""
+
+MULTIPLE_RETSUB_EXCEPTED = {
+    11: Stack([StackValue({0}), StackValue({global_field.GroupSize()}), StackValue({2})]),
+    17: Stack([StackValue({global_field.GroupSize()}), StackValue({3})]),
+    24: Stack([StackValue({global_field.GroupSize()}), StackValue({1})]),
+}
+
+SUBROUTINE_BACK_JUMP = """
+#pragma version 5
+b main
+getmod:
+    %
+    retsub
+is_odd:
+    global GroupSize
+    int 4
+    <
+    assert
+    global GroupSize
+    int 2
+    !=
+    assert
+    int 2
+    b getmod
+main:
+    int 5
+    callsub is_odd
+    return
+"""
+
+SUBROUTINE_BACK_JUMP_EXCEPTED = {
+    10: Stack([StackValue({global_field.GroupSize()}), StackValue({4})]),
+    14: Stack([StackValue({global_field.GroupSize()}), StackValue({2})]),
+}
+
+BRANCHING = """
+#pragma version 4
+global GroupSize
+int 2
+>=
+assert
+global GroupSize
+int 4
+>
+bz fin
+global GroupSize
+int 1
+==
+bnz check_second_arg
+int 0
+return
+check_second_arg:
+txn ApplicationArgs 1
+btoi
+int 100
+>
+bnz fin
+int 0
+return
+fin:
+int 1
+return
+"""
+
+BRANCHING_EXCEPTED = {
+    5: Stack([StackValue({global_field.GroupSize()}), StackValue({2})]),
+    9: Stack([StackValue({global_field.GroupSize()}), StackValue({4})]),
+    13: Stack([StackValue({global_field.GroupSize()}), StackValue({1})]),
+    21: Stack([StackValue({100})]),
+}
+
+LOOPS = """
+#pragma version 5
+global GroupSize
+int 4
+!=
+assert
+int 0
+loop:
+    dup
+    global GroupSize
+    int 3
+    >=
+    bz end
+    int 1
+    +
+    global GroupSize
+    int 3
+    <
+    assert
+    b loop
+end:
+    int 2
+    global GroupSize
+    ==
+    assert
+    int 1
+    return
+"""
+
+LOOPS_EXCEPTED = {
+    5: Stack([StackValue({global_field.GroupSize()}), StackValue({4})]),
+    12: Stack([StackValue({global_field.GroupSize()}), StackValue({3})]),
+    18: Stack([StackValue({global_field.GroupSize()}), StackValue({3})]),
+    24: Stack([StackValue({2}), StackValue({global_field.GroupSize()})]),
+}
+
+ALL_TESTS = [
+    (MULTIPLE_RETSUB, MULTIPLE_RETSUB_EXCEPTED),
+    (SUBROUTINE_BACK_JUMP, SUBROUTINE_BACK_JUMP_EXCEPTED),
+    (BRANCHING, BRANCHING_EXCEPTED),
+    (LOOPS, LOOPS_EXCEPTED),
+]
+
+
+@pytest.mark.parametrize("test", ALL_TESTS)
+def test_group_indices(test: Tuple[str, Dict[int, List[Any]]]) -> None:
+    teal = parse_teal(test[0])
+
+    ci = StackValueAnalysis(teal)
+    ci.run_analysis()
+
+    for ins in teal.instructions:
+        if isinstance(
+            ins,
+            (
+                instructions.Greater,
+                instructions.GreaterE,
+                instructions.Less,
+                instructions.LessE,
+                instructions.Eq,
+                instructions.Neq,
+            ),
+        ):
+            excepted = test[1][ins.line]
+            assert excepted == ci.ins_in[ins]
+
+
+def print_stack(code: str) -> None:
+    teal = parse_teal(code)
+
+    sv = StackValueAnalysis(teal)
+    sv.run_analysis()
+    print(code)
+
+    for ins in teal.instructions:
+        if isinstance(
+            ins,
+            (
+                instructions.Greater,
+                instructions.GreaterE,
+                instructions.Less,
+                instructions.LessE,
+                instructions.Eq,
+                instructions.Neq,
+            ),
+        ):
+            print("###")
+            print(ins)
+            print(f"Before: {sv.ins_in[ins]}")
+            print(f"After: {sv.ins_out[ins]}")
+            print()
+
+
+if __name__ == "__main__":
+    print_stack(MULTIPLE_RETSUB)
+    print_stack(SUBROUTINE_BACK_JUMP)
+    print_stack(BRANCHING)
+    print_stack(LOOPS)


### PR DESCRIPTION
- Add AbstractDataflow, which is a generic dataflow analysis, following an abstract interpretation approach.
- Add CollectInstruction, which is just an example. The analysis collects all the instructions executed
- Add StackValue, which track the values push/pop on the stack, with a focus on int/global field/transaction field

Build on top of [116](https://github.com/crytic/tealer/pull/116)

This is a draft. Todo list:
- Implement missing opcode handlers for important operations
- Add more tests (ex: to stress the merging operations)

Once this is done, the next step will be to increase the abstract value to also track light equation (ex: `Eq(1, GroupSize)`), and propagating them while collecting logical operations (or, and)