### PR TITLE
Use a single format for terminal description of detectors

### DIFF
--- a/tealer/detectors/abstract_detector.py
+++ b/tealer/detectors/abstract_detector.py
@@ -91,6 +91,9 @@ class DetectorClassification(ComparableEnum):
 
     UNIMPLEMENTED = 999
 
+    def __str__(self) -> str:
+        return self.name.title()
+
 
 classification_txt = {
     DetectorClassification.OPTIMIZATION: "Optimization",

--- a/tealer/detectors/anyone_can_delete.py
+++ b/tealer/detectors/anyone_can_delete.py
@@ -8,8 +8,12 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 from tealer.utils.teal_enums import TealerTransactionType
+
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -78,9 +82,7 @@ Eve calls `delete_application` method and deletes the application making its ass
             self.teal.bbs[0], checks_field
         )
 
-        description = (
-            "Lack of access controls on methods approving a DeleteApplication transaction."
-        )
+        description = detector_terminal_description(self)
         filename = "anyone_can_delete"
 
         return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/anyone_can_update.py
+++ b/tealer/detectors/anyone_can_update.py
@@ -8,7 +8,10 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 
 if TYPE_CHECKING:
@@ -78,9 +81,7 @@ Eve updates the application by calling `update_application` method and steals al
             self.teal.bbs[0], checks_field
         )
 
-        description = (
-            "Lack of access controls on methods approving a UpdateApplication transaction."
-        )
+        description = detector_terminal_description(self)
 
         filename = "anyone_can_update"
         return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -8,7 +8,10 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 
 if TYPE_CHECKING:
@@ -95,8 +98,7 @@ Validate `CloseRemainderTo` field in the LogicSig.
             self.teal.bbs[0], checks_field
         )
 
-        description = "Lack of CloseRemainderTo check allows to close the account and"
-        description += " transfer all the funds to attacker controlled address."
+        description = detector_terminal_description(self)
 
         filename = "can_close_account"
 

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -8,7 +8,10 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 
 if TYPE_CHECKING:
@@ -95,8 +98,8 @@ Validate `AssetCloseTo` field in the LogicSig.
             self.teal.bbs[0], checks_field
         )
 
-        description = "Lack of AssetCloseTo check allows to close the asset holdings"
-        description += " of the account."
+        description = detector_terminal_description(self)
+
         filename = "can_close_asset"
 
         return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -14,7 +14,10 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import Fee
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 from tealer.utils.algorand_constants import MAX_TRANSACTION_COST
 
 if TYPE_CHECKING:
@@ -117,8 +120,8 @@ Validate `Fee` field in the LogicSig.
             self.teal.bbs[0], checks_field
         )
 
-        description = "Lack of fee check allows draining the funds of sender account,"
-        description += "contract account or signer of delegate contract."
+        description = detector_terminal_description(self)
+
         filename = "missing_fee_check"
 
         return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/groupsize.py
+++ b/tealer/detectors/groupsize.py
@@ -11,6 +11,7 @@ from tealer.teal.basic_blocks import BasicBlock
 from tealer.teal.global_field import GroupSize
 from tealer.teal.instructions.instructions import Return, Int, Global
 from tealer.teal.teal import Teal
+from tealer.detectors.utils import detector_terminal_description
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -140,7 +141,7 @@ Eve receives 15 million wrapped-algos instead of 1 million wrapped-algos.\
         paths_without_check: List[List[BasicBlock]] = []
         self._check_groupsize(self.teal.bbs[0], [], paths_without_check)
 
-        description = "Lack of groupSize check found"
+        description = detector_terminal_description(self)
         filename = "missing_group_size"
 
         return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/is_deletable.py
+++ b/tealer/detectors/is_deletable.py
@@ -8,7 +8,10 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 
 if TYPE_CHECKING:
@@ -74,8 +77,8 @@ Do not approve `DeleteApplication` type application calls.
             self.teal.bbs[0], checks_field
         )
 
-        description = "Lack of txn OnCompletion == int DeleteApplication check allows to"
-        description += " delete the application."
+        description = detector_terminal_description(self)
+
         filename = "is_deletable"
 
         return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/is_updatable.py
+++ b/tealer/detectors/is_updatable.py
@@ -8,7 +8,10 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 
 if TYPE_CHECKING:
@@ -75,8 +78,7 @@ Do not approve `UpdateApplication` type application calls.
             self.teal.bbs[0], checks_field
         )
 
