### PR TITLE
Update GroupSize detector to consider usage of absolute indexes

### DIFF
--- a/tealer/analyses/dataflow/int_fields.py
+++ b/tealer/analyses/dataflow/int_fields.py
@@ -22,6 +22,7 @@ from tealer.analyses.utils.stack_ast_builder import KnownStackValue, UnknownStac
 if TYPE_CHECKING:
     from tealer.teal.instructions.instructions import Instruction
 
+# TODO: Change GroupSize, GroupIndex values representation to something similar of FeeValue.
 group_size_key = "GroupSize"
 group_index_key = "GroupIndex"
 analysis_keys = [group_size_key, group_index_key]

--- a/tealer/detectors/groupsize.py
+++ b/tealer/detectors/groupsize.py
@@ -8,62 +8,108 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.teal.global_field import GroupSize
-from tealer.teal.instructions.instructions import Return, Int, Global
+from tealer.teal.instructions.instructions import (
+    Gtxn,
+    Gtxna,
+    Gtxnas,
+    Gtxns,
+    Gtxnsa,
+    Gtxnsas,
+)
 from tealer.teal.teal import Teal
+from tealer.utils.algorand_constants import MAX_GROUP_SIZE
+from tealer.utils.analyses import is_int_push_ins
+from tealer.analyses.utils.stack_ast_builder import construct_stack_ast, UnknownStackValue
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
+    from tealer.teal.instructions.instructions import Instruction
 
 
 class MissingGroupSize(AbstractDetector):  # pylint: disable=too-few-public-methods
-    """Detector to find execution paths missing GroupSize check.
-
-    Algorand supports atomic transactions. Atomic transactions are a
-    group of transactions with the property that either all execute
-    successfully or None of them. It is necessary to check the group size
-    of the transaction based on the application.
-
-    This detector tries to find execution paths that approve the algorand
-    transaction("return 1") and doesn't check the CloseRemainderTo field.
-    """
+    """Detector to find execution paths using absoulte index without checking group size."""
 
     NAME = "groupSize"
-    DESCRIPTION = "Detect paths with a missing GroupSize check"
+    DESCRIPTION = "Detect paths using absolute indexes to validate group transaction without checking the group size"
     TYPE = DetectorType.STATEFULLGROUP
 
     IMPACT = DetectorClassification.MEDIUM
     CONFIDENCE = DetectorClassification.HIGH
 
     WIKI_TITLE = "Missing GroupSize check"
-    WIKI_DESCRIPTION = "Detect paths with a missing GroupSize check"
+    WIKI_DESCRIPTION = "Detect paths using absolute indexes to validate group transaction without checking the group size"
     WIKI_EXPLOIT_SCENARIO = """
-Consider the system consisting of two contracts, designed in such a way that first contract should be called by the
-first transaction of the group and second one by the second transaction. first contract handles all the verification,
-second contract approves the transfer of certain amount of assets if first contract approves its transaction.
-ofcourse, second contract verifies that first transaction in the group is call to the first contract.
+```py
+def mint_wrapped_algo() -> Expr:
+    validations = Assert(
+        And(
+            Gtxn[0].receiver() == Global.current_application_address(),
+            Gtxn[0].type_enum() == TxnType.Payment,
+        )
+    )
+    transfer_op = transfer_wrapped_algo(Txn.sender(), Gtxn[0].amount())
+    return Seq([validations, transfer_op, Approve()])
+```
 
-Possible exploit scenario is if second contract **only** verifies that first transaction is a call to first contract and
-doesn't check the group size to the expected value of `2`. The attacker could add an additional transaction(s) which are
-copy of second transaction i.e transfer of assets. As all the transactions to second contract only verify the first transaction,
-the attacker may possibly transfer all the assets by appending transactions which are each a copy of second transaction.
+Attacker sends following group transaction:
+    0. Payment of 1 million Algos to application address
+    1. Call mint_wrapped_algo
+    2. Call mint_wrapped_algo 
+    ...
+    15. Call mint_wrapped_algo
 
-Attacker can get upto 14 times(max atomic group size 16) more than the intended amount.
+Attacker receives 15 million wrapped-algos instead of 1 million wrapped-algos. Attacker exchanges the\
+wrapped-algo to Algo and steals 14 million Algos.
+
+More at [building-secure-contracts/not-so-smart-contracts/algorand/group_size_check](https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/algorand/group_size_check)
 """
     WIKI_RECOMMENDATION = """
-Always verify that group size(number of transactions in atomic group) is equal to what logic is expecting.
+Use ARC-4 ABI and relative indexes to verify the group transaction.
 """
 
     def __init__(self, teal: Teal):
         super().__init__(teal)
         self.results_number = 0
 
