### PR TITLE
Update txn field analysis to use stack emulation

### DIFF
--- a/tealer/analyses/dataflow/addr_fields.py
+++ b/tealer/analyses/dataflow/addr_fields.py
@@ -134,7 +134,7 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
             return asserted_addresses, self._universal_set()
         return self._universal_set(), asserted_addresses
 
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
         return self._get_asserted_txn_gtxn(key, ins_stack_value)
 
     @staticmethod

--- a/tealer/analyses/dataflow/fee_field.py
+++ b/tealer/analyses/dataflow/fee_field.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, List, Tuple, Union, Optional
 
 from tealer.analyses.dataflow.generic import DataflowTransactionContext
 from tealer.teal.instructions.instructions import (
@@ -10,13 +10,21 @@ from tealer.teal.instructions.instructions import (
     LessE,
 )
 from tealer.utils.analyses import is_int_push_ins
-from tealer.utils.algorand_constants import MAX_GROUP_SIZE, MAX_UINT64
+from tealer.utils.algorand_constants import MAX_GROUP_SIZE, MAX_UINT64, MAX_TRANSACTION_COST
 from tealer.analyses.utils.stack_emulator import KnownStackValue, UnknownStackValue
 
 if TYPE_CHECKING:
     from tealer.teal.instructions.instructions import Instruction
 
 FEE_KEY = "Fee"
+
+# It's not always possible to know the integer value used to compare Fee.
+# All the unknown values are represented using "UnknownBoundedInt".
+# Tealer does not report paths if Fee is less than MAX_TRANSACTION_COST.
+# UnknownBoundedInt is assumed to be a value between 0 and MAX_TRANSACTION_COST
+# Tealer does not report paths if Fee is checked against some unknown value.
+
+SOME_INT = "UnknownBoundedInt"  # Represent a value that is between 0 < x <= MAX_TRANSACTION_COST
 
 
 class FeeField(DataflowTransactionContext):
@@ -31,16 +39,52 @@ class FeeField(DataflowTransactionContext):
     def _null_set(self, key: str) -> int:
         return 0
 
-    def _union(self, key: str, a: int, b: int) -> int:
+    def _union(self, key: str, a: Union[int, str], b: Union[int, str]) -> Union[int, str]:
+        if isinstance(a, str) and isinstance(b, str):
+            # Both are unknown values between 0 < x <= MAX_TRANSACTION_COST
+            return a
+        if isinstance(a, str):
+            # a is a unknown bounded value and b is int
+            # a: 0 < x < MAX_TRANSACTION_COST
+            assert isinstance(b, int)  # for mypy
+            if b > MAX_TRANSACTION_COST:
+                return b  # a is less than MAX_TRANSACTION_COST
+            return a
+        if isinstance(b, str):
+            # b is a unknown bounded value and a is int
+            # b: 0 < x < MAX_TRANSACTION_COST
+            assert isinstance(a, int)
+            if a > MAX_TRANSACTION_COST:
+                return a  # b is less than MAX_TRANSACTION_COST
+            return b
+        # both are ints
         return max(a, b)
 
-    def _intersection(self, key: str, a: int, b: int) -> int:
+    def _intersection(self, key: str, a: Union[int, str], b: Union[int, str]) -> Union[int, str]:
+        if isinstance(a, str) and isinstance(b, str):
+            # Both are unknown values between 0 < x < MAX_TRANSACTION_COST
+            return a
+        if isinstance(a, str):
+            # a is a unknown bounded value and b is int
+            # a: 0 < x < MAX_TRANSACTION_COST
+            assert isinstance(b, int)
+            if b > MAX_TRANSACTION_COST:
+                return a  # a is less than MAX_TRANSACTION_COST
+            return b
+        if isinstance(b, str):
+            # b is a unknown bounded value and a is int
+            # b: 0 < x < MAX_TRANSACTION_COST
+            assert isinstance(a, int)
+            if a > MAX_TRANSACTION_COST:
+                return b  # b is less than MAX_TRANSACTION_COST
+            return a
+        # both are ints
         return min(a, b)
 
     @staticmethod
     def _get_asserted_max_value(
-        comparison_ins: "Instruction", compared_int: int, max_possible_value: int
-    ) -> Tuple[int, int]:
+        comparison_ins: "Instruction", compared_int: Union[int, str], max_possible_value: int
+    ) -> Tuple[Union[int, str], Union[int, str]]:
         """Return maximum possible value that will make the comparison True and maximum
         possible value that will make the comparison False. Both values are upper bounded
         by arg "max_possible_value".
@@ -62,6 +106,8 @@ class FeeField(DataflowTransactionContext):
             return U, compared_int
         if isinstance(comparison_ins, Less):
             # x < i => (i - 1), U
+            if isinstance(compared_int, str):
+                return compared_int, U
             return max(0, compared_int - 1), U
         if isinstance(comparison_ins, LessE):
             # x <= i => i, U
@@ -71,32 +117,56 @@ class FeeField(DataflowTransactionContext):
             return U, compared_int
         if isinstance(comparison_ins, GreaterE):
             # x >= i => U, (i - 1)
+            if isinstance(compared_int, str):
+                return U, compared_int
             return U, max(0, compared_int - 1)
         return U, U
 
-    def _get_asserted_fee(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[int, int]:
+    def _get_asserted_fee(  # pylint: disable=too-many-branches
+        self, key: str, ins_stack_value: KnownStackValue
+    ) -> Tuple[Union[int, str], Union[int, str]]:
         U = self._universal_set(key)  # max value for the field
 
         if isinstance(ins_stack_value.instruction, (Eq, Neq, Less, LessE, Greater, GreaterE)):
             arg1 = ins_stack_value.args[0]
             arg2 = ins_stack_value.args[1]
-            if isinstance(arg1, UnknownStackValue) or isinstance(arg2, UnknownStackValue):
-                # if one of the args is unknown
+            compared_value: Optional[Union[int, str]] = None
+
+            if isinstance(arg1, UnknownStackValue) and isinstance(arg2, UnknownStackValue):
+                # Both the args are unknown
                 return U, U
-            ins1 = arg1.instruction
-            ins2 = arg2.instruction
-            compared_value = None
 
-            if self._is_txn_or_gtxn(key, ins1):
-                is_int, value = is_int_push_ins(ins2)
+            if isinstance(arg1, UnknownStackValue):
+                if not isinstance(arg2, UnknownStackValue) and not self._is_txn_or_gtxn(
+                    key, arg2.instruction
+                ):
+                    # arg1 is unknown and arg2 is not related to "key"
+                    return U, U
+                # arg2 is related to key and arg1 is some unknown value
+                compared_value = SOME_INT
+            elif isinstance(arg2, UnknownStackValue):
+                if not isinstance(arg1, UnknownStackValue) and not self._is_txn_or_gtxn(
+                    key, arg1.instruction
+                ):
+                    # arg2 is unknown and arg1 is not related to "key"
+                    return self._universal_set(key), self._universal_set(key)
+                # arg1 is related to "key" and arg2 is some unknown int value
+                compared_value = SOME_INT
+            elif self._is_txn_or_gtxn(key, arg1.instruction):
+                is_int, value = is_int_push_ins(arg2.instruction)
                 if is_int:
                     compared_value = value
-            elif self._is_txn_or_gtxn(key, ins2):
-                is_int, value = is_int_push_ins(ins1)
+                else:
+                    compared_value = SOME_INT
+
+            elif self._is_txn_or_gtxn(key, arg2.instruction):
+                is_int, value = is_int_push_ins(arg1.instruction)
                 if is_int:
                     compared_value = value
+                else:
+                    compared_value = SOME_INT
 
-            if compared_value is None or not isinstance(compared_value, int):
+            if compared_value is None:
                 # compared_value is not int.
                 return U, U
 
@@ -104,14 +174,22 @@ class FeeField(DataflowTransactionContext):
             return self._get_asserted_max_value(ins, compared_value, U)
         return U, U
 
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[int, int]:
+    def _get_asserted_single(
+        self, key: str, ins_stack_value: KnownStackValue
+    ) -> Tuple[Union[int, str], Union[int, str]]:
         res = self._get_asserted_fee(key, ins_stack_value)
         return res
 
     def _store_results(self) -> None:
         for b in self._teal.bbs:
-            b.transaction_context.max_fee = self._block_contexts[FEE_KEY][b]
+            max_fee = self._block_contexts[FEE_KEY][b]
+            if isinstance(max_fee, str):
+                b.transaction_context.max_fee_unknown = True
+            else:
+                b.transaction_context.max_fee = max_fee
             for idx in range(MAX_GROUP_SIZE):
-                b.transaction_context.gtxn_context(idx).max_fee = self._block_contexts[
-                    self.gtx_key(idx, FEE_KEY)
-                ][b]
+                max_fee = self._block_contexts[self.gtx_key(idx, FEE_KEY)][b]
+                if isinstance(max_fee, str):
+                    b.transaction_context.gtxn_context(idx).max_fee_unknown = True
+                else:
+                    b.transaction_context.gtxn_context(idx).max_fee = max_fee

--- a/tealer/analyses/dataflow/generic.py
+++ b/tealer/analyses/dataflow/generic.py
@@ -139,7 +139,90 @@ This is because, when traversing the CFG without differentiating subroutine bloc
 
 However, At runtime, execution will reach B3 if and only if it reaches B2, same for B5 and B3. Using this reasoning while
 combining information from predecessors and successors will give more accurate results.
+
+---------------------------------------------------------------------------
+
+`DataflowTransactionContext._get_asserted_single(key, ins_stack_value)` returns a Tuple of true_values and false_values.
+    true_values: Given that the result of `ins_stack_value` is NON-ZERO, what are the possible
+                values for the key.
+    false_values: Given that the result of `ins_stack_value` is ZERO, what are the possible values
+                for the key.
+
+`_get_asserted_single` uses pattern matching to identify comparisons on interested fields. It only works when the
+`ins_stack_value` directly represents the value of the comparison.
+e.g
+    - Eq(txn RekeyTo, global Zeroaddress)
+    - Neq(txn OnCompletion, int UpdateApplication)
+    - ...
+
+But when the result depends on multiple equations it is NOT possible to use the same kind of pattern matching and derive
+possible values.
+e.g
+ins_stack_value =   Or(
+                        And(
+                            Eq(txn RekeyTo, global ZeroAddress),
+                            Eq(txn CloseRemainderTo, global ZeroAddress),
+                        ),
+                        And(
+                            Eq(txn Fee, global MinTxnFee),
+                            Eq(txn AssetCloseTo, global ZeroAddress),
+                        ),
+                    )
+
+
+We can combine information from multiple equations when they are connected using And, Or, !.
+e.g
+    txn RekeyTo
+    global ZeroAddress
+    ==                      // equation <1>
+    txn CloseRemainderTo
+    global ZeroAddress
+    ==                      // <2>
+    &&
+    txn Fee
+    global MinTxnFee
+    <=                      // <3>
+    &&
+
+=> And(
+    And(
+        Eq(txn RekeyTo, global ZeroAddress),
+        Eq(txn CloseRemainderTo, global ZeroAddress),
+    ),
+    LessE(txn Fee, global MinTxnFee),
+)
+
+=> And(And(<1>, <2>), <3>)
+=> ins_stack_value = And(<1>, <2>, <3>)           // flattend
+
+if it is given that ins_stack_value is False, Then atleast ONE of the equations <1>, <2> or <3> is False.
+if it is given that ins_stack_value is True, Then ALL of the equations <1>, <2> and <3> are True.
+
+This applies for any number of equations: And(<1>, <2>, <3>, <4>, ....)
+
+-> if the ins_stack_value is of form And(<1>, <2>, <3>, <4>, ....) and is `True`, Then we can combine possible values
+from multiple equations using set `Intersection`.
+-> if the ins_stack_value is of form And(<1>, <2>, <3>, <4>, ....) and is `False`, Then we can combine possible values
+from multiple equations using set `Union`.
+
+if any of equation in And(<1>, ...) is UnknownStackValue then `false_values` for And(...) is universal_set U.
+    -> The result of And() could be false because the UnknownStackValue is False. None of the known values have
+        to be False.
+    -> true_values are not affected by having an UnknownStackValue. All the known values have to be True irrespective
+        of unknown values for the result to be True.
+
+Similar reasoning can be done for Or(<1>, <2>, <3>, <4>, ....)
+
+if ins_stack_value is True, Then atleast ONE of the equations <1>, <2>, <3>, ... is True.   (Union)
+if ins_stack_value is False, Then ALL of the equations <1>, <2>, <3>, ... are False.        (Intersection)
+
+if any of equation in Or(<1>, ...) is UnknownStackValue then `true_values` for Or(...) is universal_set U.
+    -> The result of Or() could be True because the UnknownStackValue is True. None of the known values have
+        to be True.
+    -> false_values are not affected by having an UnknownStackValue. All the known values have to be False irrespective
+        of unknown values for the result to be False
 """
