### PR TITLE
Fix bugs in parsing and analysis of subroutines containing return instruction

### DIFF
--- a/tealer/analyses/dataflow/generic.py
+++ b/tealer/analyses/dataflow/generic.py
@@ -642,7 +642,7 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
         for next_b in block.next:
             livein_information = self._union(key, livein_information, liveout[next_b])
 
-        if block.sub_return_point is not None:
+        if block.sub_return_point is not None and len(block.sub_return_point.prev) != 0:
             # this block is the `callsub block` and `block.sub_return_point` is the block that will be executed after subroutine.
             livein_information = self._intersection(
                 key, livein_information, liveout[block.sub_return_point]

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -270,6 +270,8 @@ def _first_pass(  # pylint: disable=too-many-branches
         call = None
         if isinstance(ins, Callsub):
             call = ins
+            if call.label not in rets.keys():
+                rets[call.label] = []
 
         # Finally, add the instruction to the instruction list
         instructions.append(ins)

--- a/tests/detectors/multiple_calls_to_subroutine.py
+++ b/tests/detectors/multiple_calls_to_subroutine.py
@@ -69,11 +69,127 @@ false_negative_program, _, _ = false_negative_router.compile_program(
 working_approval_program_paths = [[0, 1, 3, 8, 4]]
 false_negative_program_paths = [[0, 1, 3, 9, 8, 10, 8, 11, 4]]
 
+
+method_returns_using_approve = Router(
+    name="MethodReturnsUsingApprove",
+    bare_calls=BareCallActions(
+        no_op=OnCompleteAction(action=Approve(), call_config=CallConfig.CREATE),
+    ),
+)
+
+
+@method_returns_using_approve.method(update_application=CallConfig.CALL)
+def update_application_3() -> Expr:
+    return Approve()
+
+
+method_returns_using_approve_program, _, _ = method_returns_using_approve.compile_program(
+    version=7,
+)
+
+method_returns_using_approve_program_teal = """
+#pragma version 7       // B0
+txn NumAppArgs
+int 0
+==
+bnz main_l4
+
+txna ApplicationArgs 0          // B1
+method "update_application_3()void"
+==
+bnz main_l3
+
+err             // B2
+
+main_l3:            // B3
+txn OnCompletion
+int UpdateApplication
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+callsub updateapplication3_0
+
+int 1       // B4
+return
+
+main_l4:    // B5
+txn OnCompletion
+int NoOp
+==
+bnz main_l6
+
+err         // B6
+
+main_l6:        // B7
+txn ApplicationID
+int 0
+==
+assert
+int 1
+return
+
+// update_application_3
+updateapplication3_0:   // B8
+int 1
+return
+"""
+
+# Each of router methods have a corresponding subroutine in the compiled code.
+# `updateapplication3_0` subroutine for update_application_3() method in above example.
+# PyTeal implicitly adds instructions `int 1; return;` after the call to the subroutine of the method.
+# See block B4 in above code.
+# PyTeal adds those instructions even if the subroutine uses `return` instead of `retsub`.
+# This is a problem for Tealer. Because, B4 is considered as a return point to `callsub` instruction.
+# B4 does not have any predecessors and execution is not reachable.
+# During the TransactionFieldAnalysis, information of return point block is used to calculate information for callsub block.
+# And because B4 is not reachable, it will have empty set for possible values. In backward propagation, information from B4
+# is intersected with information of B3 resulting in empty set of possible values for B3 as well. This propagates across the CFG
+# and blocks will have incorrect information.
+
+# This bug is now fixed.
+
+method_returns_using_approve_program_paths = [[0, 1, 3, 8]]
+
+method_returns_using_approve_2 = Router(
+    name="MethodReturnsUsingApprove",
+    bare_calls=BareCallActions(
+        no_op=OnCompleteAction(action=Approve(), call_config=CallConfig.CREATE),
+    ),
+)
+
+
+@method_returns_using_approve_2.method(update_application=CallConfig.CALL)
+def update_application_3() -> Expr:
+    # return in one path of the subroutine.
+    # And retsub in another path of the subroutine.
+    return If(Txn.application_args[0] == Bytes("Update"), Approve(), Return())
+
+
+method_returns_using_approve_2_program, _, _ = method_returns_using_approve_2.compile_program(
+    version=7
+)
+
+method_returns_using_approve_2_program_paths = [
+    [0, 1, 3, 8, 9, 4],
+    [0, 1, 3, 8, 10],
+]
+
 multiple_calls_to_subroutine_tests = [
     (working_approval_program, CanUpdate, working_approval_program_paths),
     (false_negative_program, CanUpdate, false_negative_program_paths),
+    (method_returns_using_approve_program, CanUpdate, method_returns_using_approve_program_paths),
+    (
+        method_returns_using_approve_2_program,
+        CanUpdate,
+        method_returns_using_approve_2_program_paths,
+    ),
 ]
 
 if __name__ == "__main__":
     print(working_approval_program)
-    # print(false_negative_program)
+    print(false_negative_program)
+    print(method_returns_using_approve_program)
+    print(method_returns_using_approve_2_program)

--- a/tests/detectors/subroutine_patterns.py
+++ b/tests/detectors/subroutine_patterns.py
@@ -34,8 +34,25 @@ MULTIPLE_RETURN_POINTS_VULNERABLE_PATHS_3: List[List[int]] = [
     [0, 3, 1, 3, 2],
 ]
 
+# Tealer does not identify a subroutine when `callsub` instruction is the last instruction.
+# Bug is fixed now
+CALLSUB_AT_END = """
+#pragma version 7
+b main
+sub:
+    int 1
+    return
+main:
+    callsub sub
+"""
+
+CALLSUB_AT_END_VULNERABLE_PATHS: List[List[int]] = [
+    [0, 2, 1],
+]
+
 subroutine_patterns_tests = [
     # (MULTIPLE_RETURN_POINTS, CanUpdate, MULTIPLE_RETURN_POINTS_VULNERABLE_PATHS_1),
     # (MULTIPLE_RETURN_POINTS, CanUpdate, MULTIPLE_RETURN_POINTS_VULNERABLE_PATHS_2),
     (MULTIPLE_RETURN_POINTS, CanUpdate, MULTIPLE_RETURN_POINTS_VULNERABLE_PATHS_3),
+    (CALLSUB_AT_END, CanUpdate, CALLSUB_AT_END_VULNERABLE_PATHS),
 ]


### PR DESCRIPTION
This PR addresses two bugs
- In parsing, when the `callsub` is the last instruction of the program, the called subroutine is not identified as a "Subroutine" by Tealer.
- In TransactionFieldAnalysis, when a subroutine uses the `return` opcode instead of `retsub`. Analysis results in incorrect information about possible values for the transaction fields. This in turn affects the detector results