### PR TITLE
Update txn field analysis to use comparison-return pattern

### DIFF
--- a/tests/detectors/can_close_account.py
+++ b/tests/detectors/can_close_account.py
@@ -396,6 +396,61 @@ return
 
 CAN_CLOSE_ACCOUNT_2_VULNERABLE_PATHS: List[List[int]] = [[0]]
 
+CAN_CLOSE_ACCOUNT_RETURN_1 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+return                  # return value is the result of the expression
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS: List[List[int]] = [[0]]
+
+CAN_CLOSE_ACCOUNT_RETURN_2 = """
+#pragma version 4
+txn Receiver
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==
+txn Fee
+int 10000
+<
+&&
+txn RekeyTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+global GroupSize
+int 1
+==
+&&
+gtxn 0 CloseRemainderTo
+addr 6ZIOGDXGSQSL4YINHLKCHYRV64FSN4LTUIQ6A4VWYK36FXFF42VI2UV7SM
+==                  // Not vulnerable to CanCloseAccount as well.
+&&
+return
+"""
+
+CAN_CLOSE_ACCOUNT_RETURN_2_VULNERABLE_PATHS: List[List[int]] = []
 
 new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     (
@@ -423,4 +478,12 @@ new_can_close_account_tests: List[Tuple[str, Type[AbstractDetector], List[List[i
     (CAN_CLOSE_ACCOUNT_2, MissingRekeyTo, []),
     (CAN_CLOSE_ACCOUNT_2, MissingFeeCheck, []),
     (CAN_CLOSE_ACCOUNT, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAccount, CAN_CLOSE_ACCOUNT_RETURN_1_VULNERABLE_PATHS),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_1, MissingFeeCheck, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAccount, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, CanCloseAsset, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingRekeyTo, []),
+    (CAN_CLOSE_ACCOUNT_RETURN_2, MissingFeeCheck, []),
 ]


### PR DESCRIPTION
```
txn RekeyTo
global ZeroAddress
==
return
```
^Result of comparison is directly used as the return value. The comparison's result should be True for the successful execution of the contract implying that RekeyTo should have ZeroAddress. 

This PR adds support to collect information from validations using the pattern `Return(...)`. 