### PR TITLE
Move print-cfg to a separate printer

### DIFF
--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -78,7 +78,6 @@ from tealer.printers import all_printers
 from tealer.printers.abstract_printer import AbstractPrinter
 from tealer.teal.parse_teal import parse_teal
 from tealer.utils.command_line import output_detectors, output_printers
-from tealer.utils.output import cfg_to_dot
 from tealer.utils.algoexplorer import (
     get_application_using_app_id,
     logic_sig_from_contract_account,
@@ -203,13 +202,6 @@ def parse_args(
         help="displays the current version",
         version=require("tealer")[0].version,
         action="version",
-    )
-
-    parser.add_argument(
-        "--print-cfg",
-        nargs="?",
-        help="export cfg in dot format to given file, default cfg.dot",
-        const="cfg.dot",
     )
 
     parser.add_argument(
@@ -421,27 +413,6 @@ def get_detectors_and_printers() -> Tuple[
     return detector_classes, printer_classes
 
 
-def handle_print_cfg(args: argparse.Namespace, teal: "Teal") -> None:
-    """Util function to handle print cfg command line argument.
-
-    This function is invoked when command line argument ``--print-cfg``
-    is used by the user to export the CFG of the contract in dot format.
-
-    Args:
-        args: Namespace object representing the command line arguments selected
-            by the user.
-        teal: Teal object representing the contract being analyzed.
-    """
-
-    filename = args.print_cfg
-    if not filename.endswith(".dot"):
-        filename += ".dot"
-
-    filename = Path(args.dest) / Path(filename)
-    print(f"\nCFG exported to file: {filename}")
-    cfg_to_dot(teal.bbs, filename=filename)
-
-
 def handle_detectors_and_printers(
     args: argparse.Namespace,
     teal: "Teal",
@@ -559,10 +530,6 @@ def main() -> None:
     try:
         contract_source = fetch_contract(args)
         teal = parse_teal(contract_source)
-
-        if args.print_cfg is not None:
-            handle_print_cfg(args, teal)
-            return
 
         results_detectors, _results_printers = handle_detectors_and_printers(
             args, teal, detector_classes, printer_classes

--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -64,11 +64,10 @@ To choose printers to run from the available list:
 
 import argparse
 import inspect
-
+import json
 import os
 import re
 import sys
-import json
 from pathlib import Path
 from typing import List, Any, Type, Tuple, TYPE_CHECKING, Optional, Union, Sequence
 
@@ -76,22 +75,21 @@ from pkg_resources import iter_entry_points, require  # type: ignore
 
 from tealer.detectors import all_detectors
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorType
+from tealer.exceptions import TealerException
 from tealer.printers import all_printers
 from tealer.printers.abstract_printer import AbstractPrinter
 from tealer.teal.parse_teal import parse_teal
+from tealer.utils.algoexplorer import (
+    get_application_using_app_id,
+    logic_sig_from_contract_account,
+    logic_sig_from_txn_id,
+)
 from tealer.utils.command_line import (
     output_detectors,
     output_printers,
     output_to_markdown,
     output_wiki,
 )
-from tealer.utils.output import cfg_to_dot
-from tealer.utils.algoexplorer import (
-    get_application_using_app_id,
-    logic_sig_from_contract_account,
-    logic_sig_from_txn_id,
-)
-from tealer.exceptions import TealerException
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal

--- a/tealer/printers/abstract_printer.py
+++ b/tealer/printers/abstract_printer.py
@@ -52,6 +52,7 @@ class AbstractPrinter(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-
 
     NAME = ""
     HELP = ""
+    WIKI_URL = ""
 
     def __init__(self, teal: "Teal"):
         self.teal = teal
@@ -64,6 +65,11 @@ class AbstractPrinter(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-
         if not self.HELP:
             raise IncorrectPrinterInitialization(
                 f"HELP is not initialized {self.__class__.__name__}"
+            )
+
+        if not self.WIKI_URL:
+            raise IncorrectPrinterInitialization(
+                f"WIKI_URL is not initialized for {self.__class__.__name__}"
             )
 
     @abc.abstractmethod

--- a/tealer/printers/all_printers.py
+++ b/tealer/printers/all_printers.py
@@ -5,10 +5,11 @@ Exported printers are:
 * ``human-summary``: PrinterHumanSummary prints summary of the contract.
 * ``call-graph``: PrinterCallGraph exports call-graph of the contract.
 * ``function-cfg``: PrinterFunctionCFG exports contract subroutines in dot format.
-
+* ``cfg``: PrinterCFG exports CFG of the entire contract.
 """
 
 # pylint: disable=unused-import
 from tealer.printers.human_summary import PrinterHumanSummary
 from tealer.printers.call_graph import PrinterCallGraph
 from tealer.printers.function_cfg import PrinterFunctionCFG
+from tealer.printers.full_cfg import PrinterCFG

--- a/tealer/printers/call_graph.py
+++ b/tealer/printers/call_graph.py
@@ -20,6 +20,7 @@ class PrinterCallGraph(AbstractPrinter):  # pylint: disable=too-few-public-metho
 
     NAME = "call-graph"
     HELP = "Export the call graph of contract to a dot file"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Printer-documentation#call-graph"
 
     def _construct_call_graph(self) -> Dict[str, List[str]]:
         """construct call graph for the contract.

--- a/tealer/printers/full_cfg.py
+++ b/tealer/printers/full_cfg.py
@@ -1,0 +1,33 @@
+"""Printer for exporting full contract CFG in dot format.
+
+Classes:
+    PrinterCFG: Printer to export contract CFG.
+"""
+
+from pathlib import Path
+
+from typing import Optional
+
+from tealer.printers.abstract_printer import AbstractPrinter
+from tealer.utils.output import cfg_to_dot
+
+
+class PrinterCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
+    """Printer to export contract CFG in dot."""
+
+    NAME = "cfg"
+    HELP = "Export the CFG of entire contract"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Printer-documentation#cfg"
+
+    def print(self, dest: Optional[Path] = None) -> None:
+        """Export the CFG of entire contract.
+
+        Args:
+            dest (Optional[Path]): destination directory to save the dot file in.
+        """
+        if dest is None:
+            dest = Path(".")
+
+        filename = Path("full_cfg.dot")
+        print(f"\nCFG exported to file: {filename}")
+        cfg_to_dot(self.teal.bbs, filename=dest / filename)

--- a/tealer/printers/function_cfg.py
+++ b/tealer/printers/function_cfg.py
@@ -34,7 +34,8 @@ class PrinterFunctionCFG(AbstractPrinter):  # pylint: disable=too-few-public-met
     """
 
     NAME = "function-cfg"
-    HELP = "Export cfgs of each subroutine defined in the contract."
+    HELP = "Export the CFG of each subroutine"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Printer-documentation#subroutine-cfg"
 
     @staticmethod
     def _subroutine_to_dot(subroutine: List["BasicBlock"]) -> str:

--- a/tealer/printers/human_summary.py
+++ b/tealer/printers/human_summary.py
@@ -26,7 +26,8 @@ class PrinterHumanSummary(AbstractPrinter):
     """Printer to print summary of the contract"""
 
     NAME = "human-summary"
-    HELP = "Print a human-readable summary of the contracts"
+    HELP = "Print a human-readable summary of the contract"
+    WIKI_URL = "https://github.com/crytic/tealer/wiki/Printer-documentation#human-summary"
 
     def _is_complex_code(self) -> str:
         """Check whether contract code is complex or not.


### PR DESCRIPTION
Tealer has additional argument `--print-cfg` to export CFG of the contract. Having a separate command to export cfg is non-uniform. This PR adds a separate printer class to export CFG. CFG is now listed as a printer and can be run by
```
$ tealer program.teal --print cfg
```
This PR also adds `WIKI_URL` to the AbstractPrinter class and all printer classes. 