+
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Set
@@ -152,11 +235,19 @@ from tealer.teal.instructions.instructions import (
     Err,
     Txn,
     Gtxn,
+    And,
+    Or,
+    Not,
 )
 from tealer.teal.instructions.parse_transaction_field import TX_FIELD_TXT_TO_OBJECT
 from tealer.utils.analyses import is_int_push_ins
 from tealer.utils.algorand_constants import MAX_GROUP_SIZE
-from tealer.analyses.utils.stack_emulator import KnownStackValue, UnknownStackValue, emulate_stack
+from tealer.analyses.utils.stack_emulator import (
+    KnownStackValue,
+    UnknownStackValue,
+    emulate_stack,
+    compute_equations,
+)
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal
@@ -245,20 +336,85 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
         """return intersection of a and b, where a, b represent values for the given key"""
 
     @abstractmethod
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Any, Any]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Any, Any]:
         """For the given key and ins_stack, return true_values and false_values
 
-        true_values for a key are considered to be values which result in non-zero value on
-        top of the stack.
-        false_values for a key are considered to be values which result in zero value on top
-        of the stack.
+        true_values: Given that the result of `ins_stack_value` is NON-ZERO, what are the possible
+            values for the key.
+        false_values: Given that the result of `ins_stack_value` is ZERO, what are the possible values
+            for the key.
         """
 
     @abstractmethod
     def _store_results(self) -> None:
         """Store the collected information in the context object of each block"""
 