+    @staticmethod
+    def _accessed_using_absolute_index(bb: BasicBlock) -> bool:
+        """Return True if a instruction in bb access a field using absolute index
+
+        a. gtxn t f, gtxna t f i, gtxnas t f,
+        b. gtxns f, gtxnsa f i, gtxnsas f
+
+        Instructions in (a) take transaction index as a immediate argument.
+        Return True if bb contains any one of those instructions.
+
+        Instructions in (b) take transaction index from the stack.
+        `gtxns f` and `gtxnsa f i` take only one argument and it is the transaction index.
+        `gtxnsas f` takes two arguments and transaction index is the first argument.
+        Return True if the transaction index is pushed by an int instruction.
+        """
+        stack_gtxns_ins: List["Instruction"] = []
+        for ins in bb.instructions:
+            if isinstance(ins, (Gtxn, Gtxna, Gtxnas)):
+                return True
+            if isinstance(ins, (Gtxns, Gtxnsa, Gtxnsas)):
+                stack_gtxns_ins.append(ins)
+        if not stack_gtxns_ins:
+            return False
+        ast_values = construct_stack_ast(bb)
+        for ins in stack_gtxns_ins:
+            index_value = ast_values[ins].args[0]
+            if isinstance(index_value, UnknownStackValue):
+                continue
+            is_int, _ = is_int_push_ins(index_value.instruction)
+            if is_int:
+                return True
+        return False
+
     def _check_groupsize(
         self,
         bb: BasicBlock,
         current_path: List[BasicBlock],
-        # use_gtnx: bool,
         paths_without_check: List[List[BasicBlock]],
+        used_abs_index: bool,
     ) -> None:
         """Find execution paths with missing GroupSize check.
 
@@ -81,30 +127,29 @@ Always verify that group size(number of transactions in atomic group) is equal t
                 Execution paths with missing GroupSize check. This is a
                 "in place" argument. Vulnerable paths found by this function are
                 appended to this list.
+            used_abs_index: Should be True if absolute index in `current_path`.
         """
 
         # check for loops
         if bb in current_path:
             return
 
+        if MAX_GROUP_SIZE not in bb.transaction_context.group_sizes:
+            # GroupSize is checked
+            return
+
+        if not used_abs_index:
+            used_abs_index = self._accessed_using_absolute_index(bb)
+
         current_path = current_path + [bb]
-        for ins in bb.instructions:
-
-            if isinstance(ins, Global):
-                if isinstance(ins.field, GroupSize):
-                    return
-
-            if isinstance(ins, Return):
-                if len(ins.prev) == 1:
-                    prev = ins.prev[0]
-                    if isinstance(prev, Int):
-                        if prev.value == 0:
-                            return
-
+        if not bb.next:
+            # leaf block
+            if used_abs_index:
+                # accessed a field using absolute index in this path.
                 paths_without_check.append(current_path)
-
+            return
         for next_bb in bb.next:
-            self._check_groupsize(next_bb, current_path, paths_without_check)
+            self._check_groupsize(next_bb, current_path, paths_without_check, used_abs_index)
 
     def detect(self) -> "SupportedOutput":
         """Detect execution paths with missing GroupSize check.
@@ -116,9 +161,13 @@ Always verify that group size(number of transactions in atomic group) is equal t
         """
 
         paths_without_check: List[List[BasicBlock]] = []
-        self._check_groupsize(self.teal.bbs[0], [], paths_without_check)
+        self._check_groupsize(self.teal.bbs[0], [], paths_without_check, False)
 
-        description = "Lack of groupSize check found"
+        description = (
+            "Uses absolute indices to validate group transaction without checking the group size"
+        )
         filename = "missing_group_size"
 
-        return self.generate_result(paths_without_check, description, filename)
+        results = self.generate_result(paths_without_check, description, filename)
+        construct_stack_ast.cache_clear()
+        return results

--- a/tealer/utils/analyses.py
+++ b/tealer/utils/analyses.py
@@ -39,6 +39,7 @@ def is_int_push_ins(ins: Instruction) -> Tuple[bool, Optional[Union[int, str]]]:
         is_known, value = teal.get_int_constant(ins.index)
         if is_known:
             return True, value
+        return True, None
     return False, None
 
 
@@ -54,6 +55,7 @@ def is_byte_push_ins(ins: Instruction) -> Tuple[bool, Optional[str]]:
         is_known, value = teal.get_byte_constant(ins.index)
         if is_known:
             return True, value
+        return True, None
     return False, None
 
 

--- a/tests/detectors/groupsize.py
+++ b/tests/detectors/groupsize.py
@@ -1,6 +1,9 @@
+from typing import List
+
 from tealer.teal.instructions import instructions, transaction_field
 from tealer.detectors.all_detectors import MissingGroupSize
 from tealer.teal import global_field
