### PR TITLE
Refactor cfg_to_dot output helpers

### DIFF
--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -418,7 +418,7 @@ def handle_print_cfg(args: argparse.Namespace, teal: "Teal") -> None:
 
     filename = Path(args.dest) / Path(filename)
     print(f"\nCFG exported to file: {filename}")
-    cfg_to_dot(teal.bbs, filename)
+    cfg_to_dot(teal.bbs, filename=filename)
 
 
 def handle_detectors_and_printers(

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -588,7 +588,7 @@ def parse_teal(source_code: str) -> Teal:
     for bb in teal.bbs:
         bb.teal = teal
         # Add tealer comment of cost and id
-        bb.tealer_comments.insert(0, f"id = {bb.idx}; cost = {bb.cost}")
+        bb.tealer_comments.insert(0, f"block_id = {bb.idx}; cost = {bb.cost}")
 
     _apply_transaction_context_analysis(teal)
 

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -5,13 +5,9 @@ and display different types of output formats used by tealer detectors
 and printers.
 
 Functions:
-    cfg_to_dot(bbs: List[BasicBlock], filename: Path) -> None:
+    cfg_to_dot(bbs: List[BasicBlock], config: Optional[CFGDotConfig]=None, filename: Optional[Path]=None) -> None:
         Exports dot representation of CFG represented by :bbs: in
         dot format to given filename.
-
-    execution_path_to_dot(cfg: List[BasicBlock], path: List[BasicBlock]) -> str:
-        Returns dot representation of the given control flow graph :cfg:
-        with basic blocks present in :path: highlighted.
 
 Classes:
     ExecutionPaths: Class to represent results of a detector, stores
@@ -25,16 +21,34 @@ Types:
 
 import html
 from pathlib import Path
-from typing import List, TYPE_CHECKING, Dict
+from typing import List, TYPE_CHECKING, Dict, Callable, Optional
+from dataclasses import dataclass
 
-from tealer.teal.instructions.instructions import BZ, BNZ, Callsub, Retsub
+from tealer.teal.instructions.instructions import BZ, BNZ, Callsub, Retsub, Label
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
     from tealer.teal.instructions.instructions import Instruction
 
 
-def _instruction_to_dot(ins: "Instruction", set_port: bool = True) -> str:
+@dataclass
+class CFGDotConfig:  # pylint: disable=too-many-instance-attributes
+    ins_additional_comments: Callable[["Instruction"], List[str]] = lambda _x: []
+    # include additional tealer comments at the top of the block.
+    bb_additional_comments: Callable[["BasicBlock"], List[str]] = lambda _x: []
+    # don't include edge bi -> bj in dot output?
+    ignore_edge: Callable[["BasicBlock", "BasicBlock"], bool] = lambda _bi, _bj: False
+    # Apply colors to different types of edges?
+    color_edges: bool = True
+    jump_branch_color: str = "#36d899"  # "green"
+    default_branch_color: str = "#e0182b"  # "red"
+    callsub_edge_color: str = "#ff8c00"  # "orange"
+    remaining_edges_color: str = "BLACK"
+    comments_cell_border_size: int = 2  # size of basic block comments cell
+    bb_border_color: Callable[["BasicBlock"], str] = lambda _x: "BLACK"
+
+
+def _instruction_to_dot(ins: "Instruction", config: CFGDotConfig) -> str:
     """Return dot representation of Teal instruction.
 
     string representation of the instruction is represented as
@@ -42,6 +56,7 @@ def _instruction_to_dot(ins: "Instruction", set_port: bool = True) -> str:
 
     Args:
         ins: teal instruction to represent in dot format.
+        config: configuration for dot output
 
     Returns:
         string containing the dot representation of the given
@@ -57,34 +72,50 @@ def _instruction_to_dot(ins: "Instruction", set_port: bool = True) -> str:
     """
 
     # ins.source_code stores the indentation and whitespace. strip them
-    ins_str = html.escape(ins.source_code.strip(), quote=True)
+    ins_str = html.escape(ins.source_code.strip(), quote=True)  # original teal code
     # make callsub and retsub bold and italic
     if isinstance(ins, (Callsub, Retsub)):
         ins_str = f"<B><I>{ins_str}</I></B>"
+
+    # format:
+    # <B>
+    #   // tealer_comment_1 <BR/>
+    #   // tealer_comment_2 <BR/>
+    # </B>
+    # <BR/>
     tealer_comments = ""
-    if ins.tealer_comments:
-        tealer_comments = "<BR/>".join(
-            f"// {html.escape(comment.strip(), quote=True)}" for comment in ins.tealer_comments
-        )
+    if ins.tealer_comments + config.ins_additional_comments(ins):
+        sanitized_comments = [
+            html.escape(comment.strip(), quote=True)
+            for comment in ins.tealer_comments + config.ins_additional_comments(ins)
+        ]
+        tealer_comments = "<BR/>".join(f"// {comment}" for comment in sanitized_comments)
         tealer_comments = f"<B>{tealer_comments}</B><BR/>"  # make them bold
+
+    # format:
+    #   // source_comment_1 <BR/>
+    #   // source_comment_2 <BR/>
     source_code_comments = ""
     if ins.comments_before_ins:
-        source_code_comments = "<BR/>".join(
-            f"{html.escape(comment.strip(), quote=True)}" for comment in ins.comments_before_ins
-        )
+        sanitized_comments = [
+            html.escape(comment.strip(), quote=True) for comment in ins.comments_before_ins
+        ]
+        source_code_comments = "<BR/>".join(f"{comment}" for comment in sanitized_comments)
         source_code_comments += "<BR/>"
-    port = ""
-    if set_port:
-        # port is used as a link destination.
-        port = f'PORT="{ins.line}"'
-    cell_i_contents = f"{tealer_comments}{source_code_comments}{ins.line}. {ins_str}"
-    cell_i = f'<TD ALIGN="LEFT" BALIGN="LEFT" {port} COLOR="BLACK">{cell_i_contents}</TD>'
-    return f"<TR>{cell_i}</TR>\n"
+
+    cell_i = (
+        "<TR>"
+        '<TD ALIGN="LEFT" BALIGN="LEFT" COLOR="BLACK">'
+        f"{tealer_comments}"
+        f"{source_code_comments}"
+        f"{ins.line}. {ins_str}"
+        "</TD>"
+        "</TR>\n"
+    )
+    return cell_i
 
 
-def _bb_to_dot(  # pylint: disable=too-many-locals
-    bb: "BasicBlock", border_color: str = "BLACK", color_edges: bool = True
-) -> str:
+def _bb_to_dot(bb: "BasicBlock", config: CFGDotConfig) -> str:
     """Return dot representation of basic block.
 
     Basic Blocks are represented in the form of a tabel in dot.
@@ -92,79 +123,80 @@ def _bb_to_dot(  # pylint: disable=too-many-locals
 
     Args:
         bb: basic block to represent in dot format.
+        config: configuration for dot output
 
     Returns:
         string containing the dot representation of the given
         basic block.
     """
 
-    table_prefix = f'<<TABLE ALIGN="LEFT" COLOR="{border_color}">\n'
-    table_suffix = "</TABLE>> labelloc=top shape=plain\n"
-    comments_cell = ""
-    table_rows = ""
-    graph_edges = ""
+    # format: `{source_node}:s -> {dest_node}{dest_port}:n [color=""];`
+    def graph_edge_str(src_bb: "BasicBlock", dest_bb: "BasicBlock", edge_color: str) -> str:
+        if config.ignore_edge(src_bb, dest_bb):
+            return ""
+        return f'{src_bb.idx}:s -> {dest_bb.idx}:{dest_bb.entry_instr.line}:n [color="{edge_color}"];\n'
 
-    if bb.tealer_comments:
-        # Increase the border size to differentiate the comments cell/row.
-        comments_cell_border_size = 2
-        tealer_comments = "<BR/>".join(
-            f"// {html.escape(comment.strip(), quote=True)}" for comment in bb.tealer_comments
-        )
-        tealer_comments = f"<B>{tealer_comments}</B><BR/>"  # make them bold
-        comments_cell = f'<TR><TD COLOR="BLACK" ALIGN="LEFT" BALIGN="LEFT" PORT="{bb.entry_instr.line}" BORDER="{comments_cell_border_size}">{tealer_comments}</TD></TR>\n'
+    # format:
+    #     <TR> tealer_comments and additional_comments </TR>
+    #     <TR> instruction_1                           </TR>
+    #     <TR> instruction_2                           </TR>
+    #     ...
+    table_rows: List[str] = []
 
-        table_rows += comments_cell
-        # if there's a comments_cell then don't add port(link) to the first instruction cell.
-        table_rows += _instruction_to_dot(bb.entry_instr, set_port=False)
-    else:
-        table_rows += _instruction_to_dot(bb.entry_instr)
+    santized_comments = [
+        html.escape(comment.strip(), quote=True)
+        for comment in bb.tealer_comments + config.bb_additional_comments(bb)
+    ]
+    comments_cell_str = (
+        "<TR>"
+        f'<TD COLOR="BLACK" ALIGN="LEFT" BALIGN="LEFT" PORT="{bb.entry_instr.line}" BORDER="{config.comments_cell_border_size}">'
+        "<B>"
+        f'{"<BR/>".join(f"// {comment}" for comment in santized_comments)}'
+        "</B>"
+        "</TD>"
+        "</TR>\n"
+    )
 
-    for ins in bb.instructions[1:]:
-        table_rows += _instruction_to_dot(ins)
+    table_rows.append(comments_cell_str)
 
-    jump_branch_color = ""
-    default_branch_color = ""
-    callsub_edge_color = ""
-    remaining_edges_color = ""
-    if color_edges:
-        jump_branch_color = "#36d899"  # "green"
-        default_branch_color = "#e0182b"  # "red"
-        callsub_edge_color = "#ff8c00"  # "orange"
-        # remaining_edges_color = ""  # "#1155ff"
+    for ins in bb.instructions:
+        table_rows.append(_instruction_to_dot(ins, config))
 
-    if isinstance(bb.exit_instr, (BZ, BNZ)):
-        # color graph edges if exit instruction is BZ or BNZ.
-        if len(bb.next) == 1:
-            # happens when bz/bnz is the last instruction in the contract and there is no default branch
-            default_branch = None
-            jump_branch = bb.next[0]
-        else:
-            default_branch = bb.next[0]
-            jump_branch = bb.next[1]
+    graph_edges: List[str] = []
+    if config.color_edges and isinstance(bb.exit_instr, (BZ, BNZ, Callsub)):
+        if isinstance(bb.exit_instr, (BZ, BNZ)):
+            # color graph edges if exit instruction is BZ or BNZ.
+            if len(bb.next) == 1:
+                # happens when bz/bnz is the last instruction in the contract and there is no default branch
+                default_branch = None
+                jump_branch = bb.next[0]
+            else:
+                default_branch = bb.next[0]
+                jump_branch = bb.next[1]
 
-        exit_loc = bb.exit_instr.line
-        if default_branch is not None:
-            default_entry_loc = default_branch.entry_instr.line
-            graph_edges += f'{bb.idx}:{exit_loc}:s -> {default_branch.idx}:{default_entry_loc}:n [color="{default_branch_color}"];\n'
-
-        jump_entry_loc = jump_branch.entry_instr.line
-        graph_edges += f'{bb.idx}:{exit_loc}:s -> {jump_branch.idx}:{jump_entry_loc}:n [color="{jump_branch_color}"];\n'
-    elif isinstance(bb.exit_instr, Callsub):
-        # make callsub instruction -> subroutine edge orange.
-        callsub_branch = bb.next[0]
-        exit_loc = bb.exit_instr.line
-        subroutine_loc = callsub_branch.entry_instr.line
-        graph_edges += f'{bb.idx}:{exit_loc}:s -> {callsub_branch.idx}:{subroutine_loc}:n [color="{callsub_edge_color}"];\n'
+            if default_branch is not None:
+                graph_edges.append(graph_edge_str(bb, default_branch, config.default_branch_color))
+            graph_edges.append(graph_edge_str(bb, jump_branch, config.jump_branch_color))
+        elif isinstance(bb.exit_instr, Callsub):
+            # make callsub instruction -> subroutine edge orange.
+            callsub_branch = bb.next[0]
+            graph_edges.append(graph_edge_str(bb, callsub_branch, config.callsub_edge_color))
     else:
         for next_bb in bb.next:
-            exit_loc = bb.exit_instr.line
-            entry_loc = next_bb.entry_instr.line
-            graph_edges += f'{bb.idx}:{exit_loc}:s -> {next_bb.idx}:{entry_loc}:n [color="{remaining_edges_color}"];\n'
-    table = table_prefix + table_rows + table_suffix
-    return f"{bb.idx}[label={table}]" + graph_edges
+            graph_edges.append(graph_edge_str(bb, next_bb, config.remaining_edges_color))
+
+    table_str = (
+        f'<<TABLE ALIGN="LEFT" COLOR="{config.bb_border_color(bb)}">\n'
+        f'{"".join(table_rows)}'
+        "</TABLE>> labelloc=top shape=plain\n"
+    )
+
+    return f'{bb.idx}[label={table_str}] {"".join(graph_edges)}'
 
 
-def cfg_to_dot(bbs: List["BasicBlock"], filename: Path) -> None:
+def cfg_to_dot(  # pylint: disable=too-many-locals
+    bbs: List["BasicBlock"], config: Optional[CFGDotConfig] = None, filename: Optional[Path] = None
+) -> Optional[str]:
     """Export control flow graph to a dot file.
 
     The control flow graph is represented as a digraph in dot.
@@ -174,58 +206,65 @@ def cfg_to_dot(bbs: List["BasicBlock"], filename: Path) -> None:
     Args:
         bbs: list of basic blocks representing the control
             flow graph.
+        config: optional configuration for dot output.
         filename: name of the file to save the dot representation
             of control flow graph in.
+
     """
 
-    dot_output = "digraph g{\n ranksep = 1 \n overlap = scale \n"
     teal = bbs[0].teal
     assert teal is not None
     subroutine_block_idx = set(
         bb.idx for subroutine_bbs in teal.subroutines for bb in subroutine_bbs
     )
-    subroutine_blocks_border_color = "#ff6600"
-    for bb in bbs:
-        # TODO: have different color for each subroutine. Yellow for subroutine 1, orange for 2,...??
-        if bb.idx in subroutine_block_idx:
-            dot_output += _bb_to_dot(bb, subroutine_blocks_border_color)
-        else:
-            dot_output += _bb_to_dot(bb)
+    # responsible for "box" around each subroutine.
+    subroutine_clusters: List[str] = []
+    for i, subroutine_bbs in enumerate(teal.subroutines):
+        assert isinstance(subroutine_bbs[0].entry_instr, Label)
+        cluster_name = i
+        subroutine_name = str(subroutine_bbs[0].entry_instr.label)
+        cluster_nodes = " ".join(str(bb.idx) for bb in subroutine_bbs)
+        # TODO: Add number of args and return values to label in the future.
+        subgraph_dot = f"""
+            subgraph cluster_{cluster_name} {{
+                label = "Subroutine {subroutine_name}";
+                graph[style=dashed];
+                {cluster_nodes};
+            }}
+        """
+        subroutine_clusters.append(subgraph_dot)
 
-    dot_output += "}"
+    # default config
+    if not config:
+        config = CFGDotConfig()
+        # border color for subroutine blocks
+        subroutine_blocks_border_color = "#000066"
+        config.bb_border_color = (
+            lambda bb: "BLACK"
+            if bb.idx not in subroutine_block_idx
+            else subroutine_blocks_border_color
+        )
+
+    bb_nodes_dot: List[str] = []
+    for bb in bbs:
+        bb_nodes_dot.append(_bb_to_dot(bb, config))
+
+    subroutine_clusters_str = "\n".join(subroutine_clusters)
+    bb_nodes_str = "\n".join(bb_nodes_dot)
+
+    dot_output = (
+        "digraph g{\n ranksep = 1 \n overlap = scale \n"
+        f"{subroutine_clusters_str}\n"
+        f"{bb_nodes_str}\n"
+        "}"
+    )
+
+    if filename is None:
+        return dot_output
 
     with open(filename, "w", encoding="utf-8") as f:
         f.write(dot_output)
-
-
-def execution_path_to_dot(cfg: List["BasicBlock"], path: List["BasicBlock"]) -> str:
-    """Return CFG with a execution path highlighted in dot format.
-
-    The CFG is represented as a digraph in dot. nodes are basic blocks
-    of the CFG. The execution path, which is a sequence of basic blocks
-    are highlighted using a color in the dot representation.
-
-    Args:
-        cfg: Control Flow Graph of the contract.
-        path: An execution path to highlight in the given CFG.
-
-    Returns:
-        string containg the dot representation of CFG where nodes
-        corresponding to the given execution path are highlighted
-        using red color.
-    """
-
-    dot_output = "digraph g{\n ranksep = 1 \n overlap = scale \n"
-
-    for bb in cfg:
-        if bb in path:
-            dot_output += _bb_to_dot(bb, border_color="RED", color_edges=False)
-        else:
-            dot_output += _bb_to_dot(bb, color_edges=False)
-
-    dot_output += "}"
-
-    return dot_output
+    return None
 
 
 class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
@@ -331,7 +370,9 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
         if len(self.paths) == 0:
             print("\tdetector didn't find any vulnerable paths.")
             return
-
+        # cfg_to_dot config
+        config = CFGDotConfig()
+        config.color_edges = False
         print("\tfollowing are the vulnerable paths found")
         if not all_paths_in_one:
 
@@ -343,8 +384,12 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
                 filename = dest / Path(f"{self._filename}_{idx}.dot")
                 print(f"\t\t check file: {filename}")
 
-                with open(filename, "w", encoding="utf-8") as f:
-                    f.write(execution_path_to_dot(self.cfg, path))
+                config.bb_border_color = (
+                    lambda bb: "BLACK"
+                    if bb not in path  # pylint: disable=cell-var-from-loop
+                    else "RED"
+                )
+                cfg_to_dot(self.cfg, config, filename)
         else:
             bbs_to_highlight = []
 
@@ -358,8 +403,8 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
             filename = dest / Path(f"{self._filename}.dot")
             print(f"\t\t check file: {filename}")
 
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(execution_path_to_dot(self.cfg, bbs_to_highlight))
+            config.bb_border_color = lambda bb: "BLACK" if bb not in bbs_to_highlight else "RED"
+            cfg_to_dot(self.cfg, config, filename)
 
     def to_json(self) -> Dict:
         """Return json representation of detector result.


### PR DESCRIPTION
- Refactored helper functions used to output dot files.
- Updated the dot output to have a border around each subroutine.
- Changed the **id** to **block_id** in the dot output.

E.g:
![cfg dot](https://user-images.githubusercontent.com/55708799/214789554-f8296727-be36-46ab-81d1-489cdf109136.png)

---

detector output:
![can_delete_1 dot](https://user-images.githubusercontent.com/55708799/214789619-89f2074f-a2e5-4086-a6b2-a5f29b155f2c.png)