-    def _block_level_constraints(self, analysis_keys: List[str], block: "BasicBlock") -> None:
+    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Any, Any]:
+        """For the given key and ins_stack_value, return true_values and false_values
+
+        true_values: Given that the result of `ins_stack_value` is NON-ZERO, what are the possible
+            values for the key.
+        false_values: Given that the result of `ins_stack_value` is ZERO, what are the possible values
+            for the key.
+        """
+        if not isinstance(ins_stack_value.instruction, (And, Or, Not)):
+            # and not isinstance(ins_stack_value.instruction, Or):
+            # single equation
+            t, f = self._get_asserted_single(key, ins_stack_value)
+            return t, f
+        if isinstance(ins_stack_value.instruction, Not):
+            arg = ins_stack_value.args[0]
+            if isinstance(arg, UnknownStackValue):
+                # unknown value
+                return self._universal_set(key), self._universal_set(key)
+            true_values, false_values = self._get_asserted(key, arg)
+            # swap the values
+            final_true_values, final_false_values = false_values, true_values
+            return final_true_values, final_false_values
+        if isinstance(ins_stack_value.instruction, And):
+            # x = And(<1>, <2>, <3>, ...),
+            #   if x is True then <1>, <2>, ... are all True, Intersection
+            #   if x is False then one of <1>, <2>, ... is False, Union
+            individual_equations, has_unknown_value = compute_equations(ins_stack_value, And)
+            final_true_values = self._universal_set(key)
+            final_false_values = self._null_set(key)
+            for equation in individual_equations:
+                # combine values recursively.
+                # And(<Eq()>, <Or()>, <Or()>, ...):
+                #      values Or() cannot be calculated using _get_asserted_single
+                true_values, false_values = self._get_asserted(key, equation)
+                final_true_values = self._intersection(key, final_true_values, true_values)
+                final_false_values = self._union(key, final_false_values, false_values)
+            if has_unknown_value:
+                # has_unknown_value is True if result of And depends on an unknown value.
+                # if And is False, the unknown value could be false and that unknown value
+                # might or might not depend on the key.
+                # note: Having a unknown value does not affect true_values, known values have
+                # to be True irrespective of unknown value for the result to be True
+                final_false_values = self._universal_set(key)
+            return final_true_values, final_false_values
+        # x = Or(<1>, <2>, <3>, ....),
+        #   if x is False then <1>, <2>, ... are all False,     Intersection
+        #   if x is True then one of <1>, <2>, ... is True,     Union
+        individual_equations, has_unknown_value = compute_equations(ins_stack_value, Or)
+        final_false_values = self._universal_set(key)
+        final_true_values = self._null_set(key)
+        for equation in individual_equations:
+            true_values, false_values = self._get_asserted(key, equation)
+            final_false_values = self._intersection(key, final_false_values, false_values)
+            final_true_values = self._union(key, final_true_values, true_values)
+        if has_unknown_value:
+            # has_unknown_value is True if result of Or depends on an unknown value.
+            # if Or is True, the unknown value could be True and that unknown value
+            # might or might not depend on the key
+            # note: Having a unknown value does not affect false_values, known values have
+            # to be False irrespective of unknown value for the result to be False
+            final_true_values = self._universal_set(key)
+        return final_true_values, final_false_values
+
+    def _block_level_constraints(  # pylint: disable=too-many-branches
+        self, analysis_keys: List[str], block: "BasicBlock"
+    ) -> None:
         """Calculate and store constraints on keys applied within the block.
 
         By default, no constraints are considered i.e values are assumed to be universal_set
@@ -273,7 +429,6 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
                 self._block_contexts[key] = {}
             self._block_contexts[key][block] = self._universal_set(key)
 
-        stack: List["Instruction"] = []
         for ins in block.instructions:
             if isinstance(ins, Assert):
                 assert_ins_stack_value = self._get_stack_value(ins)
@@ -293,16 +448,23 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
                 return_ins_arg = return_ins_value.args[0]
                 if isinstance(return_ins_arg, UnknownStackValue):
                     continue
+                # if int 0; return; set possible values to null set.
                 is_int, value = is_int_push_ins(return_ins_arg.instruction)
                 if is_int and value == 0:
                     for key in analysis_keys:
                         self._block_contexts[key][block] = self._null_set(key)
+                    continue
+                # if And(<1>, <2>, ..); return; i.e return value depends on the result of a comparison
+                for key in analysis_keys:
+                    true_values, _ = self._get_asserted(key, return_ins_arg)
+                    present_values = self._block_contexts[key][block]
+                    self._block_contexts[key][block] = self._intersection(
+                        key, present_values, true_values
+                    )
             elif isinstance(ins, Err):
                 # if err, set possible values to NullSet()
                 for key in analysis_keys:
                     self._block_contexts[key][block] = self._null_set(key)
-
-            stack.append(ins)
 
     def _path_level_constraints(  # pylint: disable=too-many-branches
         self, analysis_keys: List[str], block: "BasicBlock"

--- a/tealer/analyses/dataflow/int_fields.py
+++ b/tealer/analyses/dataflow/int_fields.py
@@ -183,7 +183,7 @@ class GroupIndices(DataflowTransactionContext):  # pylint: disable=too-few-publi
             return set(asserted_values), set(U) - set(asserted_values)
         return set(U), set(U)
 
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
         if key == self.GROUP_SIZE_KEY:
             return self._get_asserted_groupsizes(ins_stack_value)
         return self._get_asserted_groupindices(ins_stack_value)

--- a/tealer/analyses/dataflow/txn_types.py
+++ b/tealer/analyses/dataflow/txn_types.py
@@ -21,6 +21,7 @@ from tealer.utils.teal_enums import (
 )
 from tealer.utils.teal_enums import oncompletion_to_tealer_type, transaction_type_to_tealer_type
 from tealer.utils.analyses import is_int_push_ins
+from tealer.analyses.utils.stack_emulator import KnownStackValue, UnknownStackValue
 
 if TYPE_CHECKING:
     from tealer.teal.instructions.instructions import Instruction
@@ -66,10 +67,10 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
             return isinstance(ins, Gtxn) and ins.idx == idx and isinstance(ins.field, field)
         return isinstance(ins, Txn) and isinstance(ins.field, field)
 
-    def _get_asserted_transaction_types(  # pylint: disable=too-many-branches
-        self, key: str, ins_stack: List["Instruction"]
+    def _get_asserted_transaction_types(  # pylint: disable=too-many-branches, too-many-locals
+        self, key: str, ins_stack_value: KnownStackValue
     ) -> Tuple[Set["TealerTransactionType"], Set["TealerTransactionType"]]:
-        """return set of transaction type that make the comparison true and a set that make false.
+        """return set of transaction type that make the comparison true and a set that makes it false.
 
         considered instruction patterns:
         [g]txn [idx] ApplicationID
@@ -95,32 +96,36 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
         bz/bnz
         """
         U = set(self.UNIVERSAL_SETS[self.TRANSACTION_TYPE_KEY])