+from tealer.teal.basic_blocks import BasicBlock
 
 from tests.utils import construct_cfg
 
@@ -102,7 +105,7 @@ bbs_links = [
 
 bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
 
-MISSING_GROUP_SIZE_VULNERABLE_PATHS = [[bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5]]]
+MISSING_GROUP_SIZE_VULNERABLE_PATHS: List[List[BasicBlock]] = []
 
 
 MISSING_GROUP_SIZE_LOOP = """
@@ -231,9 +234,7 @@ bbs_links = [
 
 bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
 
-MISSING_GROUP_SIZE_LOOP_VULNERABLE_PATHS = [
-    [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5], bbs[11], bbs[13]],
-]
+MISSING_GROUP_SIZE_LOOP_VULNERABLE_PATHS: List[List[BasicBlock]] = []
 
 
 missing_group_size_tests = [

--- a/tests/detectors/pyteal_group_size.py
+++ b/tests/detectors/pyteal_group_size.py
@@ -1,0 +1,160 @@
+from typing import List
+from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+
+from tealer.detectors.all_detectors import MissingGroupSize
+
+
+@Subroutine(TealType.none)
+def transfer_wrapped_algo(_receiver: Expr, _amount: Expr) -> Expr:
+    return Pop(Bytes("Inner txn to transfer assets"))
+
+
+@Subroutine(TealType.none)
+def transfer_algo(_receiver: Expr, _amount: Expr) -> Expr:
+    return Pop(Bytes("Inner txn to transfer Algos"))
+
+
+def mint_wrapped_algo() -> Expr:
+    validations = Assert(
+        And(
+            Gtxn[0].receiver() == Global.current_application_address(),
+            Gtxn[0].type_enum() == TxnType.Payment,
+        )
+    )
+    transfer_op = transfer_wrapped_algo(Txn.sender(), Gtxn[0].amount())
+    return Seq([validations, transfer_op, Approve()])
+
+
+def burn_wrapped_algo() -> Expr:
+    validations = Assert(
+        And(
+            # Gtxn[Int(x)] => int x; gtxn ...
+            Gtxn[Int(0)].receiver() == Global.current_application_address(),
+            Gtxn[Int(0)].type_enum() == TxnType.AssetTransfer,
+            Gtxn[Int(0)].xfer_asset() == Int(1337),
+        )
+    )
+    transfer_op = transfer_algo(Txn.sender(), Gtxn[0].asset_amount())
+    return Seq([validations, transfer_op, Approve()])
+
+
+def mint_wrapped_algo_fixed() -> Expr:
+    validations = Assert(
+        And(
+            # Gtxn[Int(x)] => int x; gtxn ...
+            Gtxn[Int(0)].receiver() == Global.current_application_address(),
+            Gtxn[0].type_enum() == TxnType.Payment,
+            Global.group_size() == Int(2),
+        )
+    )
+    transfer_op = transfer_wrapped_algo(Txn.sender(), Gtxn[0].amount())
+    return Seq([validations, transfer_op, Approve()])
+
+
+def burn_wrapped_algo_fixed() -> Expr:
+    index = Txn.group_index() - Int(1)
+    validations = Assert(
+        And(
+            Gtxn[index].receiver() == Global.current_application_address(),
+            Gtxn[index].type_enum() == TxnType.AssetTransfer,
+            Gtxn[index].xfer_asset() == Int(1337),
+        )
+    )
+    transfer_op = transfer_algo(Txn.sender(), Gtxn[index].asset_amount())
+    return Seq([validations, transfer_op, Approve()])
+
+
+def wrapped_approval_program_1() -> Expr:
+    return Cond(
+        [Txn.application_args[0] == Bytes("mint"), mint_wrapped_algo()],
+        [Txn.application_args[0] == Bytes("burn"), burn_wrapped_algo()],
+    )
+
+
+def wrapped_approval_program_2() -> Expr:
+    return Cond(
+        [Txn.application_args[0] == Bytes("mint"), mint_wrapped_algo_fixed()],
+        [Txn.application_args[0] == Bytes("burn"), burn_wrapped_algo()],
+    )
+
+
+def wrapped_approval_program_3() -> Expr:
+    return Cond(
+        [Txn.application_args[0] == Bytes("mint"), mint_wrapped_algo()],
+        [Txn.application_args[0] == Bytes("burn"), burn_wrapped_algo_fixed()],
+    )
+
+
+def wrapped_approval_program_4() -> Expr:
+    return Cond(
+        [Txn.application_args[0] == Bytes("mint"), mint_wrapped_algo_fixed()],
+        [Txn.application_args[0] == Bytes("burn"), burn_wrapped_algo_fixed()],
+    )
+
+
+wrapped_approval_program_1_teal = compileTeal(
+    wrapped_approval_program_1(),
+    mode=Mode.Application,
+    version=8,
+)
+
+wrapped_approval_program_1_vulnerable_paths: List[List[int]] = [
+    [0, 1, 3, 8, 4],  # burn
+    [0, 5, 7, 6],  # mint
+]
+
+wrapped_approval_program_2_teal = compileTeal(
+    wrapped_approval_program_2(),
+    mode=Mode.Application,
+    version=8,
+)
+
+wrapped_approval_program_2_vulnerable_paths: List[List[int]] = [
+    [0, 1, 3, 8, 4],
+]
+
+wrapped_approval_program_3_teal = compileTeal(
+    wrapped_approval_program_3(),
+    mode=Mode.Application,
+    version=8,
+)
+
+wrapped_approval_program_3_vulnerable_paths: List[List[int]] = [
+    [0, 5, 7, 6],
+]
+
+wrapped_approval_program_4_teal = compileTeal(
+    wrapped_approval_program_4(),
+    mode=Mode.Application,
+    version=8,
+)
+
+wrapped_approval_program_4_vulnerable_paths: List[List[int]] = []
+
+
+group_size_tests_pyteal = [
+    (
+        wrapped_approval_program_1_teal,
+        MissingGroupSize,
+        wrapped_approval_program_1_vulnerable_paths,
+    ),
+    (
+        wrapped_approval_program_2_teal,
+        MissingGroupSize,
+        wrapped_approval_program_2_vulnerable_paths,
+    ),
+    (
+        wrapped_approval_program_3_teal,
+        MissingGroupSize,
+        wrapped_approval_program_3_vulnerable_paths,
+    ),
+    (
+        wrapped_approval_program_4_teal,
+        MissingGroupSize,
+        wrapped_approval_program_4_vulnerable_paths,
+    ),
+]
+
+if __name__ == "__main__":
+    print(wrapped_approval_program_3_teal)

--- a/tests/detectors/pyteal_group_size.py
+++ b/tests/detectors/pyteal_group_size.py
@@ -1,3 +1,5 @@
+# pylint: skip-file
+# mypy: ignore-errors
 from typing import List
 from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
 

--- a/tests/test_detectors_using_pyteal.py
+++ b/tests/test_detectors_using_pyteal.py
@@ -17,11 +17,14 @@ from tests.detectors.router_with_assembled_constants import (  # pylint: disable
 from tests.detectors.pyteal_can_close import (  # pylint: disable=wrong-import-position
     txn_type_based_tests,
 )
-
+from tests.detectors.pyteal_group_size import (  # pylint: disable=wrong-import-position
+    group_size_tests_pyteal,
+)
 
 TESTS: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     *router_with_assembled_constants,
     *txn_type_based_tests,
+    *group_size_tests_pyteal,
 ]
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -430,11 +430,11 @@ def test_intc_bytec_false(test: str) -> None:
     teal = parse_teal(test)
     for ins in teal.instructions:
         if isinstance(ins, IntcInstruction):
-            is_known, _ = is_int_push_ins(ins)
-            assert not is_known
+            is_int, value = is_int_push_ins(ins)
+            assert is_int and value is None
 
     teal = parse_teal(test.replace("intc", "bytec"))
     for ins in teal.instructions:
         if isinstance(ins, BytecInstruction):
-            is_known, _ = is_byte_push_ins(ins)
-            assert not is_known
+            is_bytes, value = is_byte_push_ins(ins)
+            assert is_bytes and value is None


### PR DESCRIPTION
MissingGroupSize detector is used to report execution paths that do not check the group size.
However, Current recommendation is to use ARC-4 ABI and relative indices to verify the group transaction.

This PR updates the MissingGroupSize detector to consider the usage of absolute indexes. MissingGroupSize now only reports execution paths that use the absolute index to access group-transaction without checking the group size.


#### Exploit Scenario

```py
def mint_wrapped_algo() -> Expr:
    validations = Assert(
        And(
            Gtxn[0].receiver() == Global.current_application_address(),
            Gtxn[0].type_enum() == TxnType.Payment,
        )
    )
    transfer_op = transfer_wrapped_algo(Txn.sender(), Gtxn[0].amount())
    return Seq([validations, transfer_op, Approve()])
```
Attacker sends following group transaction:
```
    0. Payment of 1 million Algos to application address
    1. Call mint_wrapped_algo
    2. Call mint_wrapped_algo 
    ...
    15. Call mint_wrapped_algo
```
Attacker receives 15 million wrapped-algos instead of 1 million wrapped-algos. Attacker exchanges the\
wrapped-algo to Algo and steals 14 million Algos.
More at [building-secure-contracts/not-so-smart-contracts/algorand/group_size_check](https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/algorand/group_size_check)

#### Recommendation
Use ARC-4 ABI and relative indexes to verify the group transaction.