### PR TITLE
Add support to run Tealer on contracts from algoexplorer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "prettytable>=0.7.2",
+        "py-algorand-sdk",
+        "pycryptodomex",
+        "requests",
     ],
     extras_require={"dev": ["pylint==2.13.4", "black==22.3.0", "mypy==0.942"]},
     license="AGPL-3.0",

--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -64,6 +64,7 @@ To choose printers to run from the available list:
 
 import argparse
 import inspect
+import re
 import sys
 import json
 from pathlib import Path
@@ -78,6 +79,11 @@ from tealer.printers.abstract_printer import AbstractPrinter
 from tealer.teal.parse_teal import parse_teal
 from tealer.utils.command_line import output_detectors, output_printers
 from tealer.utils.output import cfg_to_dot
+from tealer.utils.algoexplorer import (
+    get_application_using_app_id,
+    logic_sig_from_contract_account,
+    logic_sig_from_txn_id,
+)
 from tealer.exceptions import TealerException
 
 if TYPE_CHECKING:
@@ -204,6 +210,13 @@ def parse_args(
         nargs="?",
         help="export cfg in dot format to given file, default cfg.dot",
         const="cfg.dot",
+    )
+
+    parser.add_argument(
+        "--network",
+        help='Algorand network to fetch the contract from, ("mainnet" or "testnet"). defaults to "mainnet".',
+        action="store",
+        default="mainnet",
     )
 
     group_detector = parser.add_argument_group("Detectors")