-        if len(ins_stack) == 0:
-            return set(U), set(U)
 
-        ins1 = ins_stack[-1]
+        ins1 = ins_stack_value.instruction
         if self._is_ins_tx_field(key, ins1, ApplicationID):
             # txn ApplicationID pushes 0 if this Application creation transaction elses pushes nonzero
             return set(APPLICATION_TRANSACTION_TYPES) - set(
                 [TealerTransactionType.ApplCreation]
             ), set([TealerTransactionType.ApplCreation])
 
-        if len(ins_stack) > 1:
-            ins2 = ins_stack[-2]
-            if isinstance(ins1, Not) and self._is_ins_tx_field(key, ins2, ApplicationID):
+        if isinstance(ins1, Not):
+            not_arg = ins_stack_value.args[0]
+            if isinstance(not_arg, UnknownStackValue):
+                return set(U), set(U)
+            ins2 = not_arg.instruction
+            if self._is_ins_tx_field(key, ins2, ApplicationID):
                 # txn ApplicationID
                 # !
                 # return
                 return set([TealerTransactionType.ApplCreation]), set(
                     APPLICATION_TRANSACTION_TYPES
                 ) - set([TealerTransactionType.ApplCreation])
-
-        if len(ins_stack) < 3:
             return set(U), set(U)
 
         if isinstance(ins1, (Eq, Neq)):
-            ins2 = ins_stack[-2]
-            ins3 = ins_stack[-3]
+            arg1 = ins_stack_value.args[0]
+            arg2 = ins_stack_value.args[1]
+            if isinstance(arg1, UnknownStackValue) or isinstance(arg2, UnknownStackValue):
+                # if one of the args is unknown
+                return set(U), set(U)
+            ins2 = arg1.instruction
+            ins3 = arg2.instruction
 
             is_int_ins2, value_2 = is_int_push_ins(ins2)
             is_int_ins3, value_3 = is_int_push_ins(ins3)
@@ -168,8 +173,8 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
 
         return set(U), set(U)
 
-    def _get_asserted(self, key: str, ins_stack: List["Instruction"]) -> Tuple[Set, Set]:
-        return self._get_asserted_transaction_types(key, ins_stack)
+    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
+        return self._get_asserted_transaction_types(key, ins_stack_value)
 
     def _store_results(self) -> None:
         transaction_type_context = self._block_contexts[self.TRANSACTION_TYPE_KEY]

--- a/tealer/analyses/dataflow/txn_types.py
+++ b/tealer/analyses/dataflow/txn_types.py
@@ -173,7 +173,7 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
 
         return set(U), set(U)
 
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
         return self._get_asserted_transaction_types(key, ins_stack_value)
 
     def _store_results(self) -> None:

--- a/tealer/analyses/utils/stack_emulator.py
+++ b/tealer/analyses/utils/stack_emulator.py
@@ -142,6 +142,8 @@ Unclear/recent(v8) instructions:
 """
 
 from typing import List, Union, Dict
+from functools import lru_cache
+
 
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import (
@@ -275,6 +277,7 @@ class Stack:
         return str(self)
 
 
+@lru_cache(maxsize=None)
 def emulate_stack(bb: BasicBlock) -> Dict[Instruction, KnownStackValue]:
     r"""Emulates instructions in the basic block and return values produced by each instruction.
 

