### PR TITLE
Update detector's wiki and detector table in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,33 @@ Tealer is a static analyzer for [Teal](https://developer.algorand.org/docs/featu
 
 ## Features
 
+Run Tealer on a Teal contract:
+
+```bash
+tealer program.teal
+```
+
+For additional configuration, see the [Usage](https://github.com/crytic/tealer/wiki/Usage) documentation.
+
 ### Detectors
 
- Num |      Check      |                       What it Detects                        |      Type     | Impact | Confidence
---- | --- | --- | --- | --- | ---
-  1  |    isDeletable    |         Detect paths that can delete the application         |    Stateful   |  High  |    High
-  2  |    isUpdatable    |         Detect paths that can update the application         |    Stateful   |  High  |    High
-  3  |     CanUpdate    | Detect paths that can delete the application AND does not validate the transaction sender. |   Stateful   |  High  |    High
-  4  |     CanDelete    | Detect paths that can update the application AND does not validate the transaction sender. |   Stateful   |  High  |    High
-  5  |     rekeyTo     |          Detect paths with a missing RekeyTo check           | StatefulGroup |  High  |    High
-  6  |    groupSize    |         Detect paths with a missing GroupSize check          | StatefulGroup | Medium |    High
-  7  | canCloseAccount |      Detect paths that can close out the sender account      |   Stateless   |  High  |    High
-  8  |  canCloseAsset  | Detect paths that can close the asset holdings of the sender |   Stateless   |  High  |    High
-  9  |     feeCheck    |            Detect paths with a missing Fee check             |   Stateless   |  High  |    High
+Num | Detectors | What it Detects | Applies To | Impact | Confidence |
+--- | --- | --- | --- | --- | --- |
+1 | `is-deletable` | [Deletable Applications](https://github.com/crytic/tealer/wiki/Detector-Documentation#deletable-application) | Stateful | High | High
+2 | `is-updatable` | [Upgradable Applications](https://github.com/crytic/tealer/wiki/Detector-Documentation#upgradable-application) | Stateful | High | High
+3 | `unprotected-deletable` | [Unprotected Deletable Applications](https://github.com/crytic/tealer/wiki/Detector-Documentation#unprotected-deletable-application) | Stateful | High | High
+4 | `unprotected-updatable` | [Unprotected Upgradable Applications](https://github.com/crytic/tealer/wiki/Detector-Documentation#unprotected-updatable-application) | Stateful | High | High
+5 | `group-size-check` | [Usage of absolute indexes without validating GroupSize](https://github.com/crytic/tealer/wiki/Detector-Documentation#missing-groupsize-validation) | Stateless, Stateful | High | High
+6 | `can-close-account` | [Missing CloseRemainderTo field Validation](https://github.com/crytic/tealer/wiki/Detector-Documentation#missing-closeremainderto-field-validation) | Stateless | High | High
+7 | `can-close-asset` | [Missing AssetCloseTo Field Validation](https://github.com/crytic/tealer/wiki/Detector-Documentation#missing-assetcloseto-field-validation) | Stateless | High | High
+8 | `missing-fee-check` | [Missing Fee Field Validation](https://github.com/crytic/tealer/wiki/Detector-Documentation#missing-fee-field-validation) | Stateless | High | High
+9 | `rekey-to` | [Rekeyable Logic Signatures](https://github.com/crytic/tealer/wiki/Detector-Documentation#rekeyable-logicsig) | Stateless | High | High
 
-All the detectors are run by default
+
+For more information, see
+
+- The [Detector Documentation](https://github.com/crytic/tealer/wiki/Detector-Documentation) for information on each detector
+- The [Detection Selection](https://github.com/crytic/tealer/wiki/Usage#detector-selection) to run only selected detectors. By default, all the detectors are ran.
 
 ### Printers
 
@@ -36,28 +48,14 @@ Use `xdot` to open the files  (`sudo apt install xdot`).
 
 ## How to install
 
-Run
+### Using Git
 
 ```bash
+git clone https://github.com/crytic/tealer.git && cd tealer
 python3 setup.py install
 ```
 
 We recommend to install the tool in a [virtualenv](https://virtualenvwrapper.readthedocs.io/en/latest/).
 
-## How to run
 
-```bash
-tealer code.teal
-```
-
-### Example
-
-The following shows the CFG from [algorand/smart-contracts](https://github.com/algorand/smart-contracts.git).
-
-```bash
-git clone https://github.com/algorand/smart-contracts.git
-cd smart-contracts
-tealer ./devrel/permission-less-voting/vote_opt_out.teal --print-cfg
-```
-
-<img src="./examples/vote_opt_out.png" alt="Example" width="500"/>
+## TODO: Add License

--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -68,7 +68,7 @@ import re
 import sys
 import json
 from pathlib import Path
-from typing import List, Any, Type, Tuple, TYPE_CHECKING, Optional
+from typing import List, Any, Type, Tuple, TYPE_CHECKING, Optional, Union, Sequence
 
 from pkg_resources import iter_entry_points, require  # type: ignore
 
@@ -77,7 +77,12 @@ from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
 from tealer.printers import all_printers
 from tealer.printers.abstract_printer import AbstractPrinter
 from tealer.teal.parse_teal import parse_teal
-from tealer.utils.command_line import output_detectors, output_printers
+from tealer.utils.command_line import (
+    output_detectors,
+    output_printers,
+    output_to_markdown,
+    output_wiki,
+)
 from tealer.utils.output import cfg_to_dot
 from tealer.utils.algoexplorer import (
     get_application_using_app_id,
@@ -310,6 +315,12 @@ def parse_args(
         default=".",
     )
 
+    parser.add_argument("--markdown", help=argparse.SUPPRESS, action=OutputMarkdown, default=False)
+
+    parser.add_argument(
+        "--wiki-detectors", help=argparse.SUPPRESS, action=OutputWiki, default=False
+    )
+
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
@@ -350,6 +361,34 @@ class ListPrinters(argparse.Action):  # pylint: disable=too-few-public-methods
     ) -> None:  # pylint: disable=signature-differs
         _, printers = get_detectors_and_printers()
         output_printers(printers)
+        parser.exit()
+
+
+class OutputMarkdown(argparse.Action):  # pylint: disable=too-few-public-methods
+    def __call__(
+        self,
+        parser: Any,
+        args: Any,
+        values: Optional[Union[str, Sequence[Any]]],
+        option_string: Any = None,
+    ) -> None:
+        detectors, printers = get_detectors_and_printers()
+        assert isinstance(values, str)
+        output_to_markdown(detectors, printers, values)
+        parser.exit()
+
+
+class OutputWiki(argparse.Action):  # pylint: disable=too-few-public-methods
+    def __call__(
+        self,
+        parser: Any,
+        args: Any,
+        values: Optional[Union[str, Sequence[Any]]],
+        option_string: Any = None,
+    ) -> None:
+        detectors, _ = get_detectors_and_printers()
+        assert isinstance(values, str)
+        output_wiki(detectors, values)
         parser.exit()
 
 

--- a/tealer/detectors/abstract_detector.py
+++ b/tealer/detectors/abstract_detector.py
@@ -63,10 +63,13 @@ class IncorrectDetectorInitialization(Exception):
     """
 
 
+# DetectorType is used to specify "Applicability of a detector."
 class DetectorType(ComparableEnum):
-    STATELESS = 0
-    STATEFULL = 1
-    STATEFULLGROUP = 2
+    # Order by stateful, stateless and stateful, stateless
+    STATEFULL = 0
+    STATELESS_AND_STATEFULL = 1
+    STATELESS = 2
+    STATEFULLGROUP = 3
 
     UNDEFINED = 255
 
@@ -74,6 +77,7 @@ class DetectorType(ComparableEnum):
 DETECTOR_TYPE_TXT = {
     DetectorType.STATELESS: "Stateless",
     DetectorType.STATEFULL: "Stateful",
+    DetectorType.STATELESS_AND_STATEFULL: "Stateless, Stateful",
     DetectorType.STATEFULLGROUP: "StatefulGroup",
 }
 
@@ -147,6 +151,7 @@ class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public
     IMPACT: DetectorClassification = DetectorClassification.UNIMPLEMENTED
     CONFIDENCE: DetectorClassification = DetectorClassification.UNIMPLEMENTED
 
+    WIKI_URL = ""
     WIKI_TITLE = ""
     WIKI_DESCRIPTION = ""
     WIKI_EXPLOIT_SCENARIO = ""
@@ -188,6 +193,11 @@ class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public
         if not self.WIKI_RECOMMENDATION:
             raise IncorrectDetectorInitialization(
                 f"WIKI_RECOMMENDATION is not initialized {self.__class__.__name__}"
+            )
+
+        if not self.WIKI_URL:
+            raise IncorrectDetectorInitialization(
+                f"WIKI_URL is not initialized {self.__class__.__name__}"
             )
 
         if self.IMPACT not in [

--- a/tealer/detectors/anyone_can_delete.py
+++ b/tealer/detectors/anyone_can_delete.py
@@ -28,46 +28,33 @@ class AnyoneCanDelete(AbstractDetector):  # pylint: disable=too-few-public-metho
         - Transaction sender can be any address.
     """
 
-    NAME = "anyoneCanDelete"
-    DESCRIPTION = (
-        "Detect paths missing validations on sender field AND allows to delete the application."
-    )
+    NAME = "unprotected-deletable"
+    DESCRIPTION = "Unprotected Deletable Applications"
     TYPE = DetectorType.STATEFULL
 
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.HIGH
 
-    WIKI_TITLE = "Anyone Can Delete Application"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Detector-Documentation#unprotected-deletable-application"
+    WIKI_TITLE = "Unprotected Deletable Application"
     WIKI_DESCRIPTION = (
-        "Detect paths missing validations on sender field AND allows to delete the application."
+        "Application can be deleted by anyone. "
+        "More at [building-secure-contracts/not-so-smart-contracts/algorand/access_controls]"
+        "(https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/algorand/access_controls)."
     )
-    WIKI_EXPLOIT_SCENARIO = """
+    WIKI_EXPLOIT_SCENARIO = """\
 ```py
-@router.method(no_op=CallConfig.CALL, delete_application=CallConfig.CALL)
-def remove_user():
-    return Seq([
-        App.localDel(Txn.sender(), "balance"),
-        Return(Int(1))
-    ])
+@router.method(delete_application=CallConfig.CALL)
+def delete_application() -> Expr:
+    return Approve()
 ```
 
-Algorand supports multiple types of application transactions. All types of application transactions execute the application
-and fail if the execution fails. Based on the application type, AVM performs additional operations on the application.
-
-Additional operations for DeleteApplication type transaction is 
-```
-After executing the ApprovalProgram, delete the application parameters from the account data of the application's creator.
-```
-
-There should be proper access controls protecting the execution paths/methods approving DeleteApplication type transactions.
-
-Exploitation:
-    Attacker submits a DeleteApplication type transaction to "remove_user" method. Application parameters are deleted from the creator's
-    account and application assets became inaccesible.
+Eve calls `delete_application` method and deletes the application making its assets permanently inaccesible.
 """
 
     WIKI_RECOMMENDATION = """
-Place proper access controls for privileged methods. One approach is to validate transaction sender is equal to a privileged address(admin) in the system.
+- Avoid deletable applications.
+- Add access controls to the vulnerable method.
 """
 
     def detect(self) -> "SupportedOutput":

--- a/tealer/detectors/anyone_can_update.py
+++ b/tealer/detectors/anyone_can_update.py
@@ -28,46 +28,33 @@ class AnyoneCanUpdate(AbstractDetector):  # pylint: disable=too-few-public-metho
         - Transaction sender can be any address.
     """
 
-    NAME = "anyoneCanUpdate"
-    DESCRIPTION = (
-        "Detect paths missing validations on sender field AND allows to update the application."
-    )
+    NAME = "unprotected-updatable"
+    DESCRIPTION = "Unprotected Upgradable Applications"
     TYPE = DetectorType.STATEFULL
 
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.HIGH
 
-    WIKI_TITLE = "Anyone Can Update Application"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Detector-Documentation#unprotected-updatable-application"
+    WIKI_TITLE = "Unprotected Upgradable Application"
     WIKI_DESCRIPTION = (
-        "Detect paths missing validations on sender field AND allows to update the application."
+        "Application can be updated by anyone. "
+        "More at [building-secure-contracts/not-so-smart-contracts/algorand/access_controls]"
+        "(https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/algorand/access_controls)."
     )
     WIKI_EXPLOIT_SCENARIO = """
 ```py
-@router.method(no_op=CallConfig.CALL, update_application=CallConfig.CALL)
-def update_balance():
-    return Seq([
-        App.localPut(Txn.sender(), "key", Int(1000)),
-        Return(Int(1))
-    ])
+@router.method(update_application=CallConfig.CALL)
+def update_application() -> Expr:
+    return Approve()
 ```
 
-Algorand supports multiple types of application transactions. All types of application transactions execute the application
-and fail if the execution fails. Based on the application type, AVM performs additional operations on the application.
-
-Additional operations for UpdateApplication type transaction is 
-```
-After executing the ApprovalProgram, replace the ApprovalProgram and ClearStateProgram associated with this application ID with the programs specified in this transaction.
-```
-
-Ability to execute UpdateApplication transaction will give complete control of application code, which controls all the assets held by the application. There should be proper
-access controls protecting the execution paths/methods approving UpdateApplication type transactions.
-
-Exploitation:
-    Attacker sends a UpdateApplication transaction with the new approval program which transfers all of the application's assets to attacker's address.
+Eve updates the application by calling `update_application` method and steals all of its assets.
 """
 
     WIKI_RECOMMENDATION = """
-Place proper access controls for privileged methods. One approach is to validate the transaction sender: Assert it is equal to a privileged address(admin) in the system.
+- Avoid upgradable applications.
+- Add access controls to the vulnerable method.
 """
 
     def detect(self) -> "SupportedOutput":

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -29,33 +29,48 @@ class CanCloseAsset(AbstractDetector):  # pylint: disable=too-few-public-methods
     transaction("return 1") and doesn't check the AssetCloseTo field.
     """
 
-    NAME = "canCloseAsset"
-    DESCRIPTION = "Detect paths that can close the asset holdings of the sender"
+    NAME = "can-close-asset"
+    DESCRIPTION = "Missing AssetCloseTo Field Validation"
     TYPE = DetectorType.STATELESS
 
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.HIGH
 
-    WIKI_TITLE = "Can Close Asset"
-    WIKI_DESCRIPTION = "Detect paths that can close the asset holdings of the sender"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Detector-Documentation#missing-assetcloseto-field-validation"
+    WIKI_TITLE = "Missing AssetCloseTo Field Validation"
+    WIKI_DESCRIPTION = (
+        "LogicSig does not validate `AssetCloseTo` field."
+        " Attacker can submit a transaction with `AssetCloseTo` field set to their address and steal account's assets."
+        " More at [building-secure-contracts/not-so-smart-contracts/algorand/closing_asset]"
+        "(https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/algorand/closing_asset)"
+    )
     WIKI_EXPLOIT_SCENARIO = """
-```
-#pragma version 2
-txn Receiver
-addr BAZ7SJR2DVKCO6EHLLPXT7FRSYHNCZ35UTQD6K2FI4VALM2SSFIWTBZCTA
-==
-txn AssetAmount
-int 10
-==
-&&
-...
+```py
+def withdraw(...) -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.type_enum() == TxnType.AssetTransfer,
+                    Txn.first_valid() % period == Int(0),
+                    Txn.last_valid() == Txn.first_valid() + duration,
+                    Txn.asset_receiver() == receiver,
+                    Txn.asset_amount() == amount,
+                    Txn.first_valid() < timeout,
+                )
+            ),
+            Approve(),
+        ]
+    )
 ```
 
-receiver sets the AssetCloseTo transaction field of a Asset Transfer Transaction with above contract account as Sender which will result in removal of asset holding from the contract's account and sending the asset's to AssetCloseTo address.
+Alice signs the logic-sig to allow recurring payments to Bob in USDC.\
+ Eve uses the logic-sig and submits a valid transaction with `AssetCloseTo` field set to her address.\
+ Eve steals Alice's USDC balance.
 """
 
     WIKI_RECOMMENDATION = """
-Always check that AssetCloseTo transaction field is set to a ZeroAddress or intended address if needed.
+Validate `AssetCloseTo` field in the LogicSig.
 """
 
     def detect(self) -> "SupportedOutput":

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -53,35 +53,50 @@ class MissingFeeCheck(AbstractDetector):  # pylint: disable=too-few-public-metho
     transaction("return 1") and doesn't check the Fee field.
     """
 
-    NAME = "feeCheck"
-    DESCRIPTION = "Detect paths with a missing Fee check"
+    NAME = "missing-fee-check"
+    DESCRIPTION = "Missing Fee Field Validation"
     TYPE = DetectorType.STATELESS
 
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.HIGH
 
-    WIKI_TITLE = "Missing Fee check"
-    WIKI_DESCRIPTION = "Detect paths with a missing Fee check"
+    WIKI_URL = (
+        "https://github.com/crytic/tealer/wiki/Detector-Documentation#missing-fee-field-validation"
+    )
+    WIKI_TITLE = "Missing Fee Field Validation"
+    WIKI_DESCRIPTION = (
+        "LogicSig does not validate `Fee` field."
+        " Attacker can submit a transaction with `Fee` field set to large value and drain the account balance."
+        " More at [building-secure-contracts/not-so-smart-contracts/algorand/unchecked_transaction_fee]"
+        "(https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/algorand/unchecked_transaction_fee)"
+    )
     WIKI_EXPLOIT_SCENARIO = """
-```
-#pragma version 2
-txn Receiver
-addr BAZ7SJR2DVKCO6EHLLPXT7FRSYHNCZ35UTQD6K2FI4VALM2SSFIWTBZCTA
-==
-txn Amount
-int 1000000
-==
-&&
-...
+```py
+def withdraw(...) -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.type_enum() == TxnType.Payment,
+                    Txn.first_valid() % period == Int(0),
+                    Txn.last_valid() == Txn.first_valid() + duration,
+                    Txn.receiver() == receiver,
+                    Txn.amount() == amount,
+                    Txn.first_valid() < timeout,
+                )
+            ),
+            Approve(),
+        ]
+    )
 ```
 
-Above stateless contract could be used to allow witdraw certain amount by a predefined receiver. if the contract doesn't check the transaction fee, the receiver who turns out be malicious could set it to a high value and drain the
-balance of the account that signed the contract as the fee will be deducted from that account.
-
+Alice signs the logic-sig to allow recurring payments to Bob.\
+ Eve uses the logic-sig and submits a valid transaction with `Fee` set to 1 million ALGOs.\
+ Alice loses 1 million ALGOs.
 """
 
     WIKI_RECOMMENDATION = """
-Always check that transaction fee which can be accessed using `txn Fee` in Teal is less than certain limit and fail if that's not the case.
+Validate `Fee` field in the LogicSig.
 """
 
     def detect(self) -> "SupportedOutput":

--- a/tealer/detectors/is_deletable.py
+++ b/tealer/detectors/is_deletable.py
@@ -30,45 +30,30 @@ class IsDeletable(AbstractDetector):  # pylint: disable=too-few-public-methods
     transaction is not DeleteApplication are excluded.
     """
 
-    NAME = "isDeletable"
-    DESCRIPTION = "Detect paths that can delete the application"
+    NAME = "is-deletable"
+    DESCRIPTION = "Deletable Applications"
     TYPE = DetectorType.STATEFULL
 
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.HIGH
 
-    WIKI_TITLE = "Can Delete Application"
-    WIKI_DESCRIPTION = "Detect paths that can delete the application"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Detector-Documentation#deletable-application"
+    WIKI_TITLE = "Deletable Application"
+    WIKI_DESCRIPTION = (
+        "Application can be deleted by sending an `DeleteApplication` type application call. "
+    )
     WIKI_EXPLOIT_SCENARIO = """
-```
-#pragma version 5
-...
-int NoOp
-txn OnCompletion
-==
-bnz handle_noop
-return 1 // return sucess for all other transaction types
-handle_noop:
-    ...
+```py
+@router.method(delete_application=CallConfig.CALL)
+def delete_application() -> Expr:
+    return Assert(Txn.sender() == Global.creator_address())
 ```
 
-Algorand supports multiple types of application transactions. All types of application transactions execute the application
-and fail if the execution fails. Additional to application execution, each application transaction type will result in different
-operations before or after the application execution. This operations will be reverted if the approval program execution fails.
-
-One of the application transaction type is DeleteApplication which
-```
-After executing the ApprovalProgram, delete the application parameters from the account data of the application's creator.
-```
-
-Ability to execute DeleteApplication transaction will give the ability to make application assets permanently inaccesible to anyone.
-
-Attacker sends a DeleteApplication transaction and make assets inaccessible to everyone.
+Eve steals application creator's private key and deletes the application. Application's assets are permanently lost.
 """
 
     WIKI_RECOMMENDATION = """
-Teal stores type of application transaction in `OnCompletion` transaction field, which can be accessed using `txn OnCompletion`.
-Check if `txn OnCompletion == int DeleteApplication` and do appropriate actions based on the need.
+Do not approve `DeleteApplication` type application calls.
 """
 
     def detect(self) -> "SupportedOutput":

--- a/tealer/detectors/is_updatable.py
+++ b/tealer/detectors/is_updatable.py
@@ -31,45 +31,30 @@ class IsUpdatable(AbstractDetector):  # pylint: disable=too-few-public-methods
     transaction is not UpdateApplication are excluded.
     """
 
-    NAME = "isUpdatable"
-    DESCRIPTION = "Detect paths that can update the application"
+    NAME = "is-updatable"
+    DESCRIPTION = "Upgradable Applications"
     TYPE = DetectorType.STATEFULL
 
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.HIGH
 
-    WIKI_TITLE = "Can Update Application"
-    WIKI_DESCRIPTION = "Detect paths that can update the application"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Detector-Documentation#upgradable-application"
+    WIKI_TITLE = "Upgradable Application"
+    WIKI_DESCRIPTION = (
+        "Application can be updated by sending an `UpdateApplication` type application call."
+    )
     WIKI_EXPLOIT_SCENARIO = """
-```
-#pragma version 5
-...
-int NoOp
-txn OnCompletion
-==
-bnz handle_noop
-return 1 // return sucess for all other transaction types
-handle_noop:
-    ...
+```py
+@router.method(update_application=CallConfig.CALL)
+def update_application() -> Expr:
+    return Assert(Txn.sender() == Global.creator_address())
 ```
 
-Algorand supports multiple types of application transactions. All types of application transactions execute the application
-and fail if the execution fails. Additional to application execution, each application transaction type will result in different
-operations before or after the application execution. This operations will be reverted if the approval program execution fails.
-
-One of the application transaction type is UpdateApplication which
-```
-After executing the ApprovalProgram, replace the ApprovalProgram and ClearStateProgram associated with this application ID with the programs specified in this transaction.
-```
-
-Ability to execute UpdateApplication transaction will give complete control of application code, which controls all the assets held by the application.
-
-Attacker sends a UpdateApplication transaction with the new approval program which transfers all the application assets to attacker's address using inner transaction.
+Creator updates the application and steals all of its assets.
 """
 
     WIKI_RECOMMENDATION = """
-Teal stores type of application transaction in `OnCompletion` transaction field, which can be accessed using `txn OnCompletion`.
-Check if `txn OnCompletion == int UpdateApplication` and do appropriate actions based on the need.
+Do not approve `UpdateApplication` type application calls.
 """
 
     def detect(self) -> "SupportedOutput":


### PR DESCRIPTION
Changes:
- Changed the detector names to use snake-case instead of camelCase. Reasons: Printer names are in snake-case and slither also uses the snake-case for detector names. Wanted to keep the usage uniform.
- Changed the names and reduced the description of the detectors.
- Added `wiki_url` to detectors, linking the github wiki documentation.
- Updated the Readme
    - Added links to the wiki wherever needed.
    - Updated the detector table.
- Added helpers to automatically generate wiki and readme for detectors, printers. (Copied from Slither)
- Updated the exploit scenario's of detectors with examples written in PyTeal
- Changed the `DetectorType` classes.

Now, `DetectorType` means the type of contracts a particular detector is applicable.