-        description = "Lack of txn OnCompletion == int UpdateApplication check allows to"
-        description += " update the application's approval and clear programs."
+        description = detector_terminal_description(self)
 
         filename = "is_updatable"
         return self.generate_result(paths_without_check, description, filename)

--- a/tealer/detectors/rekeyto.py
+++ b/tealer/detectors/rekeyto.py
@@ -8,7 +8,10 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations,
+    detector_terminal_description,
+)
 
 
 if TYPE_CHECKING:
@@ -105,10 +108,8 @@ Validate `RekeyTo` field in the LogicSig.
             paths_without_check_unique.append(path)
             added_paths.append(short)
 
-        description = "Lack of txn RekeyTo check allows rekeying the account to"
-        description += " attacker controlled address and control the account directly."
-        description += "\nExecution paths with missing rekeyTo check of the current transaction and"
-        description += "missing rekeyTo check of other transactions in the group."
+        description = detector_terminal_description(self)
+
         filename = "missing_rekeyto_check"
 
         return self.generate_result(paths_without_check_unique, description, filename)

--- a/tealer/detectors/utils.py
+++ b/tealer/detectors/utils.py
@@ -3,6 +3,7 @@ from typing import List, TYPE_CHECKING, Callable
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
+    from tealer.detectors.abstract_detector import AbstractDetector
 
 
 def validated_in_block(
@@ -101,3 +102,12 @@ def detect_missing_tx_field_validations(
     paths_without_check: List[List["BasicBlock"]] = []
     search_paths(entry_block, [], paths_without_check)
     return paths_without_check
+
+
+def detector_terminal_description(detector: "AbstractDetector") -> str:
+    """Return description for the detector that is printed to terminal before listing vulnerable paths."""
+    return (
+        f'\nCheck: "{detector.NAME}", Impact: {detector.IMPACT}, Confidence: {detector.CONFIDENCE}\n'
+        f"Description: {detector.DESCRIPTION}\n\n"
+        f"Wiki: {detector.WIKI_URL}\n"
+    )

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -475,7 +475,6 @@ def _verify_version(ins_list: List[Instruction], program_version: int) -> bool:
     stateless_ins: List[Instruction] = []
     error = False
 
-    print("\nchecking instruction, field versions with contract version\n")
     for ins in ins_list:
         if program_version < ins.version:
             print(

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -382,15 +382,14 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
                 Default False.
         """
 
-        print(f"\ncheck: {self.check}, impact: {self.impact}, confidence: {self.confidence}")
         print(self.description)
         if len(self.paths) == 0:
-            print("\tdetector didn't find any vulnerable paths.")
+            print("\tDetector didn't find any vulnerable paths.")
             return
         # cfg_to_dot config
         config = CFGDotConfig()
         config.color_edges = False
-        print("\tfollowing are the vulnerable paths found")
+        print("\tFollowing are the vulnerable paths found:")
         if not all_paths_in_one:
 
             for idx, path in enumerate(self._paths, start=1):
@@ -407,6 +406,7 @@ class ExecutionPaths:  # pylint: disable=too-many-instance-attributes
                     else "RED"
                 )
                 cfg_to_dot(self.cfg, config, filename)
+            print("-" * 100)
         else:
             bbs_to_highlight = []
 


### PR DESCRIPTION
When detector output paths are listed, detector information is also printed. This PR makes the detector's description uniform for all detectors. This is how terminal output looks like:

```sh
$  tealer walgo.teal
Reading contract from file: "walgo.teal"

Check: "unprotected-deletable", Impact: High, Confidence: High
Description: Unprotected Deletable Applications

Wiki: https://github.com/crytic/tealer/wiki/Detector-Documentation#unprotected-deletable-application

	Following are the vulnerable paths found:

		 path: 0 -> 1 -> 3 -> 8 -> 4
		 check file: anyone_can_delete_1.dot

		 path: 0 -> 5 -> 7 -> 6
		 check file: anyone_can_delete_2.dot
----------------------------------------------------------------------------------------------------

Check: "unprotected-updatable", Impact: High, Confidence: High
Description: Unprotected Upgradable Applications

Wiki: https://github.com/crytic/tealer/wiki/Detector-Documentation#unprotected-updatable-application

	Following are the vulnerable paths found:

		 path: 0 -> 1 -> 3 -> 8 -> 4
		 check file: anyone_can_update_1.dot

		 path: 0 -> 5 -> 7 -> 6
		 check file: anyone_can_update_2.dot
----------------------------------------------------------------------------------------------------
```