--- a/tealer/analyses/utils/stack_emulator.py
+++ b/tealer/analyses/utils/stack_emulator.py
@@ -141,7 +141,7 @@ Unclear/recent(v8) instructions:
     proto, frame_dig, frame_bury,
 """
 
-from typing import List, Union, Dict
+from typing import List, Union, Dict, Type, Tuple
 from functools import lru_cache
 
 
@@ -225,7 +225,8 @@ class KnownStackValue:
         # args = ", ".join(str(i) for i in self._args)
         # return f"{self._ins.__class__.__name__}(<{args}>)"
         args = "[" + ", ".join(str(i) for i in self.args) + "]"
-        return f"KnownStackValue(ins = {str(self._ins.__class__.__name__)}, args = {args})"
+        # return f"KnownStackValue(ins = {str(self._ins.__class__.__name__)}, args = {args})"
+        return f"KnownStackValue(ins = {repr(self._ins)}, args = {args})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -341,3 +342,110 @@ def emulate_stack(bb: BasicBlock) -> Dict[Instruction, KnownStackValue]:
             stack.push(KnownStackValue(ins, popped_values, i))
         ins_stack_value[ins] = KnownStackValue(ins, popped_values)
     return ins_stack_value
+
+
+def _flatten_ast(root: StackValue, node_ins: Type[Instruction]) -> List[StackValue]:
+    r"""Return all the leaf values given the root of the instruction AST.
+
+    node_ins instruction is one of `And`, `Or`.
+    `And` and `Or` consume two values. These two values are the children of the node.
+
+    Inner nodes are values whose `instruction` is a instance of `node_ins`.
+    Leaf values are values whose `instruction` is not `node_ins`.
+
+      &&
+    /    \
+   ==     &&
+        /    \
+       &&     ||
+      /  \   /  \
+     ==  >  !   !=
+    /\   /\
+
+    All the nodes in the tree are represented by `StackValue`. A StackValue can be unknown or known.
+    unknown stack values are considered to be leaf values and are stored.
+    A known stack value contains the instruction and arguments consumed by that instruction. These
+    arguments are also stack values and are treated as children.
+
+    In above example, if `node_ins` is `And` then values with instruction, `==, >, ||`, are all treated
+    as leaf blocks and are NOT traversed further.
+
+    int 1
+    int 2
+    ==
+    addr "..."
+    txn RekeyTo
+    !=
+    &&
+    byte "X"
+    byte "Y"
+    ==
+    &&
+
+    Tree:
+                        And
+                      /     \
+                    And       Eq
+                  /    \    /     \
+                Eq     Neq  Byte   Byte
+              /   \   /    \
+            Int  Int Addr  Txn RekeyTo
+
+    node_ins = And
+
+    ^^Only And instruction values are considered as nodes. remaining values are treated as leaves
+    and are not traversed.
+
+    After traversing, this functions returns the leaf values:
+        [
+            Eq(Int(<>), Int(<>)),
+            Neq(Addr(<>), Txn(<>)),
+            Eq(Byte(<>), Byte(<>))
+        ]
+
+    This function essentially flattens the given tree:
+        And(And(<1>, <2>), And(And(<3>, <4>), And(<5>, <6>)))
+        node_ins = And
+        => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+
+        Or(Or(Or(<1>, <2>), Or(<3>, <4>)), Or(<5>, <6>))
+        node_ins = Or
+        => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+    """
+    if isinstance(root, UnknownStackValue):
+        return [root]
+    if not isinstance(root.instruction, node_ins):
+        # is not node_ins stack value. so a leaf
+        return [root]
+    left, right = root.args[0], root.args[1]
+    return _flatten_ast(left, node_ins) + _flatten_ast(right, node_ins)
+
+
+@lru_cache(maxsize=None)
+def compute_equations(
+    root: KnownStackValue, node_ins: Type[Instruction]
+) -> Tuple[List[KnownStackValue], bool]:
+    """Compute equations from And or Or expression.
+
+    Returns:
+        equations: List of values on which, the result of **root** depends.
+
+            And(And(<1>, <2>), And(And(<3>, <4>), And(<5>, <6>)))
+            node_ins = And
+            => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+
+            Or(Or(Or(<1>, <2>), Or(<3>, <4>)), Or(<5>, <6>))
+            node_ins = Or
+            => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+
+        has_unknown_value: True if the result of **root** depends on a unknown value.
+    """
+    equations = _flatten_ast(root, node_ins)
+    has_unkown_value = False
+    known_equations = []
+    for eq in equations:
+        if isinstance(eq, UnknownStackValue):
+            has_unkown_value = True
+        else:
+            known_equations.append(eq)
+    return known_equations, has_unkown_value

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -9,20 +9,17 @@ from tealer.detectors.abstract_detector import (
 )
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import (
-    Eq,
-    Greater,
-    GreaterE,
     Instruction,
     Int,
-    Less,
-    LessE,
-    Return,
     Txn,
 )
 from tealer.teal.instructions.transaction_field import Fee
+from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.utils.algorand_constants import MAX_TRANSACTION_COST
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
+    from tealer.teal.context.block_transaction_context import BlockTransactionContext
 
 
 def _is_fee_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -87,63 +84,6 @@ balance of the account that signed the contract as the fee will be deducted from
 Always check that transaction fee which can be accessed using `txn Fee` in Teal is less than certain limit and fail if that's not the case.
 """
 
-    def _check_fee(
-        self,
-        bb: BasicBlock,
-        current_path: List[BasicBlock],
-        paths_without_check: List[List[BasicBlock]],
-    ) -> None:
-        """Find execution paths with missing Fee check.
-
-        This function recursively explores the Control Flow Graph(CFG) of the
-        contract and reports execution paths with missing Fee check.
-
-        This function is "in place", modifies arguments with the data it is
-        supposed to return.
-
-        Args:
-            bb: Current basic block being checked(whose execution is simulated.)
-            current_path: Current execution path being explored.
-            paths_without_check:
-                Execution paths with missing Fee check. This is a
-                "in place" argument. Vulnerable paths found by this function are
-                appended to this list.
-        """
-
-        # check for loops
-        if bb in current_path:
-            return
-
-        current_path = current_path + [bb]
-
-        stack: List[Instruction] = []
-
-        for ins in bb.instructions:
-
-            if isinstance(ins, (Less, LessE, Greater, GreaterE, Eq)):
-                if len(stack) >= 2:
-                    one = stack[-1]
-                    two = stack[-2]
-                    # int .. <[=?] txn fee or txn fee <[=?] int .. or
-                    # int .. >[=?] txnfee or txn fee >[=?] int .. or
-                    #  txn fee == int .. or txn fee == int ..
-                    if _is_fee_check(one, two) or _is_fee_check(two, one):
-                        return
-
-            if isinstance(ins, Return):
-                if len(ins.prev) == 1:
-                    prev = ins.prev[0]
-                    if isinstance(prev, Int) and prev.value == 0:
-                        return
-
-                paths_without_check.append(current_path)
-                return
-
-            stack.append(ins)
-
-        for next_bb in bb.next:
-            self._check_fee(next_bb, current_path, paths_without_check)
-
     def detect(self) -> "SupportedOutput":
         """Detect execution paths with missing Fee check.
 
@@ -153,8 +93,14 @@ Always check that transaction fee which can be accessed using `txn Fee` in Teal 
             information.
         """
 
