### PR TITLE
Update MissingFeeCheck detector to use transaction field analysis

### DIFF
--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -9,20 +9,17 @@ from tealer.detectors.abstract_detector import (
 )
 from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.instructions.instructions import (
-    Eq,
-    Greater,
-    GreaterE,
     Instruction,
     Int,
-    Less,
-    LessE,
-    Return,
     Txn,
 )
 from tealer.teal.instructions.transaction_field import Fee
+from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.utils.algorand_constants import MAX_TRANSACTION_COST
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
+    from tealer.teal.context.block_transaction_context import BlockTransactionContext
 
 
 def _is_fee_check(ins1: Instruction, ins2: Instruction) -> bool:
@@ -87,63 +84,6 @@ balance of the account that signed the contract as the fee will be deducted from
 Always check that transaction fee which can be accessed using `txn Fee` in Teal is less than certain limit and fail if that's not the case.
 """
 
-    def _check_fee(
-        self,
-        bb: BasicBlock,
-        current_path: List[BasicBlock],
-        paths_without_check: List[List[BasicBlock]],
-    ) -> None:
-        """Find execution paths with missing Fee check.
-
-        This function recursively explores the Control Flow Graph(CFG) of the
-        contract and reports execution paths with missing Fee check.
-
-        This function is "in place", modifies arguments with the data it is
-        supposed to return.
-
-        Args:
-            bb: Current basic block being checked(whose execution is simulated.)
-            current_path: Current execution path being explored.
-            paths_without_check:
-                Execution paths with missing Fee check. This is a
-                "in place" argument. Vulnerable paths found by this function are
-                appended to this list.
-        """
-
-        # check for loops
-        if bb in current_path:
-            return
-
-        current_path = current_path + [bb]
-
-        stack: List[Instruction] = []
-
-        for ins in bb.instructions:
-
-            if isinstance(ins, (Less, LessE, Greater, GreaterE, Eq)):
-                if len(stack) >= 2:
-                    one = stack[-1]
-                    two = stack[-2]
-                    # int .. <[=?] txn fee or txn fee <[=?] int .. or
-                    # int .. >[=?] txnfee or txn fee >[=?] int .. or
-                    #  txn fee == int .. or txn fee == int ..
-                    if _is_fee_check(one, two) or _is_fee_check(two, one):
-                        return
-
-            if isinstance(ins, Return):
-                if len(ins.prev) == 1:
-                    prev = ins.prev[0]
-                    if isinstance(prev, Int) and prev.value == 0:
-                        return
-
-                paths_without_check.append(current_path)
-                return
-
-            stack.append(ins)
-
-        for next_bb in bb.next:
-            self._check_fee(next_bb, current_path, paths_without_check)
-
     def detect(self) -> "SupportedOutput":
         """Detect execution paths with missing Fee check.
 
@@ -153,8 +93,14 @@ Always check that transaction fee which can be accessed using `txn Fee` in Teal 
             information.
         """
 
-        paths_without_check: List[List[BasicBlock]] = []
-        self._check_fee(self.teal.bbs[0], [], paths_without_check)
+        def checks_field(block_ctx: "BlockTransactionContext") -> bool:
+            # returns True if fee is bounded by some unknown value
+            # or is bounded by some known value less than maximum transaction cost.
+            return block_ctx.max_fee_unknown or block_ctx.max_fee <= MAX_TRANSACTION_COST
+
+        paths_without_check: List[List[BasicBlock]] = detect_missing_tx_field_validations(
+            self.teal.bbs[0], checks_field
+        )
 
         description = "Lack of fee check allows draining the funds of sender account,"
         description += "contract account or signer of delegate contract."

--- a/tealer/utils/algorand_constants.py
+++ b/tealer/utils/algorand_constants.py
@@ -2,3 +2,11 @@ MAX_GROUP_SIZE = 16
 MIN_ALGORAND_FEE = 1000  # in micro algos
 ZERO_ADDRESS = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEVAL4QAJS7JHB4"
 MAX_UINT64 = (1 << 64) - 1  # 2**64 - 1
+# Maximum number of inner transactions a group transaction can have.
+MAX_NUM_INNER_TXN = 256
+
+# Over estimation of maximum cost a transaction can consume.
+# There can be a maximum of 256 inner transactions in a group.
+# There can be maximum of 16 transactions in a group.
+# Each inner txn and txn costs MIN_ALGORAND Fee
+MAX_TRANSACTION_COST = (MAX_GROUP_SIZE + MAX_NUM_INNER_TXN) * MIN_ALGORAND_FEE

--- a/tests/detectors/can_close_account.py
+++ b/tests/detectors/can_close_account.py
@@ -369,7 +369,7 @@ CAN_CLOSE_ACCOUNT_GROUP_INDEX_3_VULNERABLE_PATHS: List[List[int]] = []  # not vu
 
 
 CAN_CLOSE_ACCOUNT_2 = """
-# pragma version 4
+#pragma version 4
 txn Receiver
 addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
 ==
@@ -422,4 +422,5 @@ new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[i
     (CAN_CLOSE_ACCOUNT_2, CanCloseAsset, []),
     (CAN_CLOSE_ACCOUNT_2, MissingRekeyTo, []),
     (CAN_CLOSE_ACCOUNT_2, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT, MissingFeeCheck, []),
 ]

--- a/tests/detectors/can_close_account.py
+++ b/tests/detectors/can_close_account.py
@@ -396,6 +396,61 @@ return
 
 CAN_CLOSE_ACCOUNT_2_VULNERABLE_PATHS: List[List[int]] = [[0]]
 
+CAN_CLOSE_ACCOUNT_RETURN_1 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+return                  # return value is the result of the expression
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS: List[List[int]] = [[0]]
+
+CAN_CLOSE_ACCOUNT_RETURN_2 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+gtxn 0 CloseRemainderTo
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==                  // Not vulnerable to CanCloseAccount as well.
+&&
+return
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_2_VULNERABLE_PATHS: List[List[int]] = []
 
 new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     (
@@ -423,4 +478,12 @@ new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[i
     (CAN_CLOSE_ACCOUNT_2, MissingRekeyTo, []),
     (CAN_CLOSE_ACCOUNT_2, MissingFeeCheck, []),
     (CAN_CLOSE_ACCOUNT, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAccount, CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAccount, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingFeeCheck, []),
 ]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -6,7 +6,7 @@ from tealer.detectors.abstract_detector import AbstractDetector
 from tealer.teal.parse_teal import parse_teal
 
 from tests.detectors.groupsize import missing_group_size_tests
-from tests.detectors.fee_check import missing_fee_check_tests
+from tests.detectors.fee_check import missing_fee_check_tests, new_missing_fee_tests
 from tests.detectors.can_close_account import can_close_account_tests, new_can_close_account_tests
 from tests.detectors.can_close_asset import can_close_asset_tests, new_can_close_asset_tests
 from tests.detectors.can_delete import can_delete_tests, new_can_delete_tests
@@ -44,6 +44,7 @@ ALL_NEW_TESTS: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     *new_can_close_asset_tests,
     *new_can_update_tests,
     *new_can_delete_tests,
+    *new_missing_fee_tests,
 ]
 
 


### PR DESCRIPTION
The fee detector just checks for the following pattern and reports paths if an execution path does not have this pattern of instructions.
```
txn Fee
int <...>
[ == | != | < | <= | ..]
```

This PR updates the detector to use possible fee values calculated by transaction field analysis. Fee detector reports paths if it is not checked against some non-integer or is checked against a Large fee value.