@@ -493,6 +506,31 @@ def handle_output(
                 f.write(json.dumps(json_output, indent=2))
 
 
+def fetch_contract(args: argparse.Namespace) -> str:
+    program: str = args.program
+    network: str = args.network
+    b32_regex = "[A-Z2-7]+"
+    if program.isdigit():
+        # is a number so a app id
+        print(f'Fetching application using id "{program}"')
+        return get_application_using_app_id(network, int(program))
+    if len(program) == 52 and re.fullmatch(b32_regex, program) is not None:
+        # is a txn id: base32 encoded. length after encoding == 52
+        print(f'Fetching logic-sig contract that signed the transaction "{program}"')
+        return logic_sig_from_txn_id(network, program)
+    if len(program) == 58 and re.fullmatch(b32_regex, program) is not None:
+        # is a address. base32 encoded. length after encoding == 58
+        print(f'Fetching logic-sig of contract account "{program}"')
+        return logic_sig_from_contract_account(network, program)
+    # file path
+    print(f'Reading contract from file: "{program}"')
+    try:
+        with open(program, encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError as e:
+        raise TealerException from e
+
+
 def main() -> None:
     """Entry point of the tealer tool.
 
@@ -511,9 +549,8 @@ def main() -> None:
     _results_printers: List = []
     error = None
     try:
-        with open(args.program, encoding="utf-8") as f:
-            print(f"Analyzing {args.program}")
-            teal = parse_teal(f.read())
+        contract_source = fetch_contract(args)
+        teal = parse_teal(contract_source)
 
         if args.print_cfg is not None:
             handle_print_cfg(args, teal)

--- a/tealer/teal/instructions/parse_instruction.py
+++ b/tealer/teal/instructions/parse_instruction.py
@@ -548,7 +548,7 @@ def parse_line(line: str) -> Optional[instructions.Instruction]:
             return ins
 
     # line is checked to not empty at the start of the function.
-    print(f"Not found {line}")
+    print(f'Not found instruction: "{line}"')
     ins = instructions.UnsupportedInstruction(line)
     ins.source_code = source_code_line
     ins.comment = ins.comment

--- a/tealer/utils/algoexplorer.py
+++ b/tealer/utils/algoexplorer.py
@@ -1,0 +1,141 @@
+"""
+Helpers to fetch contract from the Algorand network using indexer.
+
+## Test cases(Mainnet)
+
+App id:
+    - Invalid app id: 1
+    - Valid app id: 991196662
+
+Transaction id:
+    - normal_txn (not signed with logic-sig): METJ6SNMBLTBVBLADEQFY6Y6CVPI4ZMSF23HVTY2RK7R4OCO6QDQ
+    - delegate sig signed with single key: VFFVCSPFBK36ZN2FPDPDI6PFUO44OLZPBU6XPGOIGSR5L2XK6HFQ
+    - delegate sig signed with multiple key(multi-sig): NGJOVS7SEEWRIKZNA5WL7FRENXXPUKSFPKJKM5QBYUOM7UZ2SG5Q
+    - signed with contract account's sig: ZICHTBTBC6H3CFOGREUPV3G74WRYDM3ZD7W56VMRMCNXOQHP3AYQ
+
+Contract Accounts:
+    - Invalid address:  AOOIJDOIJRPZMCPJQWPIJNDISC2XEOZBDN2SNCONSOSDJX27652DNU2HDI
+    - Contract account: D6DDUCPSDWD4IA2L3FL4ZC6NVKXGQYOU4LJQMHKV6NVCYHRURSFKYPFN5M
+    - Normal account: ZW3ISEHZUHPO7OZGMKLKIIMKVICOUDRCERI454I3DB2BH52HGLSO67W754
+
+### BETANET:
+
+App id:
+    - Invalid app id: 1
+    - Valid app id: 1496883334      # worked for this application
+    - Valid app id: 1497219145      # valid application but is not found by the indexer.
+
+Dropping the support for betanet for now. Having no support is better than something that only works some times.
+And supporting betanet is not a priority.
+
+### TESTNET
+
+App id:
+    - Invalid app id: 1
+    - Valid app id: 115884263
+"""
+
+import base64
+import json
+
+import requests
+from algosdk.v2client.indexer import IndexerClient
+from algosdk.error import IndexerHTTPError
+
+from tealer.exceptions import TealerException
+
+
+def disassemble_using_algo_explorer(code: str) -> str:
+    """Disassemble the AVM bytecode to teal using Algorand node v2 api."""
+    base = "https://node.algoexplorerapi.io/"
+    url = "v2/teal/disassemble"
+    headers = {"Content-Type": "application/x-binary"}
+    code_bin = base64.b64decode(code)
+    r = requests.post(base + url, data=code_bin, headers=headers)
+    if r.status_code != 200:
+        raise TealerException(f'Unable to disassemble contract: "{code}"')
+    disassembly = json.loads(r.text)["result"]
+    return disassembly
+
+
+def get_indexer(network: str) -> IndexerClient:
+    main_net_base_url = "https://algoindexer.algoexplorerapi.io/"
+    test_net_base_url = "https://algoindexer.testnet.algoexplorerapi.io/"
+    # beta_net_base_url = "https://algoindexer.betanet.algoexplorerapi.io/"
+    if network.lower() == "testnet":
+        indexer_base_url = test_net_base_url
+        print('Network: "TESTNET"')
+    # Betannet is not supported
+    # elif network == "betanet":
+    #     indexer_base_url = beta_net_base_url
+    #     print('Network: "BETANET"')
+    elif network.lower() == "mainnet":
+        indexer_base_url = main_net_base_url
+        print('Network: "MAINET"')
+    else:
+        raise TealerException(f'Network "{network}" is not supported')
+
+    return IndexerClient(indexer_token="", indexer_address=indexer_base_url)  # type: ignore
+
+
+def get_application_using_app_id(network: str, app_id: int) -> str:
+    """Downloads approval program using the application id"""
+    try:
+        response = get_indexer(network).applications(application_id=app_id)  # type: ignore
+    except IndexerHTTPError as e:
+        raise TealerException(f'Unable to fetch application "{app_id}"\n{e}') from e
+    approval = response["application"]["params"]["approval-program"]
+    # clear = response["application"]["params"]["clear-state-program"]
+    return disassemble_using_algo_explorer(approval)
+
+
+def logic_sig_from_contract_account(network: str, account_address: str) -> str:
+    """Find logic sig of a contract account.
+
+    Logic sig of a contract account is not part of the account and is not stored in the
+    blockchain state.
+
+    In order to find the logic sig, find a transaction from the contract account and
+    get the logic sig from that.
+    """
+    try:
+        results = get_indexer(network).search_transactions(  # type: ignore
+            limit=1, sig_type="lsig", address=account_address, address_role="sender"
+        )
+    except IndexerHTTPError as e:
+        # Happens if account_address is invalid.
+        # or The search has timed-out.
+        raise TealerException(
+            f'Could not find logic signature for contract account "{account_address}"\n{e}'
+        ) from e
+    transactions = results["transactions"]
+    if len(transactions) == 0:
+        # Search has finished and didn't find any transactions.
+        # -> Either account_address is not a contract account Or
+        # -> There is not a single transaction from the account.
+        raise TealerException(
+            f'Account "{account_address}" is not a contract account.\n'
+            "Note: Account should have made submitted atleast one transaction for tealer to find the contract"
+        )
+    signature = transactions[0]["signature"]["logicsig"]
+    if "multi-signature" in signature or "signature" in signature:
+        # delegate signature, not a contract account
+        raise TealerException(f'Account "{account_address}" is not a contract account.')
+    logic_sig = signature["logic"]
+    return disassemble_using_algo_explorer(logic_sig)
+
+
+def logic_sig_from_txn_id(network: str, txn_id: str) -> str:
+    """Fetch logic-sig used to sign `txn_id` transaction"""
+    try:
+        txn_info = get_indexer(network).transaction(txn_id)  # type: ignore
+    except IndexerHTTPError as e:
+        # will happen if txn_id is not a valid base32 string(irrespective of padding)
+        # or There's no transaction with the given txn_id
+        raise TealerException(f'Invalid transaction id: "{txn_id}"\n{e}') from e
+
+    signature = txn_info["transaction"]["signature"]
+    if "logicsig" not in signature:
+        raise TealerException(f'Transaction "{txn_id}" is not signed using a logic signature.')
+    logic_sig = signature["logicsig"]["logic"]
+    return disassemble_using_algo_explorer(logic_sig)


### PR DESCRIPTION
Adds support to fetch contracts from Algoexplorer (https://algoexplorer.io/) and run tealer on them.

Runs on the application given it's id
```sh
$ tealer 991196662 --print-cfg
Fetching application using id "991196662"
Network: "MAINET"

CFG exported to file: cfg.dot
```

Runs on the logic signature(stateless contract) that signed the given transaction
```sh
$ tealer VFFVCSPFBK36ZN2FPDPDI6PFUO44OLZPBU6XPGOIGSR5L2XK6HFQ --print-cfg
Fetching logic-sig contract that signed the transaction "VFFVCSPFBK36ZN2FPDPDI6PFUO44OLZPBU6XPGOIGSR5L2XK6HFQ"
Network: "MAINET"

CFG exported to file: cfg.dot
```

Runs on the logic signature controlling a contract account
```sh
$ tealer D6DDUCPSDWD4IA2L3FL4ZC6NVKXGQYOU4LJQMHKV6NVCYHRURSFKYPFN5M --print-cfg --network mainnet
Fetching logic-sig of contract account "D6DDUCPSDWD4IA2L3FL4ZC6NVKXGQYOU4LJQMHKV6NVCYHRURSFKYPFN5M"
Network: "MAINET"

CFG exported to file: cfg.dot
```

`Mainnet` and `Testnet` are supported. Use `--network` to specify the Algorand network from which to fetch the contract.

```
$ tealer --help
...
options:
...
  --network NETWORK     Algorand network to fetch the contract from, ("mainnet" or "testnet"). defaults to
                        "mainnet".
```

Testnet example:

```sh
$ tealer 115884263 --network testnet --print-cfg
Fetching application using id "115884263"
Network: "TESTNET"

CFG exported to file: cfg.dot
```
