### PR TITLE
Update parser to construct separate subroutine CFGs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ logging-not-lazy,
 duplicate-code,
 import-error,
 unsubscriptable-object,
+protected-access
 """

--- a/tealer/printers/full_cfg.py
+++ b/tealer/printers/full_cfg.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 from tealer.printers.abstract_printer import AbstractPrinter
-from tealer.utils.output import full_cfg_to_dot, ROOT_OUTPUT_DIRECTORY
+from tealer.utils.output import full_cfg_to_dot, ROOT_OUTPUT_DIRECTORY, full_cfg_to_dot_NEW
 
 
 class PrinterCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
@@ -28,3 +28,7 @@ class PrinterCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
 
         print(f"\nCFG exported to file: {filename}")
         full_cfg_to_dot(self.teal.bbs, filename=filename)
+
+        print("New CFG to file: new-cfg.dot")
+        with open("new-cfg.dot", "w", encoding="utf-8") as f:
+            f.write(full_cfg_to_dot_NEW(self.teal))

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -36,6 +36,7 @@ from tealer.exceptions import TealerException
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
+    from tealer.teal.subroutine import Subroutine
 
 
 class ContractType(ComparableEnum):
@@ -187,8 +188,10 @@ class Instruction:  # pylint: disable=too-many-instance-attributes
         self._tealer_comments = comments
 
     @property
-    def bb(self) -> Optional["BasicBlock"]:
+    def bb(self) -> "BasicBlock":
         """Instance of BasicBlock this instruction is part of."""
+        if self._bb is None:
+            raise TealerException(f"Instruction.bb is not initialized: {str(self)}")
         return self._bb
 
     @bb.setter
@@ -1738,6 +1741,7 @@ class Callsub(InstructionWithLabel):
         super().__init__(label)
         self._return_point: Optional[Instruction] = None
         self._version: int = 4
+        self._called_subroutine: Optional["Subroutine"] = None
 
     @property
     def return_point(self) -> Optional[Instruction]:
@@ -1759,6 +1763,19 @@ class Callsub(InstructionWithLabel):
         if self._return_point is not None:
             raise ValueError("Return point already set")
         self._return_point = ins
+
+    @property
+    def called_subroutine(self) -> "Subroutine":
+        """Return the subroutine object called by this instruction"""
+        if self._called_subroutine is None:
+            raise TealerException(
+                f"callsub.called_subroutine is accessed before assignment: {str(self)}"
+            )
+        return self._called_subroutine
+
+    @called_subroutine.setter
+    def called_subroutine(self, subroutine: "Subroutine") -> None:
+        self._called_subroutine = subroutine
 
     def __str__(self) -> str:
         return f"callsub {self._label}"

--- a/tealer/teal/subroutine.py
+++ b/tealer/teal/subroutine.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from tealer.teal.teal import Teal
 
 
-class Subroutine:
+class Subroutine:  # pylint: disable=too-many-instance-attributes
     """Represent a Teal subroutine.
 
     Main entry point code, code that is not part of any subroutine, is represented as a separate subroutine.
@@ -22,6 +22,8 @@ class Subroutine:
             b for b in blocks if len(b.next) == 0 or isinstance(b.exit_instr, Retsub)
         ]
         self._contract: Optional["Teal"] = None
+        self._caller_callsub_blocks: List["BasicBlock"] = []
+        self._return_point_blocks: List["BasicBlock"] = []
 
     @property
     def name(self) -> str:
@@ -53,3 +55,32 @@ class Subroutine:
     @contract.setter
     def contract(self, contract_obj: "Teal") -> None:
         self._contract = contract_obj
