### PR TITLE
Update group-size detector to use detect_missing_tx_field for CFG traversal

### DIFF
--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -512,6 +512,7 @@ def main() -> None:
         ("Detectors", default_log),
         ("TransactionCtxAnalysis", default_log),
         ("Parsing", default_log),
+        ("Tealer", default_log),
     ]:
         logger = logging.getLogger(logger_name)
         logger.setLevel(logger_level)
@@ -526,7 +527,9 @@ def main() -> None:
     error = None
     try:
         contract_source = fetch_contract(args)
+        logger.debug("[+] Parsing the contract")
         teal = parse_teal(contract_source)
+        logger.debug("[+] Completed Parsing")
 
         detector_classes = choose_detectors(args, detector_classes, teal)
         printer_classes = choose_printers(args, printer_classes)

--- a/tealer/printers/human_summary.py
+++ b/tealer/printers/human_summary.py
@@ -151,11 +151,8 @@ class PrinterHumanSummary(AbstractPrinter):
         txt += "Subroutines:\n"
         for sub_name in teal.subroutines:
             txt += f"\t{sub_name}\n"
-        txt += "\n"
-
-        txt_detector_results = self.get_detectors_result()
-        txt += txt_detector_results
-
+            block_ids = ", ".join(repr(bi) for bi in teal.subroutines[sub_name].blocks)
+            txt += f'\t\t"{block_ids}"\n'
         txt += f"is_complex: {self._is_complex_code()}\n"
-
         print(txt)
+        print(self.get_detectors_result())

--- a/tealer/teal/context/block_transaction_context.py
+++ b/tealer/teal/context/block_transaction_context.py
@@ -26,9 +26,11 @@ class BlockTransactionContext:  # pylint: disable=too-few-public-methods, too-ma
             # information from gtxn {i} instructions.
             self.group_indices = []
             self.group_sizes = []
+            self.is_gtxn_context = True
         else:
             self.group_sizes = list(range(1, MAX_GROUP_SIZE + 1))
             self.group_indices = list(range(0, MAX_GROUP_SIZE))
+            self.is_gtxn_context = False
         self.transaction_types = list(ALL_TRANSACTION_TYPES)
         self.rekeyto: AddrFieldValue = AddrFieldValue()
         self.closeto: AddrFieldValue = AddrFieldValue()

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -538,6 +538,8 @@ def _verify_version(ins_list: List[Instruction], program_version: int) -> bool:
 
 
 def _apply_transaction_context_analysis(teal: "Teal") -> None:
+    logger = logging.getLogger("Tealer")
+    logger.debug("[+] Running Transaction context analysis")
     group_indices_cls = all_constraints.GroupIndices
     analyses_classes = [getattr(all_constraints, name) for name in dir(all_constraints)]
     analyses_classes = [
@@ -548,8 +550,10 @@ def _apply_transaction_context_analysis(teal: "Teal") -> None:
         and c != group_indices_cls
     ]
     # Run group indices analysis first as other analysis use them.
+    logger.debug(f'[+] Running txn field analysis "{group_indices_cls.__name__}"')
     group_indices_cls(teal).run_analysis()
     for cl in analyses_classes:
+        logger.debug(f'[+] Running txn field analysis: "{cl.__name__}"')
         cl(teal).run_analysis()
     # clear cache
     construct_stack_ast.cache_clear()  # construct stack ast is not used after transaction_context_analysis.

--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -9,6 +9,7 @@ Classes:
     Teal: Class to represent a contract.
 """
 
+import logging
 from pathlib import Path
 from typing import List, Any, Optional, Type, TYPE_CHECKING, Tuple, Dict
 
@@ -281,7 +282,11 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
             of a single detector.
         """
 
-        results = [d.detect() for d in self._detectors]
+        results = []
+        logger = logging.getLogger("Tealer")
+        for d in self._detectors:
+            logger.debug(f'[+] Running detector "{d.NAME}"')
+            results.append(d.detect())
 
         return results
 


### PR DESCRIPTION
Fix issue #160

Updates `detect_missing_tx_field` util function to accept another parameter `satisfies_report_condition` which is used to decide whether to report a execution path or not. `group-size-check` detector uses `satisfies_report_condition` that returns True if absolute index is used in path and returns False otherwise.