-        paths_without_check: List[List[BasicBlock]] = []
-        self._check_fee(self.teal.bbs[0], [], paths_without_check)
+        def checks_field(block_ctx: "BlockTransactionContext") -> bool:
+            # returns True if fee is bounded by some unknown value
+            # or is bounded by some known value less than maximum transaction cost.
+            return block_ctx.max_fee_unknown or block_ctx.max_fee <= MAX_TRANSACTION_COST
+
+        paths_without_check: List[List[BasicBlock]] = detect_missing_tx_field_validations(
+            self.teal.bbs[0], checks_field
+        )
 
         description = "Lack of fee check allows draining the funds of sender account,"
         description += "contract account or signer of delegate contract."

--- a/tealer/teal/context/block_transaction_context.py
+++ b/tealer/teal/context/block_transaction_context.py
@@ -34,6 +34,7 @@ class BlockTransactionContext:  # pylint: disable=too-few-public-methods, too-ma
         self.closeto: AddrFieldValue = AddrFieldValue()
         self.assetcloseto: AddrFieldValue = AddrFieldValue()
         self.max_fee: int = MAX_UINT64
+        self.max_fee_unknown: bool = False  # True if max possible fee is bounded and unknown
 
     def gtxn_context(self, txn_index: int) -> "BlockTransactionContext":
         """context information collected from gtxn {txn_index} field instructions"""

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -207,6 +207,9 @@ class Instruction:  # pylint: disable=too-many-instance-attributes
     def __str__(self) -> str:
         return self.__class__.__qualname__.lower()
 
+    def __repr__(self) -> str:
+        return f"<Instruction('{str(self)}')>"
+
 
 class UnsupportedInstruction(Instruction):
     """

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -54,7 +54,7 @@ from tealer.teal.instructions.acct_params_field import AcctParamsField
 from tealer.teal.teal import Teal
 from tealer.analyses.dataflow import all_constraints
 from tealer.analyses.dataflow.generic import DataflowTransactionContext
-from tealer.analyses.utils.stack_emulator import emulate_stack
+from tealer.analyses.utils.stack_emulator import emulate_stack, compute_equations
 
 
 def _detect_contract_type(instructions: List[Instruction]) -> ContractType:
@@ -509,6 +509,7 @@ def _apply_transaction_context_analysis(teal: "Teal") -> None:
         cl(teal).run_analysis()
     # clear cache
     emulate_stack.cache_clear()  # emulate stack is not used after transaction_context_analysis.
+    compute_equations.cache_clear()  # compute_equations is not used after transaction_context_analysis.
 
 
 def parse_teal(source_code: str) -> Teal:

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -54,6 +54,7 @@ from tealer.teal.instructions.acct_params_field import AcctParamsField
 from tealer.teal.teal import Teal
 from tealer.analyses.dataflow import all_constraints
 from tealer.analyses.dataflow.generic import DataflowTransactionContext
+from tealer.analyses.utils.stack_emulator import emulate_stack
 
 
 def _detect_contract_type(instructions: List[Instruction]) -> ContractType:
@@ -506,6 +507,8 @@ def _apply_transaction_context_analysis(teal: "Teal") -> None:
     group_indices_cls(teal).run_analysis()
     for cl in analyses_classes:
         cl(teal).run_analysis()
+    # clear cache
+    emulate_stack.cache_clear()  # emulate stack is not used after transaction_context_analysis.
 
 
 def parse_teal(source_code: str) -> Teal:

--- a/tealer/utils/algorand_constants.py
+++ b/tealer/utils/algorand_constants.py
@@ -2,3 +2,11 @@ MAX_GROUP_SIZE = 16
 MIN_ALGORAND_FEE = 1000  # in micro algos
 ZERO_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEVAL4QAJS7JHB4"
 MAX_UINT64 = (1 << 64) - 1  # 2**64 - 1
+# Maximum number of inner transactions a group transaction can have.
+MAX_NUM_INNER_TXN = 256
+
+# Over estimation of maximum cost a transaction can consume.
+# There can be a maximum of 256 inner transactions in a group.
+# There can be maximum of 16 transactions in a group.
+# Each inner txn and txn costs MIN_ALGORAND Fee
+MAX_TRANSACTION_COST = (MAX_GROUP_SIZE + MAX_NUM_INNER_TXN) * MIN_ALGORAND_FEE

--- a/tests/detectors/can_close_account.py
+++ b/tests/detectors/can_close_account.py
@@ -1,7 +1,13 @@
-from typing import List
+from typing import List, Tuple, Type
 
 from tealer.teal.instructions import instructions, transaction_field
-from tealer.detectors.all_detectors import CanCloseAccount
+from tealer.detectors.all_detectors import (
+    CanCloseAccount,
+    CanCloseAsset,
+    MissingFeeCheck,
+    MissingRekeyTo,
+)
+from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal import global_field
 
 from tests.utils import construct_cfg
@@ -362,7 +368,91 @@ err
 CAN_CLOSE_ACCOUNT_GROUP_INDEX_3_VULNERABLE_PATHS: List[List[int]] = []  # not vulnerable
 
 
-new_can_close_account_tests = [
+CAN_CLOSE_ACCOUNT_2 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+assert
+int 1
+return
+"""
+
+CAN_CLOSE_ACCOUNT_2_VULNERABLE_PATHS: List[List[int]] = [[0]]
+
+CAN_CLOSE_ACCOUNT_RETURN_1 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+return                  # return value is the result of the expression
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS: List[List[int]] = [[0]]
+
+CAN_CLOSE_ACCOUNT_RETURN_2 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+gtxn 0 CloseRemainderTo
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==                  // Not vulnerable to CanCloseAccount as well.
+&&
+return
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_2_VULNERABLE_PATHS: List[List[int]] = []
+
+new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     (
         CAN_CLOSE_ACCOUNT_GROUP_INDEX_0,
         CanCloseAccount,
@@ -383,4 +473,17 @@ new_can_close_account_tests = [
         CanCloseAccount,
         CAN_CLOSE_ACCOUNT_GROUP_INDEX_3_VULNERABLE_PATHS,
     ),
+    (CAN_CLOSE_ACCOUNT_2, CanCloseAccount, CAN_CLOSE_ACCOUNT_2_VULNERABLE_PATHS),
+    (CAN_CLOSE_ACCOUNT_2, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_2, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_2, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAccount, CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAccount, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingFeeCheck, []),
 ]

