### PR TITLE
Store original source code for instructions and add colors to CFG edges

### DIFF
--- a/tealer/teal/basic_blocks.py
+++ b/tealer/teal/basic_blocks.py
@@ -42,6 +42,7 @@ class BasicBlock:  # pylint: disable=too-many-instance-attributes
         self._transaction_context = BlockTransactionContext()
         self._callsub_block: Optional[BasicBlock] = None
         self._sub_return_point: Optional[BasicBlock] = None
+        self._tealer_comments: List[str] = []
 
     def add_instruction(self, instruction: Instruction) -> None:
         """Append instruction to this basic block.
@@ -157,6 +158,15 @@ class BasicBlock:  # pylint: disable=too-many-instance-attributes
     @property
     def transaction_context(self) -> "BlockTransactionContext":
         return self._transaction_context
+
+    @property
+    def tealer_comments(self) -> List[str]:
+        """Additional comments added by tealer for each basic block in the output CFG."""
+        return self._tealer_comments
+
+    @tealer_comments.setter
+    def tealer_comments(self, comments: List[str]) -> None:
+        self._tealer_comments = comments
 
     def __str__(self) -> str:
         ret = ""

--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -498,6 +498,7 @@ def parse_line(line: str) -> Optional[instructions.Instruction]:
     if not line.strip():
         return None
 
+    source_code_line = line
     fields = _split_instruction_into_tokens(line)
     comment = ""
     if fields[-1].startswith("//"):
@@ -531,6 +532,7 @@ def parse_line(line: str) -> Optional[instructions.Instruction]:
 
     if ins is not None:
         ins.comment = comment
+        ins.source_code = source_code_line
         return ins
 
     line = " ".join(fields)
@@ -540,8 +542,12 @@ def parse_line(line: str) -> Optional[instructions.Instruction]:
         if line.startswith(key):
             ins = f(line[len(key) :].strip())
             ins.comment = comment
+            ins.source_code = source_code_line
             return ins
 
     # line is checked to not empty at the start of the function.
     print(f"Not found {line}")
-    return instructions.UnsupportedInstruction(line)
+    ins = instructions.UnsupportedInstruction(line)
+    ins.source_code = source_code_line
+    ins.comment = ins.comment
+    return ins

--- a/tests/pyteal_parsing/normal_application.py
+++ b/tests/pyteal_parsing/normal_application.py
@@ -42,8 +42,12 @@ normal_application_approval_program = compileTeal(
     mode=Mode.Application,
     version=7,
     optimize=OptimizeOptions(scratch_slots=False),
+    assembleConstants=True,
 )
 
 _clear_program = compileTeal(
     clear_program(), mode=Mode.Application, version=7, optimize=OptimizeOptions(scratch_slots=False)
 )
+
+if __name__ == "__main__":
+    print(normal_application_approval_program)


### PR DESCRIPTION
Changes:
- Tealer now stores original source code of instructions. Also, comments not part of the instructions are saved and outputted in the CFG dot file.
- Adds helpers to add comments to basic blocks and instructions. These comments are outputted in the CFG.
- Adds colors to edges to differentiate jump branch, default branch, and call edge.
- Adds border color to basic blocks belonging to a subroutine in the output CFG.

E.g
![cfg_dot](https://user-images.githubusercontent.com/55708799/214122795-48bd4923-219b-45c4-9bf7-09959fd9a1b7.png)

Basic-block level tealer comments are added in a separate row at the top of the block. Every basic block would contain a comment containing basic block's id and the total cost of executing instructions in that basic block.

Instruction level tealer comments are displayed directly above the instruction. For example, see "ApplicationID is 0 in Creation Txn" on `txn ApplicationId` instruction in basic-block 0.

All tealer added comments are made **bold** for better distinction.

Entry block of a subroutine contains a comment describing its name, see **"Subroutine addupton_0"** comment in basic-block 12.

Instructions `BZ/BNZ` either jump to a location in the code and execute from there or continue the execution from the next instruction in the source code.
Outgoing edges of basic blocks ending with `BZ/BNZ` have a "green" outgoing edge and "red" outgoing edge. "green" edge is taken if the condition to take the **JUMP** is satisfied (jump branch) and "red" edge represents the default branch(no jump is taken).

Additionally, the edge representing a call to a subroutine has an orange color to differentiate normal branches from subroutine calls.
And each of the basic blocks that are part of a subroutine has an "orange" border color for the same reason.

Note that, currently all subroutine blocks have the same border color i.e blocks of Subroutine 1, subroutine 2, and ... have the same orange border color. However, it might be best to use different border colors for each of subroutine for better UX.