### PR TITLE
Have uniform directory structure output files

### DIFF
--- a/plugin_example/rekey_plugin/tealer_rekey_plugin/detectors/rekeyto_stateless.py
+++ b/plugin_example/rekey_plugin/tealer_rekey_plugin/detectors/rekeyto_stateless.py
@@ -8,6 +8,7 @@ from tealer.detectors.abstract_detector import (
 from tealer.teal.global_field import ZeroAddress
 from tealer.teal.instructions.instructions import Addr, Eq, Global, Int, Neq, Return, Txn
 from tealer.teal.instructions.transaction_field import RekeyTo
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
@@ -88,8 +89,4 @@ Add a check in the contract code verifying that `RekeyTo` property of any transa
         paths_without_check: List[List["BasicBlock"]] = []
         self._check_rekey_to(self.teal.bbs[0], [], paths_without_check)
 
-        description = "Lack of txn RekeyTo check allows rekeying the account to"
-        description += " attacker controlled address and control the account"
-        filename = "missing_rekeyto_check_stateless"
-
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/__main__.py
+++ b/tealer/__main__.py
@@ -451,8 +451,14 @@ def handle_output(
             print(f"Error: {error}")
             sys.exit(-1)
 
+        detectors_with_0_results: List["AbstractDetector"] = []
         for output in detector_results:
-            output.write_to_files(args.dest, args.all_paths_in_one)
+            if output.paths:
+                output.write_to_files(args.dest, args.all_paths_in_one)
+            else:
+                detectors_with_0_results.append(output.detector)
+        detectors_with_0_results_str = ", ".join(d.NAME for d in detectors_with_0_results)
+        print(f"\n 0 results found for {detectors_with_0_results_str}.")
     else:
         json_results = [output.to_json() for output in detector_results]
 

--- a/tealer/detectors/abstract_detector.py
+++ b/tealer/detectors/abstract_detector.py
@@ -44,14 +44,12 @@ Classes:
 """
 
 import abc
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from tealer.utils.comparable_enum import ComparableEnum
-from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal
-    from tealer.teal.basic_blocks import BasicBlock
     from tealer.utils.output import SupportedOutput
 
 
@@ -222,39 +220,6 @@ class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public
             raise IncorrectDetectorInitialization(
                 f"CONFIDENCE is not initialized {self.__class__.__name__}"
             )
-
-    def generate_result(
-        self, paths: List[List["BasicBlock"]], description: str, filename: str
-    ) -> ExecutionPaths:
-        """Helper method to construct ExecutionPaths result.
-
-        This function constructs and fills up the detector information of
-        ExecutionPaths object. ExecutionPaths is used to store output of
-        detector's that represent issues/vulnerabilities as execution paths.
-
-        Args:
-            paths: List of execution paths. Each execution path is represented
-                by a list of basic blocks.
-            description: Description of the issue/vulns.
-            filename: The execution paths are saved in dot files. :filename: is
-                used as the filename prefix for that dot files.
-
-        Returns:
-            ExecutionPaths object populated with the given args and detector
-            specific information.
-        """
-
-        output = ExecutionPaths(self.teal.bbs, description, filename)
-
-        for path in paths:
-            output.add_path(path)
-
-        output.check = self.NAME
-        output.impact = classification_txt[self.IMPACT]
-        output.confidence = classification_txt[self.CONFIDENCE]
-        output.help = self.WIKI_RECOMMENDATION.strip()
-
-        return output
 
     @abc.abstractmethod
     def detect(self) -> "SupportedOutput":

--- a/tealer/detectors/anyone_can_delete.py
+++ b/tealer/detectors/anyone_can_delete.py
@@ -8,11 +8,9 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
 from tealer.utils.teal_enums import TealerTransactionType
+from tealer.utils.output import ExecutionPaths
 
 
 if TYPE_CHECKING:
@@ -82,7 +80,4 @@ Eve calls `delete_application` method and deletes the application making its ass
             self.teal.bbs[0], checks_field
         )
 
-        description = detector_terminal_description(self)
-        filename = "anyone_can_delete"
-
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/anyone_can_update.py
+++ b/tealer/detectors/anyone_can_update.py
@@ -8,11 +8,9 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
 from tealer.utils.teal_enums import TealerTransactionType
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -81,7 +79,4 @@ Eve updates the application by calling `update_application` method and steals al
             self.teal.bbs[0], checks_field
         )
 
-        description = detector_terminal_description(self)
-
-        filename = "anyone_can_update"
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -8,11 +8,9 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
 from tealer.utils.teal_enums import TealerTransactionType
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -98,8 +96,4 @@ Validate `CloseRemainderTo` field in the LogicSig.
             self.teal.bbs[0], checks_field
         )
 
-        description = detector_terminal_description(self)
-
-        filename = "can_close_account"
-
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -8,11 +8,9 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
 from tealer.utils.teal_enums import TealerTransactionType
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -98,8 +96,4 @@ Validate `AssetCloseTo` field in the LogicSig.
             self.teal.bbs[0], checks_field
         )
 
-        description = detector_terminal_description(self)
-
-        filename = "can_close_asset"
-
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -14,11 +14,9 @@ from tealer.teal.instructions.instructions import (
     Txn,
 )
 from tealer.teal.instructions.transaction_field import Fee
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
 from tealer.utils.algorand_constants import MAX_TRANSACTION_COST
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -120,8 +118,4 @@ Validate `Fee` field in the LogicSig.
             self.teal.bbs[0], checks_field
         )
 
-        description = detector_terminal_description(self)
-
-        filename = "missing_fee_check"
-
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/groupsize.py
+++ b/tealer/detectors/groupsize.py
@@ -21,10 +21,9 @@ from tealer.teal.teal import Teal
 from tealer.utils.algorand_constants import MAX_GROUP_SIZE
 from tealer.utils.analyses import is_int_push_ins
 from tealer.analyses.utils.stack_ast_builder import construct_stack_ast, UnknownStackValue
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
+from tealer.utils.output import ExecutionPaths
+
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -147,10 +146,6 @@ Eve receives 15 million wrapped-algos instead of 1 million wrapped-algos.\
         paths_without_check: List[List[BasicBlock]] = detect_missing_tx_field_validations(
             self.teal.bbs[0], checks_group_size, satisfies_report_condition
         )
-
-        description = detector_terminal_description(self)
-        filename = "missing_group_size"
-
-        results = self.generate_result(paths_without_check, description, filename)
         construct_stack_ast.cache_clear()
-        return results
+
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/is_deletable.py
+++ b/tealer/detectors/is_deletable.py
@@ -8,11 +8,9 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
 from tealer.utils.teal_enums import TealerTransactionType
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -77,8 +75,4 @@ Do not approve `DeleteApplication` type application calls.
             self.teal.bbs[0], checks_field
         )
 
-        description = detector_terminal_description(self)
-
-        filename = "is_deletable"
-
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/is_updatable.py
+++ b/tealer/detectors/is_updatable.py
@@ -8,11 +8,9 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 from tealer.teal.basic_blocks import BasicBlock
-from tealer.detectors.utils import (
-    detect_missing_tx_field_validations,
-    detector_terminal_description,
-)
+from tealer.detectors.utils import detect_missing_tx_field_validations
 from tealer.utils.teal_enums import TealerTransactionType
+from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.utils.output import SupportedOutput
@@ -78,7 +76,4 @@ Do not approve `UpdateApplication` type application calls.
             self.teal.bbs[0], checks_field
         )
 
-        description = detector_terminal_description(self)
-
-        filename = "is_updatable"
-        return self.generate_result(paths_without_check, description, filename)
+        return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/detectors/utils.py
+++ b/tealer/detectors/utils.py
@@ -235,12 +235,3 @@ def detect_missing_tx_field_validations(
     paths_without_check: List[List["BasicBlock"]] = []
     search_paths(entry_block, [], paths_without_check, [(None, teal.main)], [[]])
     return paths_without_check
-
-
-def detector_terminal_description(detector: "AbstractDetector") -> str:
-    """Return description for the detector that is printed to terminal before listing vulnerable paths."""
-    return (
-        f'\nCheck: "{detector.NAME}", Impact: {detector.IMPACT}, Confidence: {detector.CONFIDENCE}\n'
-        f"Description: {detector.DESCRIPTION}\n\n"
-        f"Wiki: {detector.WIKI_URL}\n"
-    )

--- a/tealer/printers/abstract_printer.py
+++ b/tealer/printers/abstract_printer.py
@@ -11,7 +11,7 @@ Classes:
 
 import abc
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal
@@ -73,16 +73,10 @@ class AbstractPrinter(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-
             )
 
     @abc.abstractmethod
-    def print(self, dest: Optional["Path"] = None) -> None:
+    def print(self) -> None:
         """entry method of the printer.
 
         All printers must override this method with the functionality
         specific to them. This method is the entry point of the printer
         and will be called to execute it.
-
-        Args:
-            dest: if printer generates and saves output in files then
-                :dest: will be used as destination directory if given. if
-                :dest: is None, files must be saved in the current
-                directory.
         """

--- a/tealer/printers/call_graph.py
+++ b/tealer/printers/call_graph.py
@@ -1,11 +1,13 @@
 """Printer for exporting call-graph of the contract."""
 
 import html
+import os
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 from tealer.printers.abstract_printer import AbstractPrinter
 from tealer.teal.instructions.instructions import Callsub
+from tealer.utils.output import ROOT_OUTPUT_DIRECTORY
 
 
 class PrinterCallGraph(AbstractPrinter):  # pylint: disable=too-few-public-methods
@@ -58,7 +60,7 @@ class PrinterCallGraph(AbstractPrinter):  # pylint: disable=too-few-public-metho
 
         return graph
 
-    def print(self, dest: Optional["Path"] = None) -> None:
+    def print(self) -> None:
         """Export call graph of the contract in dot format.
 
         Each node in the call graph corresponds to a subroutine and edge representing call from
@@ -66,12 +68,7 @@ class PrinterCallGraph(AbstractPrinter):  # pylint: disable=too-few-public-metho
         function and represented with label `__entry__`. Call graph will be saved as `call-graph.dot`
         in the destination directory if given or else in the current directory.
         Subroutines are supported from teal version 4. so, for contracts written in lesser version, this
-        function only prints the error message stating the same.
-
-        Args:
-            dest (Optional[Path]): destination directory to save output files in. files will be saved in
-            the current directory if it is None.
-        """
+        function only prints the error message stating the same."""
 
         if self.teal.version < 4:
             print("subroutines are not supported in teal version 3 or less")
@@ -91,9 +88,12 @@ class PrinterCallGraph(AbstractPrinter):  # pylint: disable=too-few-public-metho
         dot_output += graph_edges
         dot_output += "}\n"
 
+        # outputs a single file: set the dir to {ROOT_DIRECTORY}/{CONTRACT_NAME}
+        dest = ROOT_OUTPUT_DIRECTORY / Path(self.teal.contract_name)
+        os.makedirs(dest, exist_ok=True)
+
         filename = Path("call-graph.dot")
-        if dest is not None:
-            filename = dest / filename
+        filename = dest / filename
 
         print(f"\nExported call graph to {filename}")
         with open(filename, "w", encoding="utf-8") as f:

--- a/tealer/printers/full_cfg.py
+++ b/tealer/printers/full_cfg.py
@@ -4,12 +4,11 @@ Classes:
     PrinterCFG: Printer to export contract CFG.
 """
 
+import os
 from pathlib import Path
 
-from typing import Optional
-
 from tealer.printers.abstract_printer import AbstractPrinter
-from tealer.utils.output import full_cfg_to_dot
+from tealer.utils.output import full_cfg_to_dot, ROOT_OUTPUT_DIRECTORY
 
 
 class PrinterCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
@@ -19,15 +18,13 @@ class PrinterCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
     HELP = "Export the CFG of entire contract"
     WIKI_URL = "https://github.com/crytic/tealer/wiki/Printer-documentation#cfg"
 
-    def print(self, dest: Optional[Path] = None) -> None:
-        """Export the CFG of entire contract.
+    def print(self) -> None:
+        """Export the CFG of entire contract."""
+        # outputs a single file: set the dir to {ROOT_DIRECTORY}/{CONTRACT_NAME}
+        dest = ROOT_OUTPUT_DIRECTORY / Path(self.teal.contract_name)
+        os.makedirs(dest, exist_ok=True)
 
-        Args:
-            dest (Optional[Path]): destination directory to save the dot file in.
-        """
-        if dest is None:
-            dest = Path(".")
+        filename = dest / Path("full_cfg.dot")
 
-        filename = Path("full_cfg.dot")
         print(f"\nCFG exported to file: {filename}")
-        full_cfg_to_dot(self.teal.bbs, filename=dest / filename)
+        full_cfg_to_dot(self.teal.bbs, filename=filename)

--- a/tealer/printers/function_cfg.py
+++ b/tealer/printers/function_cfg.py
@@ -13,11 +13,11 @@ Classes:
         in the contract. The CFGs will be saved in dot format.
 """
 
+import os
 from pathlib import Path
-from typing import Optional
 
 from tealer.printers.abstract_printer import AbstractPrinter
-from tealer.utils.output import all_subroutines_to_dot
+from tealer.utils.output import all_subroutines_to_dot, ROOT_OUTPUT_DIRECTORY
 
 
 class PrinterFunctionCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
@@ -33,14 +33,10 @@ class PrinterFunctionCFG(AbstractPrinter):  # pylint: disable=too-few-public-met
     HELP = "Export the CFG of each subroutine"
     WIKI_URL = "https://github.com/crytic/tealer/wiki/Printer-documentation#subroutine-cfg"
 
-    def print(self, dest: Optional[Path] = None) -> None:
-        """Export CFG of each subroutine defined in the contract.
-
-        Args:
-            dest (Optional[Path]): directory to save the generated dot files. Uses current directory
-            by default.
-        """
-        if dest is None:
-            dest = Path(".")
+    def print(self) -> None:
+        """Export CFG of each subroutine defined in the contract."""
+        # outputs multiple files: set the dir to {ROOT_DIRECTORY}/{CONTRACT_NAME}/{"print-"PRINTER_NAME}
+        dest = ROOT_OUTPUT_DIRECTORY / Path(self.teal.contract_name) / Path(f"print-{self.NAME}")
+        os.makedirs(dest, exist_ok=True)
 
         all_subroutines_to_dot(self.teal, dest)

--- a/tealer/printers/human_summary.py
+++ b/tealer/printers/human_summary.py
@@ -12,7 +12,7 @@ Summary includes :
 
 """
 
-from typing import List, Tuple, Optional, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING
 
 from tealer.printers.abstract_printer import AbstractPrinter
 from tealer.teal.instructions.instructions import contract_type_to_txt
@@ -127,16 +127,11 @@ class PrinterHumanSummary(AbstractPrinter):
 
         return txt
 
-    def print(self, dest: Optional["Path"] = None) -> None:
+    def print(self) -> None:
         """Print summary of the contract to stdout.
 
         Currently displays version, mode, number of basic blocks, instructions, subroutines,
         Names of subroutines, number of results found by detectors for each level of impact.
-
-        Args:
-            dest: if printer saves output in files then they will be saved in
-                :dest: directory. Currently, the printer doesn't save output in
-                files, this argument is ignored.
         """
 
         teal = self.teal

--- a/tealer/printers/transaction_context.py
+++ b/tealer/printers/transaction_context.py
@@ -1,10 +1,16 @@
 """Printer to output information about transaction fields in the CFG."""
 
+import os
 from pathlib import Path
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, TYPE_CHECKING
 
 from tealer.printers.abstract_printer import AbstractPrinter
-from tealer.utils.output import CFGDotConfig, full_cfg_to_dot, all_subroutines_to_dot
+from tealer.utils.output import (
+    CFGDotConfig,
+    full_cfg_to_dot,
+    all_subroutines_to_dot,
+    ROOT_OUTPUT_DIRECTORY,
+)
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
@@ -53,17 +59,12 @@ class PrinterTransactionContext(AbstractPrinter):  # pylint: disable=too-few-pub
                 str_seqs.append(" ".join(str(i) for i in seq))
         return " ".join(str_seqs)
 
-    def print(self, dest: Optional["Path"] = None) -> None:
-        """
-        Args:
-            dest (Optional[Path]): destination directory to save output files in. files will be saved in
-            the current directory if it is None.
-        """
-
+    def print(self) -> None:
         filename = Path("transaction-context.dot")
-        if dest is None:
-            # TODO: Change default directory to `tealer-export`
-            dest = Path(".")
+
+        # outputs multiple files: set the dir to {ROOT_DIRECTORY}/{CONTRACT_NAME}/{"print-"PRINTER_NAME}
+        dest = ROOT_OUTPUT_DIRECTORY / Path(self.teal.contract_name) / Path(f"print-{self.NAME}")
+        os.makedirs(dest, exist_ok=True)
 
         filename = dest / filename
 

--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -10,7 +10,6 @@ Classes:
 """
 
 import logging
-from pathlib import Path
 from typing import List, Any, Optional, Type, TYPE_CHECKING, Tuple, Dict
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorClassification
@@ -291,7 +290,7 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
         return results
 
     # from slither: Slither Class in slither/slither.py
-    def run_printers(self, dest: Optional[Path] = None) -> List:
+    def run_printers(self) -> List:
         """Run all the registered printers.
 
         Args:
@@ -305,4 +304,4 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
             of a single printer.
         """
 
-        return [p.print(dest) for p in self._printers]
+        return [p.print() for p in self._printers]


### PR DESCRIPTION
Fix #159

All output files of a contract will be saved in `"tealer-export/{contract-name}"`.
Detectors save their output files in their own subdirectory inside contract directory: `"tealer-export/{contract-name}/{detector-name}"`.
Printers that output a single file will save in the contract directory: `"tealer-export/{contract-name}"`
Printers that output multiple files will save in their own sub directory: `"tealer-export/{contract-name}/print-{printer-name}"`

Contract name is set as

- if the contract is a local file, contract-name is the local file name without `".teal"` suffix
- if the contract is an application on mainnet/testnet, the contract name will be `"app-{application_id}"`
- if the contract is an account logic-sig on mainnet/testnet, the contract name will be `"lsig-acc-{address[:8].lower()}"`
- if the contract is logic-sig of a transaction on mainnet/testnet, the contract name will be `"txn-{txn_id[:8].lower()}"`


The terminal output of detectors is also updated: When some of the detectors do not find any vulnerable paths, tealer would just print
```
0 results found for detector1, detector2, ...
```


The `--dest` command line option which allows a user to select the destination folder for output files is also removed.