### PR TITLE
Use txn type information for CanCloseAccount and CanCloseAsset detectors

### DIFF
--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -9,7 +9,7 @@ from tealer.detectors.abstract_detector import (
 )
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.detectors.utils import detect_missing_tx_field_validations
-
+from tealer.utils.teal_enums import TealerTransactionType
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -74,7 +74,11 @@ Always check that CloseRemainderTo transaction field is set to a ZeroAddress or 
         def checks_field(block_ctx: "BlockTransactionContext") -> bool:
             # return False if CloseRemainderTo field can have any address.
             # return True if CloseRemainderTo should have some address or zero address
-            return not block_ctx.closeto.any_addr
+            # CloseRemainderTo field can only be set for Payment type transactions.
+            return not (
+                block_ctx.closeto.any_addr
+                and TealerTransactionType.Pay in block_ctx.transaction_types
+            )
 
         paths_without_check: List[List[BasicBlock]] = detect_missing_tx_field_validations(
             self.teal.bbs[0], checks_field

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -9,6 +9,7 @@ from tealer.detectors.abstract_detector import (
 )
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.utils.teal_enums import TealerTransactionType
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -69,7 +70,11 @@ Always check that AssetCloseTo transaction field is set to a ZeroAddress or inte
         def checks_field(block_ctx: "BlockTransactionContext") -> bool:
             # return False if AssetCloseTo field can have any address.
             # return True if AssetCloseTo should have some address or zero address
-            return not block_ctx.assetcloseto.any_addr
+            # AssetCloseTo field can only be set for Asset Transafer type transactions.
+            return not (
+                block_ctx.assetcloseto.any_addr
+                and TealerTransactionType.Axfer in block_ctx.transaction_types
+            )
 
         paths_without_check: List[List[BasicBlock]] = detect_missing_tx_field_validations(
             self.teal.bbs[0], checks_field

--- a/tests/detectors/can_delete.py
+++ b/tests/detectors/can_delete.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import List, Tuple, Type
 
 from tealer.teal.instructions import instructions
 from tealer.teal.instructions import transaction_field
-from tealer.detectors.all_detectors import CanDelete
+from tealer.detectors.abstract_detector import AbstractDetector
+from tealer.detectors.all_detectors import CanDelete, CanCloseAccount, CanCloseAsset
 
 from tests.utils import construct_cfg
 
@@ -390,8 +391,18 @@ CAN_DELETE_GROUP_INDEX_2_VULNERABLE_PATHS: List[List[int]] = [
     [0, 2, 7, 8, 9],
 ]
 
-new_can_delete_tests = [
+new_can_delete_tests: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     (CAN_DELETE_GROUP_INDEX_0, CanDelete, CAN_DELETE_GROUP_INDEX_0_VULNERABLE_PATHS),
     (CAN_DELETE_GROUP_INDEX_1, CanDelete, CAN_DELETE_GROUP_INDEX_1_VULNERABLE_PATHS),
     (CAN_DELETE_GROUP_INDEX_2, CanDelete, CAN_DELETE_GROUP_INDEX_2_VULNERABLE_PATHS),
+    (CAN_DELETE, CanCloseAccount, []),
+    (CAN_DELETE_LOOP, CanCloseAccount, []),
+    (CAN_DELETE_GROUP_INDEX_0, CanCloseAccount, []),
+    (CAN_DELETE_GROUP_INDEX_1, CanCloseAccount, []),
+    (CAN_DELETE_GROUP_INDEX_2, CanCloseAccount, []),
+    (CAN_DELETE, CanCloseAsset, []),
+    (CAN_DELETE_LOOP, CanCloseAsset, []),
+    (CAN_DELETE_GROUP_INDEX_0, CanCloseAsset, []),
+    (CAN_DELETE_GROUP_INDEX_1, CanCloseAsset, []),
+    (CAN_DELETE_GROUP_INDEX_2, CanCloseAsset, []),
 ]

--- a/tests/detectors/can_update.py
+++ b/tests/detectors/can_update.py
@@ -1,8 +1,9 @@
-from typing import List
+from typing import List, Tuple, Type
 
 from tealer.teal.instructions import instructions
 from tealer.teal.instructions import transaction_field
-from tealer.detectors.all_detectors import CanUpdate
+from tealer.detectors.abstract_detector import AbstractDetector
+from tealer.detectors.all_detectors import CanUpdate, CanCloseAccount, CanCloseAsset
 
 from tests.utils import construct_cfg
 
@@ -433,9 +434,25 @@ err
 
 CAN_UPDATE_GROUP_INDEX_INTC_0_VULNERABLE_PATHS: List[List[int]] = []
 
-new_can_update_tests = [
+new_can_update_tests: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     (CAN_UPDATE_GROUP_INDEX_0, CanUpdate, CAN_UPDATE_GROUP_INDEX_0_VULNERABLE_PATHS),
     (CAN_UPDATE_GROUP_INDEX_1, CanUpdate, CAN_UPDATE_GROUP_INDEX_1_VULNERABLE_PATHS),
     (CAN_UPDATE_GROUP_INDEX_2, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS),
     (CAN_UPDATE_GROUP_INDEX_INTC_0, CanUpdate, CAN_UPDATE_GROUP_INDEX_INTC_0_VULNERABLE_PATHS),
+    (
+        CAN_UPDATE,
+        CanCloseAccount,
+        [],
+    ),  # Applications are not vulnerable to CanCloseAccount and CanCloseAsset
+    (CAN_UPDATE_LOOP, CanCloseAccount, []),
+    (CAN_UPDATE_GROUP_INDEX_0, CanCloseAccount, []),
+    (CAN_UPDATE_GROUP_INDEX_1, CanCloseAccount, []),
+    (CAN_UPDATE_GROUP_INDEX_2, CanCloseAccount, []),
+    (CAN_UPDATE_GROUP_INDEX_INTC_0, CanCloseAccount, []),
+    (CAN_UPDATE, CanCloseAsset, []),
+    (CAN_UPDATE_LOOP, CanCloseAsset, []),
+    (CAN_UPDATE_GROUP_INDEX_0, CanCloseAsset, []),
+    (CAN_UPDATE_GROUP_INDEX_1, CanCloseAsset, []),
+    (CAN_UPDATE_GROUP_INDEX_2, CanCloseAsset, []),
+    (CAN_UPDATE_GROUP_INDEX_INTC_0, CanCloseAsset, []),
 ]

--- a/tests/detectors/pyteal_can_close.py
+++ b/tests/detectors/pyteal_can_close.py
@@ -1,0 +1,165 @@
+# pylint: skip-file
+# mypy: ignore-errors
+from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+from pyteal import *
+from typing import Literal
+
+from tealer.detectors.all_detectors import CanUpdate, CanDelete, CanCloseAsset, CanCloseAccount
+
+router = Router(
+    name="Example",
+    bare_calls=BareCallActions(),
+)
+
+
+@router.method(no_op=CallConfig.ALL)
+def echo(input: abi.Uint64, *, output: abi.Uint64) -> Expr:
+    """
+    Method config validations Teal pattern:
+        txn OnCompletion
+        int NoOp
+        ==
+        txn ApplicationID
+        int 0
+        !=
+        &&
+        assert            // Assert(NoOp, CALL)
+    """
+    return output.set(input.get())
+
+
+pragma(compiler_version="0.20.1")
+application_approval_program, _, _ = router.compile_program(
+    version=7,
+    assemble_constants=True,  # use intcblock, bytecblock
+    # optimize=OptimizeOptions(scratch_slots=True),
+)
+
+
+@Subroutine(TealType.none)
+def process_txn() -> Expr:
+    return Pop(Bytes("ExecuteTransaction"))
+
+
+def axfer_approval_program():
+    @Subroutine(TealType.none)
+    def validate_txn() -> Expr:
+        return Seq(
+            [
+                Assert(Global.group_size() == Int(1)),
+                Assert(Txn.fee() <= Global.min_txn_fee()),
+                Assert(Txn.type_enum() == TxnType.AssetTransfer),
+                Assert(Txn.asset_close_to() == Global.zero_address()),
+            ]
+        )
+
+    return Seq(
+        [
+            validate_txn(),
+            process_txn(),
+            Return(Int(1)),
+        ]
+    )
+
+
+axfer_approval_program_teal = compileTeal(axfer_approval_program(), mode=Mode.Signature, version=7)
+
+
+def payment_approval_program():
+    @Subroutine(TealType.none)
+    def validate_txn() -> Expr:
+        return Seq(
+            [
+                Assert(Global.group_size() == Int(1)),
+                Assert(Txn.fee() <= Global.min_txn_fee()),
+                Assert(Txn.type_enum() == TxnType.Payment),
+                Assert(Txn.close_remainder_to() == Global.zero_address()),
+            ]
+        )
+
+    return Seq(
+        [
+            validate_txn(),
+            process_txn(),
+            Return(Int(1)),
+        ]
+    )
+
+
+payment_approval_program_teal = compileTeal(
+    payment_approval_program(), mode=Mode.Signature, version=7
+)
+
+
+def axfer_payment_approval_program():
+    return (
+        If(Arg(Int(0)) == Bytes("Payment In Algo"))
+        .Then(
+            payment_approval_program(),
+        )
+        .Else(
+            axfer_approval_program(),
+        )
+    )
+
+
+axfer_payment_approval_program_teal = compileTeal(
+    axfer_payment_approval_program(), mode=Mode.Signature, version=7
+)
+
+
+def different_group_sizes_approval_program():
+    group_size_3 = Seq(
+        [
+            Assert(Global.group_size() == Int(3)),
+            Assert(Gtxn[0].fee() <= Global.min_txn_fee()),
+            Assert(Gtxn[0].type_enum() == TxnType.Payment),
+            Assert(Gtxn[0].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[1].fee() <= Global.min_txn_fee()),
+            Assert(Gtxn[1].type_enum() == TxnType.KeyRegistration),
+            Assert(Gtxn[2].fee() <= Global.min_txn_fee()),
+            Assert(Gtxn[2].type_enum() == TxnType.AssetConfig),
+            Assert(Gtxn[2].close_remainder_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+    group_size_2 = Seq(
+        [
+            Assert(Global.group_size() == Int(2)),
+            Assert(Gtxn[0].fee() <= Global.min_txn_fee()),
+            Assert(Gtxn[0].type_enum() == TxnType.AssetTransfer),
+            Assert(Gtxn[0].asset_close_to() == Txn.sender()),
+            Assert(Gtxn[1].fee() <= Global.min_txn_fee()),
+            Assert(Gtxn[1].type_enum() == TxnType.AssetFreeze),
+            Return(Int(1)),
+        ]
+    )
+
+    return (
+        If(Arg(Int(0)) == Bytes("First Operation"))
+        .Then(
+            group_size_2,
+        )
+        .Else(group_size_3)
+    )
+
+
+different_group_sizes_approval_program_teal = compileTeal(
+    different_group_sizes_approval_program(), mode=Mode.Signature, version=7
+)
+
+
+txn_type_based_tests = [
+    (application_approval_program, CanCloseAccount, []),
+    (application_approval_program, CanCloseAsset, []),
+    (axfer_approval_program_teal, CanCloseAccount, []),
+    (axfer_approval_program_teal, CanCloseAsset, []),
+    (payment_approval_program_teal, CanCloseAccount, []),
+    (payment_approval_program_teal, CanCloseAsset, []),
+    (axfer_payment_approval_program_teal, CanCloseAccount, []),
+    (axfer_payment_approval_program_teal, CanCloseAsset, []),
+    (different_group_sizes_approval_program_teal, CanCloseAccount, []),
+    (different_group_sizes_approval_program_teal, CanCloseAsset, []),
+]

--- a/tests/test_detectors_using_pyteal.py
+++ b/tests/test_detectors_using_pyteal.py
@@ -14,9 +14,14 @@ if not sys.version_info >= (3, 10):
 from tests.detectors.router_with_assembled_constants import (  # pylint: disable=wrong-import-position
     router_with_assembled_constants,
 )
+from tests.detectors.pyteal_can_close import (  # pylint: disable=wrong-import-position
+    txn_type_based_tests,
+)
+
 
 TESTS: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     *router_with_assembled_constants,
+    *txn_type_based_tests,
 ]
 
 


### PR DESCRIPTION
CanCloseAccount detector finds execution paths that allow the txn CloseRemainderTo field to have any address. CloseRemainderTo field can only be set for Payment type transactions. 
If the contract asserts that txn is not a Payment type txn, it is not vulnerable to CanCloseAccount. 

And The CanCloseAsset detector which checks if the AssetCloseTo field can have any address. The AssetCloseTo field can only be set for AssetTransfer type transactions.

This PR supports using the transaction type information while enumerating the vulnerable execution paths.