+
+    @property
+    def caller_blocks(self) -> List["BasicBlock"]:
+        """BasicBlock with callsub instructions which call this subroutine.
+
+        Returns: List of caller callsub basic blocks.
+        """
+        return self._caller_callsub_blocks
+
+    @caller_blocks.setter
+    def caller_blocks(self, caller_callsub_blocks: List["BasicBlock"]) -> None:
+        """Set caller_blocks and return point blocks
+
+        Args:
+            caller_callsub_blocks: basic blocks with callsub instruction calling this subroutine.
+        """
+        self._caller_callsub_blocks = caller_callsub_blocks
+        self._return_point_blocks = [
+            bi.next[0] for bi in caller_callsub_blocks if len(bi.next) == 1
+        ]
+
+    @property
+    def return_point_blocks(self) -> List["BasicBlock"]:
+        return self._return_point_blocks
+
+    @property
+    def retsub_blocks(self) -> List["BasicBlock"]:
+        """List of basic blocks of the subroutine containing `Retsub`."""
+        return [b for b in self._exit_blocks if isinstance(b.exit_instr, Retsub)]

--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -85,6 +85,11 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
         main: Subroutine,
         # subroutines: List[List["BasicBlock"]],
         subroutines: Dict[str, Subroutine],
+        # NEW CFG objects
+        instructions_NEW: List[Instruction],
+        bbs_NEW: List[BasicBlock],
+        main_NEW: Subroutine,
+        subroutines_NEW: Dict[str, Subroutine],
     ):
         self._instructions = instructions
         self._bbs = bbs
@@ -94,6 +99,11 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
         self._subroutines = subroutines
         self._int_constants: List[int] = []
         self._byte_constants: List[str] = []
