### PR TITLE
Add support to filter execution paths from output

### DIFF
--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -257,6 +257,14 @@ def parse_args(
         default=False,
     )
 
+    group_detector.add_argument(
+        "--filter-paths",
+        help="Excludes execution paths matching the regex from detector's output.",
+        action="store",
+        dest="filter_paths",
+        default=None,
+    )
+
     group_printer.add_argument(
         "--list-printers",
         help="List available printers",
@@ -526,6 +534,9 @@ def main() -> None:
     except TealerException as e:
         error = str(e)
 
+    if args.filter_paths is not None:
+        for detector_result in results_detectors:
+            detector_result.filter_paths(args.filter_paths)
     handle_output(args, results_detectors, _results_printers, error)
 
 

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -20,6 +20,7 @@ Types:
 """
 
 import html
+import re
 from pathlib import Path
 from typing import List, TYPE_CHECKING, Dict, Callable, Optional
 from dataclasses import dataclass
@@ -349,6 +350,22 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
     def help(self, h: str) -> None:
         self._help = h
 
+    @staticmethod
+    def _short_notation(path_bbs: List["BasicBlock"]) -> str:
+        """Return short notation representation of path"""
+        return " -> ".join(map(str, [bb.idx for bb in path_bbs]))
+
+    def filter_paths(self, filter_regex: str) -> None:
+        if filter_regex == "":
+            return
+        filtered_paths: List[List["BasicBlock"]] = []
+        for path in self._paths:
+            if re.search(filter_regex, self._short_notation(path)) is None:
+                # short notation does not contain string matching the regex
+                filtered_paths.append(path)
+        self._paths = filtered_paths
+        return
+
     def write_to_files(self, dest: Path, all_paths_in_one: bool = False) -> None:
         """Export execution paths to dot files.
 
@@ -378,7 +395,7 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
 
             for idx, path in enumerate(self._paths, start=1):
 
-                short = " -> ".join(map(str, [bb.idx for bb in path]))
+                short = self._short_notation(path)
                 print(f"\n\t\t path: {short}")
 
                 filename = dest / Path(f"{self._filename}_{idx}.dot")
@@ -394,7 +411,7 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
             bbs_to_highlight = []
 
             for path in self._paths:
-                short = " -> ".join(map(str, [bb.idx for bb in path]))
+                short = self._short_notation(path)
                 print(f"\t\t path: {short}")
                 for bb in path:
                     if bb not in bbs_to_highlight:


### PR DESCRIPTION
Adds a command line argument `--filter-paths`

```
  --filter-paths FILTER_PATHS
                        Excludes execution paths matching the regex from detector's output.
```

filter-paths option takes in a regex and uses it to filter reported execution paths by detector(s). The regex is matched against the short form notation of the execution path.
```py
short_form = " -> ".join(block_id(block) for block in path)
```
Ex:
```sh
$ tealer test_code.teal --detect feeCheck
...
		 path: 0 -> 1 -> 2 -> 3 -> 4 -> 7
		 check file: missing_fee_check_1.dot

		 path: 0 -> 1 -> 2 -> 3 -> 8
		 check file: missing_fee_check_2.dot

		 path: 0 -> 1 -> 10
		 check file: missing_fee_check_3.dot

		 path: 0 -> 11 -> 13 -> 14 -> 16 -> 12
		 check file: missing_fee_check_4.dot
```
Using filter-paths
```sh
$ tealer test_code.teal --detect feeCheck --filter-paths "1 -> . -> 3"
...
		 path: 0 -> 1 -> 10
		 check file: missing_fee_check_1.dot

		 path: 0 -> 11 -> 13 -> 14 -> 16 -> 12
		 check file: missing_fee_check_2.dot
```