### PR TITLE
Add support to analyse and-or-! connected equations

### DIFF
--- a/tealer/analyses/dataflow/addr_fields.py
+++ b/tealer/analyses/dataflow/addr_fields.py
@@ -134,7 +134,7 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
             return asserted_addresses, self._universal_set()
         return self._universal_set(), asserted_addresses
 
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
         return self._get_asserted_txn_gtxn(key, ins_stack_value)
 
     @staticmethod

--- a/tealer/analyses/dataflow/fee_field.py
+++ b/tealer/analyses/dataflow/fee_field.py
@@ -164,7 +164,7 @@ class FeeField(DataflowTransactionContext):
             return self._get_asserted_max_value(ins, compared_value, U)
         return U, U
 
-    def _get_asserted(
+    def _get_asserted_single(
         self, key: str, ins_stack_value: KnownStackValue
     ) -> Tuple[Union[int, str], Union[int, str]]:
         res = self._get_asserted_fee(key, ins_stack_value)

--- a/tealer/analyses/dataflow/generic.py
+++ b/tealer/analyses/dataflow/generic.py
@@ -139,7 +139,90 @@ This is because, when traversing the CFG without differentiating subroutine bloc
 
 However, At runtime, execution will reach B3 if and only if it reaches B2, same for B5 and B3. Using this reasoning while
 combining information from predecessors and successors will give more accurate results.
+
+---------------------------------------------------------------------------
+
+`DataflowTransactionContext._get_asserted_single(key, ins_stack_value)` returns a Tuple of true_values and false_values.
+    true_values: Given that the result of `ins_stack_value` is NON-ZERO, what are the possible
+                values for the key.
+    false_values: Given that the result of `ins_stack_value` is ZERO, what are the possible values
+                for the key.
+
+`_get_asserted_single` uses pattern matching to identify comparisons on interested fields. It only works when the
+`ins_stack_value` directly represents the value of the comparison.
+e.g
+    - Eq(txn RekeyTo, global Zeroaddress)
+    - Neq(txn OnCompletion, int UpdateApplication)
+    - ...
+
+But when the result depends on multiple equations it is NOT possible to use the same kind of pattern matching and derive
+possible values.
+e.g
+ins_stack_value =   Or(
+                        And(
+                            Eq(txn RekeyTo, global ZeroAddress),
+                            Eq(txn CloseRemainderTo, global ZeroAddress),
+                        ),
+                        And(
+                            Eq(txn Fee, global MinTxnFee),
+                            Eq(txn AssetCloseTo, global ZeroAddress),
+                        ),
+                    )
+
+
+We can combine information from multiple equations when they are connected using And, Or, !.
+e.g
+    txn RekeyTo
+    global ZeroAddress
+    ==                      // equation <1>
+    txn CloseRemainderTo
+    global ZeroAddress
+    ==                      // <2>
+    &&
+    txn Fee
+    global MinTxnFee
+    <=                      // <3>
+    &&
+
+=> And(
+    And(
+        Eq(txn RekeyTo, global ZeroAddress),
+        Eq(txn CloseRemainderTo, global ZeroAddress),
+    ),
+    LessE(txn Fee, global MinTxnFee),
+)
+
+=> And(And(<1>, <2>), <3>)
+=> ins_stack_value = And(<1>, <2>, <3>)           // flattend
+
+if it is given that ins_stack_value is False, Then atleast ONE of the equations <1>, <2> or <3> is False.
+if it is given that ins_stack_value is True, Then ALL of the equations <1>, <2> and <3> are True.
+
+This applies for any number of equations: And(<1>, <2>, <3>, <4>, ....)
+
+-> if the ins_stack_value is of form And(<1>, <2>, <3>, <4>, ....) and is `True`, Then we can combine possible values
+from multiple equations using set `Intersection`.
+-> if the ins_stack_value is of form And(<1>, <2>, <3>, <4>, ....) and is `False`, Then we can combine possible values
+from multiple equations using set `Union`.
+
+if any of equation in And(<1>, ...) is UnknownStackValue then `false_values` for And(...) is universal_set U.
+    -> The result of And() could be false because the UnknownStackValue is False. None of the known values have
+        to be False.
+    -> true_values are not affected by having an UnknownStackValue. All the known values have to be True irrespective
+        of unknown values for the result to be True.
+
+Similar reasoning can be done for Or(<1>, <2>, <3>, <4>, ....)
+
+if ins_stack_value is True, Then atleast ONE of the equations <1>, <2>, <3>, ... is True.   (Union)
+if ins_stack_value is False, Then ALL of the equations <1>, <2>, <3>, ... are False.        (Intersection)
+
+if any of equation in Or(<1>, ...) is UnknownStackValue then `true_values` for Or(...) is universal_set U.
+    -> The result of Or() could be True because the UnknownStackValue is True. None of the known values have
+        to be True.
+    -> false_values are not affected by having an UnknownStackValue. All the known values have to be False irrespective
+        of unknown values for the result to be False
 """
+
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Set
@@ -152,11 +235,19 @@ from tealer.teal.instructions.instructions import (
     Err,
     Txn,
     Gtxn,
+    And,
+    Or,
+    Not,
 )
 from tealer.teal.instructions.parse_transaction_field import TX_FIELD_TXT_TO_OBJECT
 from tealer.utils.analyses import is_int_push_ins
 from tealer.utils.algorand_constants import MAX_GROUP_SIZE
-from tealer.analyses.utils.stack_emulator import KnownStackValue, UnknownStackValue, emulate_stack
+from tealer.analyses.utils.stack_emulator import (
+    KnownStackValue,
+    UnknownStackValue,
+    emulate_stack,
+    compute_equations,
+)
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal
@@ -245,18 +336,81 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
         """return intersection of a and b, where a, b represent values for the given key"""
 
     @abstractmethod
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Any, Any]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Any, Any]:
         """For the given key and ins_stack, return true_values and false_values
 
-        true_values for a key are considered to be values which result in non-zero value on
-        top of the stack.
-        false_values for a key are considered to be values which result in zero value on top
-        of the stack.
+        true_values: Given that the result of `ins_stack_value` is NON-ZERO, what are the possible
+            values for the key.
+        false_values: Given that the result of `ins_stack_value` is ZERO, what are the possible values
+            for the key.
         """
 
     @abstractmethod
     def _store_results(self) -> None:
         """Store the collected information in the context object of each block"""
+
+    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Any, Any]:
+        """For the given key and ins_stack_value, return true_values and false_values
+
+        true_values: Given that the result of `ins_stack_value` is NON-ZERO, what are the possible
+            values for the key.
+        false_values: Given that the result of `ins_stack_value` is ZERO, what are the possible values
+            for the key.
+        """
+        if not isinstance(ins_stack_value.instruction, (And, Or, Not)):
+            # and not isinstance(ins_stack_value.instruction, Or):
+            # single equation
+            t, f = self._get_asserted_single(key, ins_stack_value)
+            return t, f
+        if isinstance(ins_stack_value.instruction, Not):
+            arg = ins_stack_value.args[0]
+            if isinstance(arg, UnknownStackValue):
+                # unknown value
+                return self._universal_set(key), self._universal_set(key)
+            true_values, false_values = self._get_asserted(key, arg)
+            # swap the values
+            final_true_values, final_false_values = false_values, true_values
+            return final_true_values, final_false_values
+        if isinstance(ins_stack_value.instruction, And):
+            # x = And(<1>, <2>, <3>, ...),
+            #   if x is True then <1>, <2>, ... are all True, Intersection
+            #   if x is False then one of <1>, <2>, ... is False, Union
+            individual_equations, has_unknown_value = compute_equations(ins_stack_value, And)
+            final_true_values = self._universal_set(key)
+            final_false_values = self._null_set(key)
+            for equation in individual_equations:
+                # combine values recursively.
+                # And(<Eq()>, <Or()>, <Or()>, ...):
+                #      values Or() cannot be calculated using _get_asserted_single
+                true_values, false_values = self._get_asserted(key, equation)
+                final_true_values = self._intersection(key, final_true_values, true_values)
+                final_false_values = self._union(key, final_false_values, false_values)
+            if has_unknown_value:
+                # has_unknown_value is True if result of And depends on an unknown value.
+                # if And is False, the unknown value could be false and that unknown value
+                # might or might not depend on the key.
+                # note: Having a unknown value does not affect true_values, known values have
+                # to be True irrespective of unknown value for the result to be True
+                final_false_values = self._universal_set(key)
+            return final_true_values, final_false_values
+        # x = Or(<1>, <2>, <3>, ....),
+        #   if x is False then <1>, <2>, ... are all False,     Intersection
+        #   if x is True then one of <1>, <2>, ... is True,     Union
+        individual_equations, has_unknown_value = compute_equations(ins_stack_value, Or)
+        final_false_values = self._universal_set(key)
+        final_true_values = self._null_set(key)
+        for equation in individual_equations:
+            true_values, false_values = self._get_asserted(key, equation)
+            final_false_values = self._intersection(key, final_false_values, false_values)
+            final_true_values = self._union(key, final_true_values, true_values)
+        if has_unknown_value:
+            # has_unknown_value is True if result of Or depends on an unknown value.
+            # if Or is True, the unknown value could be True and that unknown value
+            # might or might not depend on the key
+            # note: Having a unknown value does not affect false_values, known values have
+            # to be False irrespective of unknown value for the result to be False
+            final_true_values = self._universal_set(key)
+        return final_true_values, final_false_values
 
     def _block_level_constraints(self, analysis_keys: List[str], block: "BasicBlock") -> None:
         """Calculate and store constraints on keys applied within the block.

--- a/tealer/analyses/dataflow/int_fields.py
+++ b/tealer/analyses/dataflow/int_fields.py
@@ -183,7 +183,7 @@ class GroupIndices(DataflowTransactionContext):  # pylint: disable=too-few-publi
             return set(asserted_values), set(U) - set(asserted_values)
         return set(U), set(U)
 
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
         if key == self.GROUP_SIZE_KEY:
             return self._get_asserted_groupsizes(ins_stack_value)
         return self._get_asserted_groupindices(ins_stack_value)

--- a/tealer/analyses/dataflow/txn_types.py
+++ b/tealer/analyses/dataflow/txn_types.py
@@ -173,7 +173,7 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
 
         return set(U), set(U)
 
-    def _get_asserted(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
+    def _get_asserted_single(self, key: str, ins_stack_value: KnownStackValue) -> Tuple[Set, Set]:
         return self._get_asserted_transaction_types(key, ins_stack_value)
 
     def _store_results(self) -> None:

--- a/tealer/analyses/utils/stack_emulator.py
+++ b/tealer/analyses/utils/stack_emulator.py
@@ -141,7 +141,7 @@ Unclear/recent(v8) instructions:
     proto, frame_dig, frame_bury,
 """
 
-from typing import List, Union, Dict
+from typing import List, Union, Dict, Type, Tuple
 from functools import lru_cache
 
 
@@ -225,7 +225,8 @@ class KnownStackValue:
         # args = ", ".join(str(i) for i in self._args)
         # return f"{self._ins.__class__.__name__}(<{args}>)"
         args = "[" + ", ".join(str(i) for i in self.args) + "]"
-        return f"KnownStackValue(ins = {str(self._ins.__class__.__name__)}, args = {args})"
+        # return f"KnownStackValue(ins = {str(self._ins.__class__.__name__)}, args = {args})"
+        return f"KnownStackValue(ins = {repr(self._ins)}, args = {args})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -341,3 +342,110 @@ def emulate_stack(bb: BasicBlock) -> Dict[Instruction, KnownStackValue]:
             stack.push(KnownStackValue(ins, popped_values, i))
         ins_stack_value[ins] = KnownStackValue(ins, popped_values)
     return ins_stack_value
+
+
+def _flatten_ast(root: StackValue, node_ins: Type[Instruction]) -> List[StackValue]:
+    r"""Return all the leaf values given the root of the instruction AST.
+
+    node_ins instruction is one of `And`, `Or`.
+    `And` and `Or` consume two values. These two values are the children of the node.
+
+    Inner nodes are values whose `instruction` is a instance of `node_ins`.
+    Leaf values are values whose `instruction` is not `node_ins`.
+
+      &&
+    /    \
+   ==     &&
+        /    \
+       &&     ||
+      /  \   /  \
+     ==  >  !   !=
+    /\   /\
+
+    All the nodes in the tree are represented by `StackValue`. A StackValue can be unknown or known.
+    unknown stack values are considered to be leaf values and are stored.
+    A known stack value contains the instruction and arguments consumed by that instruction. These
+    arguments are also stack values and are treated as children.
+
+    In above example, if `node_ins` is `And` then values with instruction, `==, >, ||`, are all treated
+    as leaf blocks and are NOT traversed further.
+
+    int 1
+    int 2
+    ==
+    addr "..."
+    txn RekeyTo
+    !=
+    &&
+    byte "X"
+    byte "Y"
+    ==
+    &&
+
+    Tree:
+                        And
+                      /     \
+                    And       Eq
+                  /    \    /     \
+                Eq     Neq  Byte   Byte
+              /   \   /    \
+            Int  Int Addr  Txn RekeyTo
+
+    node_ins = And
+
+    ^^Only And instruction values are considered as nodes. remaining values are treated as leaves
+    and are not traversed.
+
+    After traversing, this functions returns the leaf values:
+        [
+            Eq(Int(<>), Int(<>)),
+            Neq(Addr(<>), Txn(<>)),
+            Eq(Byte(<>), Byte(<>))
+        ]
+
+    This function essentially flattens the given tree:
+        And(And(<1>, <2>), And(And(<3>, <4>), And(<5>, <6>)))
+        node_ins = And
+        => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+
+        Or(Or(Or(<1>, <2>), Or(<3>, <4>)), Or(<5>, <6>))
+        node_ins = Or
+        => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+    """
+    if isinstance(root, UnknownStackValue):
+        return [root]
+    if not isinstance(root.instruction, node_ins):
+        # is not node_ins stack value. so a leaf
+        return [root]
+    left, right = root.args[0], root.args[1]
+    return _flatten_ast(left, node_ins) + _flatten_ast(right, node_ins)
+
+
+@lru_cache(maxsize=None)
+def compute_equations(
+    root: KnownStackValue, node_ins: Type[Instruction]
+) -> Tuple[List[KnownStackValue], bool]:
+    """Compute equations from And or Or expression.
+
+    Returns:
+        equations: List of values on which, the result of **root** depends.
+
+            And(And(<1>, <2>), And(And(<3>, <4>), And(<5>, <6>)))
+            node_ins = And
+            => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+
+            Or(Or(Or(<1>, <2>), Or(<3>, <4>)), Or(<5>, <6>))
+            node_ins = Or
+            => returns [<1>, <2>, <3>, <4>, <5>, <6>]
+
+        has_unknown_value: True if the result of **root** depends on a unknown value.
+    """
+    equations = _flatten_ast(root, node_ins)
+    has_unkown_value = False
+    known_equations = []
+    for eq in equations:
+        if isinstance(eq, UnknownStackValue):
+            has_unkown_value = True
+        else:
+            known_equations.append(eq)
+    return known_equations, has_unkown_value

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -9,20 +9,17 @@ from tealer.detectors.abstract_detector import (
 )
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import (
-    Eq,
-    Greater,
-    GreaterE,
     Instruction,
     Int,
-    Less,
-    LessE,
-    Return,
     Txn,
 )
 from tealer.teal.instructions.transaction_field import Fee
+from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.utils.algorand_constants import MAX_TRANSACTION_COST
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
+    from tealer.teal.context.block_transaction_context import BlockTransactionContext
 
 
 def _is_fee_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -87,63 +84,6 @@ balance of the account that signed the contract as the fee will be deducted from
 Always check that transaction fee which can be accessed using `txn Fee` in Teal is less than certain limit and fail if that's not the case.
 """
 
-    def _check_fee(
-        self,
-        bb: BasicBlock,
-        current_path: List[BasicBlock],
-        paths_without_check: List[List[BasicBlock]],
-    ) -> None:
-        """Find execution paths with missing Fee check.
-
-        This function recursively explores the Control Flow Graph(CFG) of the
-        contract and reports execution paths with missing Fee check.
-
-        This function is "in place", modifies arguments with the data it is
-        supposed to return.
-
-        Args:
-            bb: Current basic block being checked(whose execution is simulated.)
-            current_path: Current execution path being explored.
-            paths_without_check:
-                Execution paths with missing Fee check. This is a
-                "in place" argument. Vulnerable paths found by this function are
-                appended to this list.
-        """
-
-        # check for loops
-        if bb in current_path:
-            return
-
-        current_path = current_path + [bb]
-
-        stack: List[Instruction] = []
-
-        for ins in bb.instructions:
-
-            if isinstance(ins, (Less, LessE, Greater, GreaterE, Eq)):
-                if len(stack) >= 2:
-                    one = stack[-1]
-                    two = stack[-2]
-                    # int .. <[=?] txn fee or txn fee <[=?] int .. or
-                    # int .. >[=?] txnfee or txn fee >[=?] int .. or
-                    #  txn fee == int .. or txn fee == int ..
-                    if _is_fee_check(one, two) or _is_fee_check(two, one):
-                        return
-
-            if isinstance(ins, Return):
-                if len(ins.prev) == 1:
-                    prev = ins.prev[0]
-                    if isinstance(prev, Int) and prev.value == 0:
-                        return
-
-                paths_without_check.append(current_path)
-                return
-
-            stack.append(ins)
-
-        for next_bb in bb.next:
-            self._check_fee(next_bb, current_path, paths_without_check)
-
     def detect(self) -> "SupportedOutput":
         """Detect execution paths with missing Fee check.
 
@@ -153,8 +93,14 @@ Always check that transaction fee which can be accessed using `txn Fee` in Teal 
             information.
         """
 
-        paths_without_check: List[List[BasicBlock]] = []
-        self._check_fee(self.teal.bbs[0], [], paths_without_check)
+        def checks_field(block_ctx: "BlockTransactionContext") -> bool:
+            # returns True if fee is bounded by some unknown value
+            # or is bounded by some known value less than maximum transaction cost.
+            return block_ctx.max_fee_unknown or block_ctx.max_fee <= MAX_TRANSACTION_COST
+
+        paths_without_check: List[List[BasicBlock]] = detect_missing_tx_field_validations(
+            self.teal.bbs[0], checks_field
+        )
 
         description = "Lack of fee check allows draining the funds of sender account,"
         description += "contract account or signer of delegate contract."

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -207,6 +207,9 @@ class Instruction:  # pylint: disable=too-many-instance-attributes
     def __str__(self) -> str:
         return self.__class__.__qualname__.lower()
 
+    def __repr__(self) -> str:
+        return f"<Instruction('{str(self)}')>"
+
 
 class UnsupportedInstruction(Instruction):
     """

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -54,7 +54,7 @@ from tealer.teal.instructions.acct_params_field import AcctParamsField
 from tealer.teal.teal import Teal
 from tealer.analyses.dataflow import all_constraints
 from tealer.analyses.dataflow.generic import DataflowTransactionContext
-from tealer.analyses.utils.stack_emulator import emulate_stack
+from tealer.analyses.utils.stack_emulator import emulate_stack, compute_equations
 
 
 def _detect_contract_type(instructions: List[Instruction]) -> ContractType:
@@ -509,6 +509,7 @@ def _apply_transaction_context_analysis(teal: "Teal") -> None:
         cl(teal).run_analysis()
     # clear cache
     emulate_stack.cache_clear()  # emulate stack is not used after transaction_context_analysis.
+    compute_equations.cache_clear()  # compute_equations is not used after transaction_context_analysis.
 
 
 def parse_teal(source_code: str) -> Teal:

--- a/tealer/utils/algorand_constants.py
+++ b/tealer/utils/algorand_constants.py
@@ -2,3 +2,11 @@ MAX_GROUP_SIZE = 16
 MIN_ALGORAND_FEE = 1000  # in micro algos
 ZERO_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEVAL4QAJS7JHB4"
 MAX_UINT64 = (1 << 64) - 1  # 2**64 - 1
+# Maximum number of inner transactions a group transaction can have.
+MAX_NUM_INNER_TXN = 256
+
+# Over estimation of maximum cost a transaction can consume.
+# There can be a maximum of 256 inner transactions in a group.
+# There can be maximum of 16 transactions in a group.
+# Each inner txn and txn costs MIN_ALGORAND Fee
+MAX_TRANSACTION_COST = (MAX_GROUP_SIZE + MAX_NUM_INNER_TXN) * MIN_ALGORAND_FEE

--- a/tests/detectors/can_close_account.py
+++ b/tests/detectors/can_close_account.py
@@ -369,7 +369,7 @@ CAN_CLOSE_ACCOUNT_GROUP_INDEX_3_VULNERABLE_PATHS: List[List[int]] = []  # not vu
 
 
 CAN_CLOSE_ACCOUNT_2 = """
-# pragma version 4
+#pragma version 4
 txn Receiver
 addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
 ==
@@ -396,6 +396,61 @@ return
 
 CAN_CLOSE_ACCOUNT_2_VULNERABLE_PATHS: List[List[int]] = [[0]]
 
+CAN_CLOSE_ACCOUNT_RETURN_1 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+return                  # return value is the result of the expression
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS: List[List[int]] = [[0]]
+
+CAN_CLOSE_ACCOUNT_RETURN_2 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+gtxn 0 CloseRemainderTo
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==                  // Not vulnerable to CanCloseAccount as well.
+&&
+return
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_2_VULNERABLE_PATHS: List[List[int]] = []
 
 new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     (
@@ -422,4 +477,13 @@ new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[i
     (CAN_CLOSE_ACCOUNT_2, CanCloseAsset, []),
     (CAN_CLOSE_ACCOUNT_2, MissingRekeyTo, []),
     (CAN_CLOSE_ACCOUNT_2, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAccount, CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAccount, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingFeeCheck, []),
 ]

--- a/tests/detectors/can_close_account.py
+++ b/tests/detectors/can_close_account.py
@@ -1,7 +1,13 @@
-from typing import List
+from typing import List, Tuple, Type
 
 from tealer.teal.instructions import instructions, transaction_field
-from tealer.detectors.all_detectors import CanCloseAccount
+from tealer.detectors.all_detectors import (
+    CanCloseAccount,
+    CanCloseAsset,
+    MissingFeeCheck,
+    MissingRekeyTo,
+)
+from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal import global_field
 
 from tests.utils import construct_cfg
@@ -362,7 +368,36 @@ err
 CAN_CLOSE_ACCOUNT_GROUP_INDEX_3_VULNERABLE_PATHS: List[List[int]] = []  # not vulnerable
 
 
-new_can_close_account_tests = [
+CAN_CLOSE_ACCOUNT_2 = """
+# pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+assert
+int 1
+return
+"""
+
+CAN_CLOSE_ACCOUNT_2_VULNERABLE_PATHS: List[List[int]] = [[0]]
+
+
+new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     (
         CAN_CLOSE_ACCOUNT_GROUP_INDEX_0,
         CanCloseAccount,
@@ -383,4 +418,8 @@ new_can_close_account_tests = [
         CanCloseAccount,
         CAN_CLOSE_ACCOUNT_GROUP_INDEX_3_VULNERABLE_PATHS,
     ),
+    (CAN_CLOSE_ACCOUNT_2, CanCloseAccount, CAN_CLOSE_ACCOUNT_2_VULNERABLE_PATHS),
+    (CAN_CLOSE_ACCOUNT_2, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_2, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_2, MissingFeeCheck, []),
 ]

--- a/tests/detectors/can_update.py
+++ b/tests/detectors/can_update.py
@@ -2,7 +2,7 @@ from typing import List
 
 from tealer.teal.instructions import instructions
 from tealer.teal.instructions import transaction_field
-from tealer.detectors.all_detectors import CanUpdate
+from tealer.detectors.all_detectors import CanUpdate, CanDelete
 
 from tests.utils import construct_cfg
 
@@ -390,8 +390,553 @@ CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS: List[List[int]] = [
     [0, 2, 7, 8, 9],
 ]
 
+CAN_UPDATE_GROUP_INDEX_2_X_0 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int CloseOut
+    ==
+    ||                      // (Eq || Eq) || Eq)
+    bnz success             // gtxn 1 is one of NoOp, OptIn, CloseOut. gtxn 0 can be UpdateApplication
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    ==
+    ||
+    bnz handle_updateapp        // pattern: (Eq<> || Eq<>)
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_0: List[List[int]] = [
+    [0, 2, 3, 4],
+    [0, 2, 5],
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_1 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    !
+    !
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    !=
+    !
+    ||
+    &&                              // gtxn 0 is NoOp or OptIn or CloseOut and gtxn 1 is NoOp or OptIn.
+    bnz success                     // Pattern:    (!!(== || ==) || ==) && (== || !(!=))
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    ==
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_1: List[List[int]] = [
+    [0, 2, 3, 4],
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_2 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    !
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    !
+    &&
+    !                       // !(&&(!x, !y)) => x || y
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    !=
+    !
+    ||
+    &&                          // Pattern: (!(&&(!x, !y)) || ==) && (== || !(!=))
+    bnz success                 // gtxn 0 is NoOp or OptIn or CloseOut and gtxn 1 is NoOp or OptIn. max group size is 2
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    ==
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_2: List[List[int]] = [
+    [0, 2, 3, 4],
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_3 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    !
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    !
+    &&
+    !                       // !(!x && !y) => x || y
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    !=
+    !
+    ||
+    &&
+    bnz success                 // gtxn 0 is NoOp or OptIn or CloseOut and gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_3: List[List[int]] = []
+
+CAN_UPDATE_GROUP_INDEX_2_X_4 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a unknown value
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_4: List[List[int]] = [
+    [0, 2, 5],  # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_5 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a independent value. GTXN_0_TransactionType is different from GTXN_1_TransactionType
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_5: List[List[int]] = [
+    [0, 2, 5],  # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_6 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a independent value. GTXN_0_TransactionType is different from GTXN_1_TransactionType
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    assert
+    int 1
+    return
+handle_updateapp:
+    err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_6: List[List[int]] = [
+    # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+    # success block checks for gtxn 0 UpdateApplication and DeleteApplication
+]
+
+CAN_UPDATE_GROUP_INDEX_2_X_7 = """
+#pragma version 6
+global GroupSize
+int 2
+==
+assert
+int 0
+txn ApplicationID
+==
+bz not_creation
+int 1
+return
+not_creation:
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 0 OnCompletion
+    int NoOp
+    ==
+    ||                      // depends on a independent value. GTXN_0_TransactionType is different from GTXN_1_TransactionType
+    gtxn 0 OnCompletion
+    int OptIn
+    ==
+    ||
+    gtxn 0 OnCompletion
+    int CloseOut
+    ==
+    ||                          // gtxn 0 does not have to be NoOp, OptIn, CloseOut. 
+    gtxn 1 OnCompletion
+    int NoOp
+    ==
+    gtxn 1 OnCompletion
+    int OptIn
+    ==
+    ||
+    &&
+    bnz success                 // gtxn 1 is NoOp or OptIn.
+    gtxn 1 OnCompletion
+    int UpdateApplication
+    !=
+    gtxn 1 OnCompletion
+    int DeleteApplication
+    !=
+    &&
+    !                           // !(!x && !y) => x || y. True if gtxn 1 is UpdateApplication or DeleteApplication
+    gtxn 0 OnCompletion
+    int UpdateApplication
+    ==
+    gtxn 0 OnCompletion
+    int DeleteApplication
+    !=
+    !
+    ||                          // True if gtxn 0 is UpdateApplication or DeleteApplication.
+    ||
+    bnz handle_updateapp
+    int 1
+    return
+success:
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+txn Fee
+int 10000
+<
+&&                          // gtxn 0 Completion should not be UpdateApplication for this to be true
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+txn Note
+byte "Note"
+==
+&&                          // gtxn 0 Completion should not be UpdateApplication for this to be true
+||                          // r = ( x && a ) || ( x && b), x must be True for r to be True, x here is `Neq(gtxn 0 OnCompletion, UpdateApplication)`
+assert
+int 1
+return
+handle_updateapp:
+err
+"""
+
+CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7: List[List[int]] = [
+    # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+    # success block checks for gtxn 0 OnCompletion is not UpdateApplication
+]
+
+CAN_DELETE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7: List[List[int]] = [
+    # gtxn 0 can be UpdateApplication or DeleteApplication and reach "success:" block
+    # success block checks for gtxn 0 OnCompletion is not UpdateApplication but not DeleteApplication
+    [0, 2, 5],
+]
+
 new_can_update_tests = [
     (CAN_UPDATE_GROUP_INDEX_0, CanUpdate, CAN_UPDATE_GROUP_INDEX_0_VULNERABLE_PATHS),
     (CAN_UPDATE_GROUP_INDEX_1, CanUpdate, CAN_UPDATE_GROUP_INDEX_1_VULNERABLE_PATHS),
     (CAN_UPDATE_GROUP_INDEX_2, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS),
+    (CAN_UPDATE_GROUP_INDEX_2_X_0, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_0),
+    (CAN_UPDATE_GROUP_INDEX_2_X_0, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_0),
+    (CAN_UPDATE_GROUP_INDEX_2_X_1, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_1),
+    (CAN_UPDATE_GROUP_INDEX_2_X_2, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_1),
+    (CAN_UPDATE_GROUP_INDEX_2_X_2, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_2),
+    (CAN_UPDATE_GROUP_INDEX_2_X_2, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_2),
+    (CAN_UPDATE_GROUP_INDEX_2_X_3, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_3),
+    (CAN_UPDATE_GROUP_INDEX_2_X_3, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_3),
+    (CAN_UPDATE_GROUP_INDEX_2_X_4, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_4),
+    (CAN_UPDATE_GROUP_INDEX_2_X_4, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_4),
+    (CAN_UPDATE_GROUP_INDEX_2_X_5, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_5),
+    (CAN_UPDATE_GROUP_INDEX_2_X_5, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_5),
+    (CAN_UPDATE_GROUP_INDEX_2_X_6, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_6),
+    (CAN_UPDATE_GROUP_INDEX_2_X_6, CanDelete, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_6),
+    (CAN_UPDATE_GROUP_INDEX_2_X_7, CanUpdate, CAN_UPDATE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7),
+    (CAN_UPDATE_GROUP_INDEX_2_X_7, CanDelete, CAN_DELETE_GROUP_INDEX_2_VULNERABLE_PATHS_X_7),
 ]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -6,7 +6,7 @@ from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal.parse_teal import parse_teal
 
 from tests.detectors.groupsize import missing_group_size_tests
-from tests.detectors.fee_check import missing_fee_check_tests
+from tests.detectors.fee_check import missing_fee_check_tests, new_missing_fee_tests
 from tests.detectors.can_close_account import can_close_account_tests, new_can_close_account_tests
 from tests.detectors.can_close_asset import can_close_asset_tests, new_can_close_asset_tests
 from tests.detectors.can_delete import can_delete_tests, new_can_delete_tests
@@ -44,6 +44,7 @@ ALL_NEW_TESTS: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     *new_can_close_asset_tests,
     *new_can_update_tests,
     *new_can_delete_tests,
+    *new_missing_fee_tests,
 ]
 
 


### PR DESCRIPTION
Fixes issues #90, #95

It is common to use logical operators to validate multiple fields at a time. examples include:

```
txn RekeyTo
global ZeroAddress
==
txn CloseRemainderTo
global ZeroAddress
==
&&
txn AssetCloseTo
global ZeroAddress
&&
assert
```
```
txn OnCompletion
int UpdateApplication
==
txn OnCompletion
int DeleteApplication
==
||
!                                  // txn is not UpdateApplication or DeleteApplication.
assert
```

More complex patterns could be used to perform transaction field validations. This PR adds support to infer information about interested fields when the comparison equations are combined using logical operators `&&`, `||`, and `!`.
