### PR TITLE
Add parsing test written in PyTeal

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,13 +19,16 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.10"]
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
 
         # Used by ci_test.sh
     - name: Install dependencies
@@ -33,10 +36,11 @@ jobs:
         python setup.py install
         pip install pytest
         pip install pytest-cov
+        pip install pyteal
 
     - name: Run Parsing tests
       run: |
-        pytest tests/test_parsing.py tests/test_versions.py --cov=tealer/teal/instructions --cov-branch  --cov-fail-under=96
+        pytest tests/test_parsing.py tests/test_versions.py tests/test_parsing_using_pyteal.py --cov=tealer/teal/instructions --cov-branch  --cov-fail-under=96
 
     - name: Run string tests
       run: |

--- a/.github/workflows/pytest310.yml
+++ b/.github/workflows/pytest310.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (python 3.10)
 
 defaults:
   run:

--- a/.github/workflows/pytest310.yml
+++ b/.github/workflows/pytest310.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
 
         # Used by ci_test.sh
     - name: Install dependencies
@@ -33,29 +33,30 @@ jobs:
         python setup.py install
         pip install pytest
         pip install pytest-cov
+        pip install pyteal
 
-    - name: Run Parsing tests
+    - name: Run Parsing tests in 3.10
       run: |
-        pytest tests/test_parsing.py tests/test_versions.py --cov=tealer/teal/instructions --cov-branch  --cov-fail-under=96
-
+        pytest tests/test_parsing.py tests/test_versions.py tests/test_parsing_using_pyteal.py --cov=tealer/teal/instructions --cov-branch  --cov-fail-under=96
+    
     - name: Run string tests
       run: |
         pytest tests/test_string_representation.py
 
-    - name: Run version tests
+    - name: Run version tests in 3.10
       run: |
         pytest tests/test_versions.py
         pytest tests/test_mode_detector.py
 
-    - name: Run cfg recovery tests
+    - name: Run cfg recovery tests in 3.10
       run: |
         pytest tests/test_cfg.py
 
-    - name: Run detectors tests
+    - name: Run detectors tests in 3.10
       run: |
         pytest tests/test_detectors.py
     
-    - name: Run dataflow analysis tests
+    - name: Run dataflow analysis tests in 3.10
       run: |
         pytest tests/transaction_context/test_group_sizes.py
         pytest tests/transaction_context/test_group_indices.py

--- a/.github/workflows/pytest310.yml
+++ b/.github/workflows/pytest310.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
         # Used by ci_test.sh
     - name: Install dependencies

--- a/tests/pyteal_parsing/normal_application.py
+++ b/tests/pyteal_parsing/normal_application.py
@@ -1,0 +1,49 @@
+# pylint: skip-file
+# mypy: ignore-errors
+from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+
+@Subroutine(TealType.uint64)
+def add_upto_n(n: ScratchVar) -> Expr:
+    i = ScratchVar()
+    result = ScratchVar()
+    return Seq(
+        [
+            result.store(Int(0)),
+            For(i.store(Int(0)), i.load() < n.load(), i.store(i.load() + Int(1))).Do(
+                result.store(result.load() + i.load())
+            ),
+            Return(result.load()),
+        ]
+    )
+
+
+def on_creation() -> Expr:
+    x = ScratchVar()
+    return Seq([x.store(Int(10)), Pop(add_upto_n(x)), Return(Int(1))])
+
+
+def approval_program() -> Expr:
+    return Cond(
+        [Txn.application_id() == Int(0), on_creation()],
+        [Txn.on_completion() == OnComplete.DeleteApplication, Reject()],
+        [Txn.on_completion() == OnComplete.UpdateApplication, Reject()],
+        [Txn.on_completion() == OnComplete.CloseOut, Approve()],
+        [Txn.on_completion() == OnComplete.OptIn, Approve()],
+    )
+
+
+def clear_program() -> Expr:
+    return Return(Int(1))
+
+
+normal_application_approval_program = compileTeal(
+    approval_program(),
+    mode=Mode.Application,
+    version=7,
+    optimize=OptimizeOptions(scratch_slots=False),
+)
+
+_clear_program = compileTeal(
+    clear_program(), mode=Mode.Application, version=7, optimize=OptimizeOptions(scratch_slots=False)
+)

--- a/tests/test_parsing_using_pyteal.py
+++ b/tests/test_parsing_using_pyteal.py
@@ -1,0 +1,27 @@
+# type: ignore[unreachable]
+import sys
+import pytest
+
+from tealer.teal.instructions import instructions
+from tealer.teal.parse_teal import parse_teal
+
+if not sys.version_info >= (3, 10):
+    pytest.skip(reason="PyTeal based tests require python >= 3.10", allow_module_level=True)
+
+# Place import statements after the version check
+from tests.pyteal_parsing.normal_application import (  # pylint: disable=wrong-import-position
+    normal_application_approval_program,
+)
+
+TARGETS = [
+    normal_application_approval_program,
+]
+
+
+@pytest.mark.parametrize("target", TARGETS)  # type: ignore
+def test_parsing_using_pyteal(target: str) -> None:
+    teal = parse_teal(target)
+    # print instruction to trigger __str__ on each ins
+    for i in teal.instructions:
+        assert not isinstance(i, instructions.UnsupportedInstruction), f'ins "{i}" is not supported'
+        print(i, i.cost)


### PR DESCRIPTION
Updated the `.github/workflows/pytest.yml` to run the unit tests in both python 3.8 and 3.10. I was unsure if it was enough to run tests in python 3.10 alone.

`mypy` and `pylint` errors needed to be disabled for files containing pyteal code. Mostly because, all of the pyteal constructs that are supported in  python 3.10 are not supported in python 3.8. And `mypy` and `pylint` are ran on python 3.8