### PR TITLE
Update txn field analysis to use new CFG

### DIFF
--- a/tealer/analyses/dataflow/addr_fields.py
+++ b/tealer/analyses/dataflow/addr_fields.py
@@ -13,6 +13,7 @@ from tealer.analyses.utils.stack_ast_builder import KnownStackValue, UnknownStac
 
 if TYPE_CHECKING:
     from tealer.teal.instructions.instructions import Instruction
+    from tealer.teal.basic_blocks import BasicBlock
     from tealer.teal.context.block_transaction_context import (
         AddrFieldValue,
         BlockTransactionContext,
@@ -158,6 +159,11 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
         ctx_addr_value.possible_addr = list(addr_values - set([ANY_ADDRESS, NO_ADDRESS]))
 
     def _store_results(self) -> None:
+        # we performed analysis using new CFG basic blocks.
+        # store the results in the old CFG basic blocks to reuse the old tests.
+        old_blocks: List["BasicBlock"] = sorted(self._teal.bbs, key=lambda bb: bb.idx)
+        new_blocks: List["BasicBlock"] = sorted(self._teal._bbs_NEW, key=lambda bb: bb.idx)
+
         key_and_addr_obj: List[
             Tuple[str, Callable[["BlockTransactionContext"], "AddrFieldValue"]]
         ] = [
@@ -169,13 +175,14 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
         for key, addr_field_obj in key_and_addr_obj:
             if key not in self.BASE_KEYS:
                 continue
-            for b in self._teal.bbs:
+            for block_old, block_new in zip(old_blocks, new_blocks):
                 self._set_addr_values(
-                    addr_field_obj(b.transaction_context), self._block_contexts[key][b]
+                    addr_field_obj(block_old.transaction_context),
+                    self._block_contexts[key][block_new],
                 )
                 for idx in range(16):
-                    addr_values = self._block_contexts[self.gtx_key(idx, key)][b]
+                    addr_values = self._block_contexts[self.gtx_key(idx, key)][block_new]
                     self._set_addr_values(
-                        addr_field_obj(b.transaction_context.gtxn_context(idx)),
+                        addr_field_obj(block_old.transaction_context.gtxn_context(idx)),
                         addr_values,
                     )

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -24,6 +24,7 @@ The final result of parsing is the Control Flow Graph(CFG) of the
 contract represented by sequence of the basic blocks.
 
 """
+# pylint: disable=too-many-lines
 
 import inspect
 import sys
@@ -984,13 +985,23 @@ def parse_teal_NEW(  # pylint: disable=too-many-locals
         for ins in subroutine_callsubs[subroutine_name]:
             ins.called_subroutine = subroutine_obj
 
+        # set subroutine to each basic block
+        for bi in subroutine_blocks:
+            bi.subroutine_NEW = subroutine_obj
         subroutines[subroutine_name] = subroutine_obj
 
     main_entry_point_blocks = _identify_subroutine_blocks_NEW(all_bbs[0])
     main_program_name = "__main__"
     main_program = Subroutine(main_program_name, all_bbs[0], main_entry_point_blocks)
+    for bi in main_entry_point_blocks:
+        bi.subroutine_NEW = main_program
 
     # TODO: Handle unreachable basic blocks.
     # Note: PyTeal generated contracts have unreachable code.
+    # unreachable blocks are not part of any subroutine and their subroutine_NEW field would not have been set.
+    # set main_program as the default subroutine for now.
+    for bi in all_bbs:
+        if bi._subroutine is None:
+            bi.subroutine_NEW = main_program
 
     return instructions, all_bbs, main_program, subroutines

--- a/tests/parsing/teal8-instructions.teal
+++ b/tests/parsing/teal8-instructions.teal
@@ -1,6 +1,4 @@
-#pragma version 8
-
-
+#pragma version 8 // B0
 int 1
 int 2
 int 3
@@ -10,22 +8,30 @@ dupn 1
 pushbytess b32(AA) base64 AA 0x00 "00"
 pushints 1 2 3 4 0x5
 callsub label1
-proto 1 2
+
+proto 1 2   // B1
 frame_dig 1
 frame_bury 1
 switch label2 label3
-match label2 label3
-box_create
+
+match label2 label3     // B2
+
+box_create              // B3
 box_extract
 box_replace
 box_del
 box_len
 box_get
 box_put
-label1:
+int 1
+return
+
+label1:                 // B4
 int 1
 retsub
-label2:
+
+label2:                 // B5
 int 2
-label3:
+
+label3:                 // B6
 int 3


### PR DESCRIPTION
The analysis is still performed on the global CFG where callsub are considered as connected to the subroutine entry blocks, etc. However, the objects used are part of the new CFG.

The result of the analysis is stored in the old CFG block objects to reuse the old tests.

Added new members to BasicBlock class. The new member check that values are properly initialized instead of returning `Optional[...]` type value. If a member is intended to be initialized at the time of parsing, then the properties of the corresponding members check the member is properly initialized. Otherwise, raise an TealerException.

[tests/parsing/teal8-instructions.teal](https://github.com/crytic/tealer/compare/dev-new-parsing...dev-new-txn-analysis?expand=1#diff-0bd779bafcd7f23bd3052d65d61f2e096a06c9cc750630efa257362ca61212df) is updated. previous code is invalid code, the execution B3 block would fall through to B4 block. B4  is a subroutine and B3 does not call the subroutine. When Retsub will be executed in B4, the execution would fail at runtime.

