### PR TITLE
Fix parsing of itxn_field instruction containing array fields

### DIFF
--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -402,7 +402,7 @@ parser_rules: List[Tuple[str, Callable[[str], Instruction]]] = [
     ("log", lambda _x: instructions.Log()),
     ("itxn_begin", lambda _x: instructions.Itxn_begin()),
     ("itxn_next", lambda _x: instructions.Itxn_next()),
-    ("itxn_field ", lambda x: instructions.Itxn_field(parse_transaction_field(x, False))),
+    ("itxn_field ", lambda x: instructions.Itxn_field(parse_transaction_field(x, True))),
     ("itxn_submit", lambda _x: instructions.Itxn_submit()),
     ("itxn ", lambda x: instructions.Itxn(parse_transaction_field(x, False))),
     ("itxna ", lambda x: instructions.Itxna(parse_transaction_field(x, False))),

--- a/tests/parsing/teal6-instructions.teal
+++ b/tests/parsing/teal6-instructions.teal
@@ -56,3 +56,21 @@ itxnas ApplicationArgs
 gitxnas 1 ApplicationArgs
 gitxnas 2 Accounts
 gitxnas 3 Assets
+
+
+itxn_begin
+byte "app_arg_1"
+itxn_field ApplicationArgs  // ArrayType argument
+byte "app_arg_2"
+itxn_field ApplicationArgs
+byte "app_arg_3"
+itxn_field ApplicationArgs
+txn Sender
+itxn_field Accounts     // ArrayType argument
+int 6
+itxn_field TypeEnum
+int 1
+itxn_field OnCompletion
+int 0
+itxn_field Fee
+itxn_submit


### PR DESCRIPTION
While parsing `itxn_field`, Tealer assumed that array transaction fields would contain the array index as the immediate argument: `itxn_field Applications 1`. However, `itxn_field` does not take the index for the array type fields: `itxn_field Applications` is correct. This PR fixes this issue.