--- a/tests/detectors/can_update.py
+++ b/tests/detectors/can_update.py
@@ -2,7 +2,7 @@ from typing import List
 
 from tealer.teal.instructions import instructions
 from tealer.teal.instructions import transaction_field
-from tealer.detectors.all_detectors import CanUpdate
+from tealer.detectors.all_detectors import CanUpdate, CanDelete
 
 from tests.utils import construct_cfg
 
@@ -390,8 +390,553 @@ CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS: List[List[int]] = [
     [0, 2, 7, 8, 9],
 ]
 
+CAN_UPDATE_GROUP_INDEX_2_X_0 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int CloseOut
+    ==
+    ||                      // (Eq || Eq) || Eq)
+    bnz success             // gtxn 1 is one of NoOp, OptIn, CloseOut. gtxn 0 can be UpdateApplication
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    ==
+    ||
+    bnz handle_updateapp        // pattern: (Eq<> || Eq<>)
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_0: List[List[int]] = [
+    [0, 2, 3, 4],
+    [0, 2, 5],
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_1 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    !
+    !
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    !=
+    !
+    ||
+    &&                              // gtxn 0 is NoOp or OptIn or CloseOut and gtxn 1 is NoOp or OptIn.
+    bnz success                     // Pattern:    (!!(== || ==) || ==) && (== || !(!=))
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    ==
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_1: List[List[int]] = [
+    [0, 2, 3, 4],
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_2 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    !
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    !
+    &&
+    !                       // !(&&(!x, !y)) => x || y
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    !=
+    !
+    ||
+    &&                          // Pattern: (!(&&(!x, !y)) || ==) && (== || !(!=))
+    bnz success                 // gtxn 0 is NoOp or OptIn or CloseOut and gtxn 1 is NoOp or OptIn. max group size is 2
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    ==
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_2: List[List[int]] = [
+    [0, 2, 3, 4],
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_3 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    !
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    !
+    &&
+    !                       // !(!x && !y) => x || y
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    !=
+    !
+    ||
+    &&
+    bnz success                 // gtxn 0 is NoOp or OptIn or CloseOut and gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_3: List[List[int]] = []
+
+CAN_UPDATE_GROUP_INDEX_2_X_4 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a unknown value
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_4: List[List[int]] = [
+    [0, 2, 5],  # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_5 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a independent value. GTXN_0_TransactionType is different from GTXN_1_TransactionType
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_5: List[List[int]] = [
+    [0, 2, 5],  # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_6 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a independent value. GTXN_0_TransactionType is different from GTXN_1_TransactionType
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    assert
+    int 1
+    return
+handle_updateapp:
+    err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_6: List[List[int]] = [
+    # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+    # success block checks for gtxn 0 UpdateApplication and DeleteApplication
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_7 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a independent value. GTXN_0_TransactionType is different from GTXN_1_TransactionType
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+txn Fee
+int 10000
+<
+&&                          // gtxn 0 Completion should not be UpdateApplication for this to be true
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+txn Note
+byte "Note"
+==
+&&                          // gtxn 0 Completion should not be UpdateApplication for this to be true
+||                          // r = ( x && a ) || ( x && b), x must be True for r to be True, x here is `Neq(gtxn 0 OnCompletion, UpdateApplication)`
+assert
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7: List[List[int]] = [
+    # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+    # success block checks for gtxn 0 OnCompletion is not UpdateApplication
+]
+
+CAN_DELETE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7: List[List[int]] = [
+    # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+    # success block checks for gtxn 0 OnCompletion is not UpdateApplication but not DeleteApplication
+    [0, 2, 5],
+]
+
 new_can_update_tests = [
     (CAN_UPDATE_GROUP_INDEX_0, CanUpdate, CAN_UPDATE_GROUP_INDEX_0_VULNERABLE_PATHS),
     (CAN_UPDATE_GROUP_INDEX_1, CanUpdate, CAN_UPDATE_GROUP_INDEX_1_VULNERABLE_PATHS),
     (CAN_UPDATE_GROUP_INDEX_2, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS),
+    (CAN_UPDATE_GROUP_INDEX_2_X_0, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_0),
+    (CAN_UPDATE_GROUP_INDEX_2_X_0, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_0),
+    (CAN_UPDATE_GROUP_INDEX_2_X_1, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_1),
+    (CAN_UPDATE_GROUP_INDEX_2_X_2, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_1),
+    (CAN_UPDATE_GROUP_INDEX_2_X_2, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_2),
+    (CAN_UPDATE_GROUP_INDEX_2_X_2, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_2),
+    (CAN_UPDATE_GROUP_INDEX_2_X_3, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_3),
+    (CAN_UPDATE_GROUP_INDEX_2_X_3, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_3),
+    (CAN_UPDATE_GROUP_INDEX_2_X_4, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_4),
+    (CAN_UPDATE_GROUP_INDEX_2_X_4, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_4),
+    (CAN_UPDATE_GROUP_INDEX_2_X_5, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_5),
+    (CAN_UPDATE_GROUP_INDEX_2_X_5, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_5),
+    (CAN_UPDATE_GROUP_INDEX_2_X_6, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_6),
+    (CAN_UPDATE_GROUP_INDEX_2_X_6, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_6),
+    (CAN_UPDATE_GROUP_INDEX_2_X_7, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7),
+    (CAN_UPDATE_GROUP_INDEX_2_X_7, CanDelete, CAN_DELETE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7),
 ]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -6,7 +6,7 @@ from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal.parse_teal import parse_teal
 
 from tests.detectors.groupsize import missing_group_size_tests
-from tests.detectors.fee_check import missing_fee_check_tests
+from tests.detectors.fee_check import missing_fee_check_tests, new_missing_fee_tests
 from tests.detectors.can_close_account import can_close_account_tests, new_can_close_account_tests
 from tests.detectors.can_close_asset import can_close_asset_tests, new_can_close_asset_tests
 from tests.detectors.can_delete import can_delete_tests, new_can_delete_tests
@@ -44,6 +44,7 @@ ALL_NEW_TESTS: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     *new_can_close_asset_tests,
     *new_can_update_tests,
     *new_can_delete_tests,
+    *new_missing_fee_tests,
 ]
 
 

--- a/tests/transaction_context/test_fee.py
+++ b/tests/transaction_context/test_fee.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union
 import pytest
 
 from tealer.teal.parse_teal import parse_teal
@@ -33,6 +33,34 @@ txn_fees = [1000, 1000, 1000, 0, 1000]
 gtxn_fees = [[1000, 1000, 1000, 0, 1000], *[[0] * 5 for _ in range(MAX_GROUP_SIZE - 1)]]
 
 BASIC_LISTS = [txn_fees, gtxn_fees]
+
+BASIC_2 = """
+#pragma version 6
+txn Fee
+global MinTxnFee
+<=
+assert
+txn GroupIndex
+int 0
+==
+bz fail_txn
+callsub perform_validations
+process_txn:
+int 1
+return
+fail_txn:
+int 0
+return
+perform_validations:
+int 1
+assert
+retsub
+"""
+
+txn_fees = [True, True, True, 0, True]
+gtxn_fees = [[True, True, True, 0, True], *[[0] * 5 for _ in range(MAX_GROUP_SIZE - 1)]]
+
+BASIC_2_LISTS = [txn_fees, gtxn_fees]
 
 NO_CHECKS = """
 #pragma version 6
@@ -252,6 +280,72 @@ gtxn_fees = [
 
 CHECKS_IN_MULTIPLE_SUBROUTINES_LISTS = [txn_fees, gtxn_fees]
 
+CHECKS_IN_MULTIPLE_SUBROUTINES_2 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+bnz group_size_2
+
+global GroupSize
+int 1
+==
+assert
+callsub validate_fee_group_size_1
+b process_txn
+
+group_size_2:
+    callsub validate_fee_group_size_2
+    b process_txn
+
+process_txn:
+    callsub perform_validations
+    int 1
+    return
+
+fail_txn:
+    int 0
+    return
+
+perform_validations:
+    int 1
+    assert
+    retsub
+
+validate_fee_group_size_1:
+    gtxn 0 Fee
+    int 10000
+    <
+    assert
+    retsub
+
+validate_fee_group_size_2:
+    gtxn 0 Fee
+    global MinTxnFee
+    int 3
+    *
+    <=                  // detection of this pattern is possible because of StackValue emulation/analysis
+    assert
+    gtxn 1 Fee
+    int 1000
+    int 4
+    *
+    <=
+    bz fail_txn
+    retsub
+"""
+
+txn_fees = [MAX_UINT64] * 12
+txn_fees[7] = 0  # fail_txn block
+gtxn_fees = [
+    # [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    [True, 9999, 9999, True, True, True, True, 0, True, 9999, True, True],
+    [True, 0, 0, True, True, True, True, 0, True, 0, True, True, True],
+    *[[0] * 12 for _ in range(MAX_GROUP_SIZE - 2)],
+]
+
+CHECKS_IN_MULTIPLE_SUBROUTINES_LISTS_2 = [txn_fees, gtxn_fees]
+
 
 CHECK_IN_ONE_PATH = """
 #pragma version 6
@@ -300,20 +394,30 @@ ALL_TESTS = [
     (MULTIPLE_GROUP_SIZES_IN_SUBROUTINES, *MULTIPLE_GROUP_SIZES_IN_SUBROUTINES_LISTS),
     (CHECKS_IN_MULTIPLE_SUBROUTINES, *CHECKS_IN_MULTIPLE_SUBROUTINES_LISTS),
     (CHECK_IN_ONE_PATH, *CHECK_IN_ONE_PATH_LISTS),
+    (BASIC_2, *BASIC_2_LISTS),
+    (CHECKS_IN_MULTIPLE_SUBROUTINES_2, *CHECKS_IN_MULTIPLE_SUBROUTINES_LISTS_2),
 ]
 
 
 @pytest.mark.parametrize("test", ALL_TESTS)  # type: ignore
-def test_tx_types_gtxn(test: Tuple[str, List[int], List[List[int]]]) -> None:
+def test_tx_types_gtxn(
+    test: Tuple[str, List[Union[bool, int]], List[List[Union[bool, int]]]]
+) -> None:
     code, max_fees_list, gtxn_fees_list = test
 
     teal = parse_teal(code.strip())
 
     bbs = order_basic_blocks(teal.bbs)
     for i, b in enumerate(bbs):
-        print(i, repr(b), b.transaction_context.max_fee)
-        assert b.transaction_context.max_fee == max_fees_list[i]
+        print("X:", i, repr(b), b.transaction_context.max_fee)
+        if isinstance(max_fees_list[i], bool):
+            assert b.transaction_context.max_fee_unknown is True
+        else:
+            assert b.transaction_context.max_fee == max_fees_list[i]
         for ind in range(MAX_GROUP_SIZE):
             ctx = b.transaction_context.gtxn_context(ind)
-            print(f"D: {ind}, {i}", ctx.max_fee, gtxn_fees_list[ind][i])
-            assert ctx.max_fee == gtxn_fees_list[ind][i]
+            print(f"Y: {ind}, {i}", ctx.max_fee, gtxn_fees_list[ind][i])
+            if isinstance(gtxn_fees_list[ind][i], bool):
+                assert ctx.max_fee_unknown is True
+            else:
+                assert ctx.max_fee == gtxn_fees_list[ind][i]


### PR DESCRIPTION
Transaction context analysis directly works on the list of instructions executed right before the `Assert/Bz/Bnz/..`. This does not give accurate results when the arguments of the comparison instruction are not in the correct order.

e.g:
```
txn Fee
int 1000
int 4
*
<=
assert
```

Given the list `[txn Fee, int 1000, int 4, *, <=]`, it is not easy to determine the exact values being compared which results in False Positives.

This PR uses local stack emulation to determine the arguments of comparison operators allowing the analysis to give more accurate results.