+
+        self._instructions_NEW = instructions_NEW
+        self._bbs_NEW = bbs_NEW
+        self._main_NEW = main_NEW
+        self._subroutines_NEW = subroutines_NEW
 
         self._contract_name: str = ""
         self._detectors: List[AbstractDetector] = []

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -348,6 +348,31 @@ def full_cfg_to_dot(  # pylint: disable=too-many-locals
     return None
 
 
+def _subroutine_to_dot_NEW(subroutine: "Subroutine", ind: int) -> str:
+    dot_output = f"subgraph cluster_X{ind} {{\n label={html.escape(subroutine.name, quote=True)}\n"
+
+    for bb in subroutine.blocks:
+        dot_output += _bb_to_dot(bb, CFGDotConfig())
+    dot_output += "}"
+
+    return dot_output
+
+
+def full_cfg_to_dot_NEW(teal: "Teal") -> str:
+    """Export CFG to dot"""
+    subroutines = list(teal._subroutines_NEW.values()) + [teal._main_NEW]
+    dot_output = "digraph g{\n ranksep = 1 \n overlap = scale \n"
+    for i, subroutine in enumerate(subroutines):
+        dot_output += _subroutine_to_dot_NEW(subroutine, i)
+        for callsub in subroutine.caller_blocks:
+            edge = f"{callsub.idx}:s -> {subroutine.entry.idx}:n;\n"
+            dot_output += edge
+
+    dot_output += "}"
+
+    return dot_output
+
+
 def detector_terminal_description(detector: "AbstractDetector") -> str:
     """Return description for the detector that is printed to terminal before listing vulnerable paths."""
     return (

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -1,8 +1,9 @@
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 import pytest
 
 
 from tealer.teal.basic_blocks import BasicBlock
+from tealer.teal.subroutine import Subroutine
 from tealer.teal.instructions import instructions
 from tealer.teal.instructions import transaction_field
 from tealer.teal.parse_teal import parse_teal
@@ -49,9 +50,20 @@ ins_list = [
 ins_partitions = [(0, 2), (2, 6), (6, 8), (8, 11), (11, 14), (14, 15)]
 bbs_links = [(0, 4), (4, 1), (1, 2), (1, 3), (2, 5), (3, 5)]
 
+bbs_edges_new = [(0, 4), (4, 5), (1, 2), (1, 3)]
+
 
 MULTIPLE_RETSUB_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
 
+MULTIPLE_RETSUB_CFG_NEW = construct_cfg(ins_list, ins_partitions, bbs_edges_new)
+
+bbs = MULTIPLE_RETSUB_CFG_NEW
+MULTIPLE_RETSUB_MAIN_NEW = Subroutine("__main__", bbs[0], [bbs[0], bbs[4], bbs[5]])
+MULTIPLE_RETSUB_SUBROUTINES_NEW = {
+    "is_even": Subroutine("is_even", bbs[1], [bbs[1], bbs[2], bbs[3]])
+}
+
+MULTIPLE_RETSUB_SUBROUTINES_NEW["is_even"].caller_blocks = [bbs[4]]
 
 SUBROUTINE_BACK_JUMP = """
 #pragma version 5
@@ -86,7 +98,16 @@ ins_list = [
 ins_partitions = [(0, 2), (2, 5), (5, 8), (8, 11), (11, 12)]
 bbs_links = [(0, 3), (3, 2), (2, 1), (1, 4)]
 
+bbs_edges_new = [(0, 3), (3, 4), (2, 1)]
+
 SUBROUTINE_BACK_JUMP_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
+SUBROUTINE_BACK_JUMP_CFG_NEW = construct_cfg(ins_list, ins_partitions, bbs_edges_new)
+
+bbs = SUBROUTINE_BACK_JUMP_CFG_NEW
+SUBROUTINE_BACK_JUMP_MAIN_NEW = Subroutine("__main__", bbs[0], [bbs[0], bbs[3], bbs[4]])
+SUBROUTINE_BACK_JUMP_SUBROUTINES_NEW = {"is_odd": Subroutine("is_odd", bbs[2], [bbs[1], bbs[2]])}
+SUBROUTINE_BACK_JUMP_SUBROUTINES_NEW["is_odd"].caller_blocks = [bbs[3]]
+
 
 BRANCHING = """
 #pragma version 2
@@ -142,6 +163,14 @@ ins_partitions = [(0, 5), (5, 9), (9, 11), (11, 17), (17, 19), (19, 22)]
 bbs_links = [(0, 1), (0, 5), (1, 2), (1, 3), (3, 4), (3, 5)]
 
 BRANCHING_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
+BRANCHING_CFG_NEW = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+bbs = BRANCHING_CFG_NEW
+BRANCHING_MAIN_NEW = Subroutine(
+    "__main__", bbs[0], [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4], bbs[5]]
+)
+BRANCHING_SUBROUTINES_NEW: Dict[str, Subroutine] = {}
+
 
 LOOPS = """
 int 0
@@ -177,6 +206,12 @@ ins_partitions = [(0, 1), (1, 6), (6, 9), (9, 12)]
 bbs_links = [(0, 1), (1, 2), (1, 3), (2, 1)]
 
 LOOPS_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
+LOOPS_CFG_NEW = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+bbs = LOOPS_CFG_NEW
+LOOPS_MAIN_NEW = Subroutine("__main__", bbs[0], [bbs[0], bbs[1], bbs[2], bbs[3]])
+LOOPS_SUBROUTINES_NEW: Dict[str, Subroutine] = {}
+
 
 SWITCH_N_MATCH = """
 #pragma version 8
@@ -218,6 +253,12 @@ ins_partitions = [(0, 3), (3, 7), (7, 9), (9, 12), (12, 15)]
 bbs_links = [(0, 1), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4)]
 
 SWITCH_N_MATCH_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
+SWITCH_N_MATCH_CFG_NEW = construct_cfg(ins_list, ins_partitions, bbs_links)
+
+bbs = SWITCH_N_MATCH_CFG_NEW
+SWITCH_N_MATCH_MAIN_NEW = Subroutine("__main__", bbs[0], [bbs[0], bbs[1], bbs[2], bbs[3], bbs[4]])
+SWITCH_N_MATCH_SUBROUTINES_NEW: Dict[str, Subroutine] = {}
+
 
 ALL_TESTS = [
     (MULTIPLE_RETSUB, MULTIPLE_RETSUB_CFG),
@@ -225,6 +266,29 @@ ALL_TESTS = [
     (BRANCHING, BRANCHING_CFG),
     (LOOPS, LOOPS_CFG),
     (SWITCH_N_MATCH, SWITCH_N_MATCH_CFG),
+]
+
+ALL_TESTS_NEW = [
+    (
+        MULTIPLE_RETSUB,
+        MULTIPLE_RETSUB_CFG_NEW,
+        MULTIPLE_RETSUB_MAIN_NEW,
+        MULTIPLE_RETSUB_SUBROUTINES_NEW,
+    ),
+    (
+        SUBROUTINE_BACK_JUMP,
+        SUBROUTINE_BACK_JUMP_CFG_NEW,
+        SUBROUTINE_BACK_JUMP_MAIN_NEW,
+        SUBROUTINE_BACK_JUMP_SUBROUTINES_NEW,
+    ),
+    (BRANCHING, BRANCHING_CFG_NEW, BRANCHING_MAIN_NEW, BRANCHING_SUBROUTINES_NEW),
+    (LOOPS, LOOPS_CFG_NEW, LOOPS_MAIN_NEW, LOOPS_SUBROUTINES_NEW),
+    (
+        SWITCH_N_MATCH,
+        SWITCH_N_MATCH_CFG_NEW,
+        SWITCH_N_MATCH_MAIN_NEW,
+        SWITCH_N_MATCH_SUBROUTINES_NEW,
+    ),
 ]
 
 
@@ -238,3 +302,33 @@ def test_cfg_construction(test: Tuple[str, List[BasicBlock]]) -> None:
         print(bb)
     print("*" * 20)
     assert cmp_cfg(teal.bbs, cfg)
+
+
+@pytest.mark.parametrize("test", ALL_TESTS_NEW)  # type: ignore
+def test_cfg_construction_new(
+    test: Tuple[str, List[BasicBlock], Subroutine, Dict[str, Subroutine]]
+) -> None:
+    code, expected_cfg, expected_main, expected_subroutines = test
+    teal = parse_teal(code.strip())
+    for bb in expected_cfg:
+        print(bb)
+    for bb in teal._bbs_NEW:
+        print(bb)
+    print("*" * 20)
+    assert cmp_cfg(teal._bbs_NEW, expected_cfg)
+    test_main = teal._main_NEW
+    test_subroutines = teal._subroutines_NEW
+
+    assert cmp_cfg([test_main.entry], [expected_main.entry])
+    assert cmp_cfg(test_main.blocks, expected_main.blocks)
+
+    assert len(test_subroutines.keys()) == len(expected_subroutines.keys())
+    assert sorted(test_subroutines.keys()) == sorted(expected_subroutines.keys())
+    for ex_name in expected_subroutines:
+        test_subroutine = test_subroutines[ex_name]
+        expected_subroutine = expected_subroutines[ex_name]
+        assert test_subroutine.name == expected_subroutine.name
+        assert cmp_cfg([test_subroutine.entry], [expected_subroutine.entry])
+        assert cmp_cfg(test_subroutine.blocks, expected_subroutine.blocks)
+        assert cmp_cfg(test_subroutine.caller_blocks, expected_subroutine.caller_blocks)
+    assert len(test_subroutines) == len(expected_subroutines)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,12 +7,16 @@ from tealer.teal.instructions import instructions
 from tealer.teal.instructions.instructions import (
     IntcInstruction,
     BytecInstruction,
+    Callsub,
+    Retsub,
 )
 from tealer.teal.instructions import transaction_field
 from tealer.teal.instructions.parse_instruction import parse_line, ParseError
 from tealer.teal.parse_teal import parse_teal
 from tealer.utils.analyses import is_int_push_ins, is_byte_push_ins
+from tealer.exceptions import TealerException
 
+from tests.utils import order_basic_blocks, cmp_instructions, cmp_basic_blocks
 
 TARGETS = [
     "tests/parsing/teal1-instructions.teal",
@@ -112,6 +116,61 @@ def test_parsing(target: str) -> None:
     for i in teal.instructions:
         assert not isinstance(i, instructions.UnsupportedInstruction), f'ins "{i}" is not supported'
         print(i, i.cost)
+
+
+# test parsing by comparing old CFG and new CFG.
+@pytest.mark.parametrize("target", TARGETS)  # type: ignore
+def test_parsing_with_reference(target: str) -> None:  # pylint: disable=too-many-locals
+    with open(target, encoding="utf-8") as f:
+        teal = parse_teal(f.read())
+
+    for i in teal._instructions_NEW:
+        assert not isinstance(i, instructions.UnsupportedInstruction), f'ins "{i}" is not supported'
+        print(i, i.cost)
+
+    # instructions should be same
+    assert len(teal._instructions_NEW) == len(teal.instructions)
+    for ins_new, ins_old in zip(teal._instructions_NEW, teal.instructions):
+        assert cmp_instructions(ins_new, ins_old)
+
+    # divison of contract into basic blocks should also be same
+    assert len(teal._bbs_NEW) == len(teal.bbs)
+    bbs_new = order_basic_blocks(teal._bbs_NEW)
+    bbs_old = order_basic_blocks(teal.bbs)
+    for bb_new, bb_old in zip(bbs_new, bbs_old):
+        assert bb_new.idx == bb_old.idx
+        assert cmp_basic_blocks(bb_new, bb_old)
+
+    # next blocks of blocks ending with callsub should be different
+    # next blocks of blocks ending with retsub should be different
+    # Other blocks should have same next blocks
+    for bb_new, bb_old in zip(bbs_new, bbs_old):
+        if isinstance(bb_new.exit_instr, Retsub):
+            # retsub is exit instruction
+            assert len(bb_new.next) == 0
+            continue
+        if isinstance(bb_new.exit_instr, Callsub):
+            # callsub has one next block unless it is the last instruction
+            assert len(bb_new.next) == 0 or len(bb_new.next) == 1
+            if len(bb_new.next) == 0:
+                continue
+            # return points should be equal
+            return_point_block_new = bb_new.next[0]
+            assert isinstance(bb_old.exit_instr, Callsub)
+            assert bb_old.exit_instr.return_point
+            return_point_block_old = bb_old.exit_instr.return_point.bb
+
+            assert return_point_block_new.idx == return_point_block_old.idx
+            assert cmp_basic_blocks(return_point_block_new, return_point_block_old)
+            continue
+
+        next_new = order_basic_blocks(list(set(bb_new.next)))
+        next_old = order_basic_blocks(list(set(bb_old.next)))
+
+        assert len(next_new) == len(next_old)
+        for bi, bj in zip(next_new, next_old):
+            assert bi.idx == bj.idx
+            assert cmp_basic_blocks(bi, bj)
 
 
 def _cmp_instructions(
@@ -305,7 +364,7 @@ def test_cost_values() -> None:
     for line in CURRENT_TEST_CODE.strip().splitlines():
         # when cost parameter accessed, it checks that instruction object's BasicBlock is not none. if it is none, then
         # cost property raises exception. These tests are included to cover those brances.
-        with pytest.raises(ValueError):
+        with pytest.raises(TealerException):
             print(line)
             # pylint: disable=expression-not-assigned
             parse_line(line).cost  # type: ignore


### PR DESCRIPTION
For each stage of the parsing, new function is added which has the same functionality with the difference that this new variant constructs the new CFG. New CFG is CFG where callsub instructions are not connected to the subroutine entry block and subroutine retsub blocks are not connected to return points.

Parsing is done two times, the first time to construct the old CFG using the old functions for each pass and the second time to construct the new CFG using the new functions of each pass. Separate objects of instructions, basic blocks, and subroutines are created for the old and new CFG.

The Teal class is updated to store the new CFG objects alongside the old CFG objects. Every function, class member, and the properties have a `_NEW` suffix to differentiate between objects of the same name in old and new CFG. At the end of the refactoring, The old properties, and functions should be removed, and run the tests after that, update the `_NEW` functions, ... to the old names in a separate PR.

Some tests are updated to use the new CFG, and new objects, and test them. An additional test is also added which takes the new CFG and compares it against the old CFG.

`protected-access` is disabled for now because all `_NEW` do not have corresponding class properties. We should enable it at the end of the refactoring.

