### PR TITLE
Update txn context tests to use new blocks

### DIFF
--- a/tealer/analyses/dataflow/addr_fields.py
+++ b/tealer/analyses/dataflow/addr_fields.py
@@ -159,11 +159,6 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
         ctx_addr_value.possible_addr = list(addr_values - set([ANY_ADDRESS, NO_ADDRESS]))
 
     def _store_results(self) -> None:
-        # we performed analysis using new CFG basic blocks.
-        # store the results in the old CFG basic blocks to reuse the old tests.
-        old_blocks: List["BasicBlock"] = sorted(self._teal.bbs, key=lambda bb: bb.idx)
-        new_blocks: List["BasicBlock"] = sorted(self._teal._bbs_NEW, key=lambda bb: bb.idx)
-
         key_and_addr_obj: List[
             Tuple[str, Callable[["BlockTransactionContext"], "AddrFieldValue"]]
         ] = [
@@ -175,14 +170,14 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
         for key, addr_field_obj in key_and_addr_obj:
             if key not in self.BASE_KEYS:
                 continue
-            for block_old, block_new in zip(old_blocks, new_blocks):
+            for block in self._teal._bbs_NEW:
                 self._set_addr_values(
-                    addr_field_obj(block_old.transaction_context),
-                    self._block_contexts[key][block_new],
+                    addr_field_obj(block.transaction_context),
+                    self._block_contexts[key][block],
                 )
                 for idx in range(16):
-                    addr_values = self._block_contexts[self.gtx_key(idx, key)][block_new]
+                    addr_values = self._block_contexts[self.gtx_key(idx, key)][block]
                     self._set_addr_values(
-                        addr_field_obj(block_old.transaction_context.gtxn_context(idx)),
+                        addr_field_obj(block.transaction_context.gtxn_context(idx)),
                         addr_values,
                     )

--- a/tealer/analyses/dataflow/fee_field.py
+++ b/tealer/analyses/dataflow/fee_field.py
@@ -188,22 +188,17 @@ class FeeField(DataflowTransactionContext):
         return res
 
     def _store_results(self) -> None:
-        # we performed analysis using new CFG basic blocks.
-        # store the results in the old CFG basic blocks to reuse the old tests.
-        old_blocks: List["BasicBlock"] = sorted(self._teal.bbs, key=lambda bb: bb.idx)
-        new_blocks: List["BasicBlock"] = sorted(self._teal._bbs_NEW, key=lambda bb: bb.idx)
-
-        for block_old, block_new in zip(old_blocks, new_blocks):
-            max_fee = self._block_contexts[FEE_KEY][block_new]
+        for block in self._teal._bbs_NEW:
+            max_fee = self._block_contexts[FEE_KEY][block]
             assert isinstance(max_fee, FeeValue)
             if max_fee.is_unknown:
-                block_old.transaction_context.max_fee_unknown = True
+                block.transaction_context.max_fee_unknown = True
             else:
-                block_old.transaction_context.max_fee = max_fee.value
+                block.transaction_context.max_fee = max_fee.value
             for idx in range(MAX_GROUP_SIZE):
-                max_fee = self._block_contexts[self.gtx_key(idx, FEE_KEY)][block_new]
+                max_fee = self._block_contexts[self.gtx_key(idx, FEE_KEY)][block]
                 assert isinstance(max_fee, FeeValue)
                 if max_fee.is_unknown:
-                    block_old.transaction_context.gtxn_context(idx).max_fee_unknown = True
+                    block.transaction_context.gtxn_context(idx).max_fee_unknown = True
                 else:
-                    block_old.transaction_context.gtxn_context(idx).max_fee = max_fee.value
+                    block.transaction_context.gtxn_context(idx).max_fee = max_fee.value

--- a/tealer/analyses/dataflow/generic.py
+++ b/tealer/analyses/dataflow/generic.py
@@ -226,7 +226,7 @@ if any of equation in Or(<1>, ...) is UnknownStackValue then `true_values` for O
 
 from abc import ABC, abstractmethod
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Set, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Set
 
 from tealer.teal.instructions.instructions import (
     Assert,
@@ -553,17 +553,10 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
 
         This requires that group_indices analysis is done before any other analysis.
         """
-        # block is new CFG block. transaction contexts are stored in old CFG blocks
-        # find the corresponding block in the old CFG and access transaction_context from it.
-        old_block: Optional["BasicBlock"] = None
-        for bi in self._teal.bbs:
-            if bi.idx == block.idx:
-                old_block = bi
-        assert old_block is not None
         for key in keys_with_gtxn:
             for ind in range(MAX_GROUP_SIZE):
                 gtx_key = self.gtx_key(ind, key)
-                if ind in old_block.transaction_context.group_indices:
+                if ind in block.transaction_context.group_indices:
                     # txn can have index {ind}
                     # gtxn {ind} {field} can have a value if and only if {txn} {field} can also have that value
                     self._block_contexts[gtx_key][block] = self._intersection(

--- a/tealer/analyses/dataflow/int_fields.py
+++ b/tealer/analyses/dataflow/int_fields.py
@@ -199,15 +199,10 @@ class GroupIndices(DataflowTransactionContext):  # pylint: disable=too-few-publi
                 range(0, max(group_sizes_context[bi], default=0))
             )
 
-        # we performed analysis using new CFG basic blocks.
-        # store the results in the old CFG basic blocks to reuse the old tests.
-        old_blocks: List["BasicBlock"] = sorted(self._teal.bbs, key=lambda bb: bb.idx)
-        new_blocks: List["BasicBlock"] = sorted(self._teal._bbs_NEW, key=lambda bb: bb.idx)
-
         group_size_block_context = self._block_contexts[self.GROUP_SIZE_KEY]
-        for block_old, block_new in zip(old_blocks, new_blocks):
-            block_old.transaction_context.group_sizes = list(group_size_block_context[block_new])
+        for block in self._teal._bbs_NEW:
+            block.transaction_context.group_sizes = list(group_size_block_context[block])
 
         group_index_block_context = self._block_contexts[self.GROUP_INDEX_KEY]
-        for block_old, block_new in zip(old_blocks, new_blocks):
-            block_old.transaction_context.group_indices = list(group_index_block_context[block_new])
+        for block in self._teal._bbs_NEW:
+            block.transaction_context.group_indices = list(group_index_block_context[block])

--- a/tealer/analyses/dataflow/txn_types.py
+++ b/tealer/analyses/dataflow/txn_types.py
@@ -186,18 +186,10 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
 
     def _store_results(self) -> None:
         transaction_type_context = self._block_contexts[self.TRANSACTION_TYPE_KEY]
-        # we performed analysis using new CFG basic blocks.
-        # store the results in the old CFG basic blocks to reuse the old tests.
-        old_blocks: List["BasicBlock"] = sorted(self._teal.bbs, key=lambda bb: bb.idx)
-        new_blocks: List["BasicBlock"] = sorted(self._teal._bbs_NEW, key=lambda bb: bb.idx)
 
-        for block_old, block_new in zip(old_blocks, new_blocks):
-            block_old.transaction_context.transaction_types = list(
-                transaction_type_context[block_new]
-            )
+        for block in self._teal._bbs_NEW:
+            block.transaction_context.transaction_types = list(transaction_type_context[block])
 
             for idx in range(16):
-                values = self._block_contexts[self.gtx_key(idx, self.TRANSACTION_TYPE_KEY)][
-                    block_new
-                ]
-                block_old.transaction_context.gtxn_context(idx).transaction_types = list(values)
+                values = self._block_contexts[self.gtx_key(idx, self.TRANSACTION_TYPE_KEY)][block]
+                block.transaction_context.gtxn_context(idx).transaction_types = list(values)

--- a/tealer/detectors/utils.py
+++ b/tealer/detectors/utils.py
@@ -40,12 +40,6 @@ def validated_in_block(
     """
     # if field is checked using `txn {field}`, return true
 
-    # access transaction context using the block of the old CFG.
-    assert block.teal
-    for bb in block.teal.bbs:
-        if bb.idx == block.idx:
-            block = bb
-            break
     if checks_field(block.transaction_context):
         return True
     # for each possible {index} the transaction can have, check if field is checked using `gtxn {index} {field}`

--- a/tests/transaction_context/test_addr_fields.py
+++ b/tests/transaction_context/test_addr_fields.py
@@ -107,7 +107,7 @@ def test_addr_fields(  # pylint: disable=too-many-locals
     ex_closeto_any, ex_closeto_none, ex_closeto = values[1]
     ex_assetcloseto_any, ex_assetcloseto_none, ex_assetcloseto = values[2]
 
-    bbs = order_basic_blocks(teal.bbs)
+    bbs = order_basic_blocks(teal._bbs_NEW)
     for b in bbs:
         if idx == -1:
             ctx = b.transaction_context

--- a/tests/transaction_context/test_fee.py
+++ b/tests/transaction_context/test_fee.py
@@ -407,7 +407,7 @@ def test_tx_types_gtxn(
 
     teal = parse_teal(code.strip())
 
-    bbs = order_basic_blocks(teal.bbs)
+    bbs = order_basic_blocks(teal._bbs_NEW)
     for i, b in enumerate(bbs):
         print("X:", i, repr(b), b.transaction_context.max_fee)
         if isinstance(max_fees_list[i], bool):

--- a/tests/transaction_context/test_group_indices.py
+++ b/tests/transaction_context/test_group_indices.py
@@ -183,6 +183,6 @@ def test_group_indices(test: Tuple[str, List[List[int]]]) -> None:
     code, group_indices = test
     teal = parse_teal(code.strip())
 
-    bbs = order_basic_blocks(teal.bbs)
+    bbs = order_basic_blocks(teal._bbs_NEW)
     for b, indices in zip(bbs, group_indices):
         assert b.transaction_context.group_indices == indices

--- a/tests/transaction_context/test_group_sizes.py
+++ b/tests/transaction_context/test_group_sizes.py
@@ -289,7 +289,7 @@ def test_group_sizes(test: Tuple[str, List[BasicBlock]]) -> None:
     print("*" * 20)
     assert cmp_cfg(teal.bbs, cfg_tested)
 
-    bbs = order_basic_blocks(teal.bbs)
+    bbs = order_basic_blocks(teal._bbs_NEW)
     cfg_tested = order_basic_blocks(cfg_tested)
     for b1, b2 in zip(bbs, cfg_tested):
         print(b1.transaction_context.group_sizes, b2.transaction_context.group_sizes)
@@ -321,7 +321,7 @@ def test_group_indices(test: Tuple[str, List[List[int]]]) -> None:
     code, group_indices_list = test
     teal = parse_teal(code.strip())
 
-    bbs = order_basic_blocks(teal.bbs)
+    bbs = order_basic_blocks(teal._bbs_NEW)
     for bb_tested, group_indices in zip(bbs, group_indices_list):
         print(bb_tested.transaction_context.group_indices, group_indices)
         assert bb_tested.transaction_context.group_indices == group_indices

--- a/tests/transaction_context/test_stack_emulation.py
+++ b/tests/transaction_context/test_stack_emulation.py
@@ -691,7 +691,7 @@ def test_just_detectors(test: Tuple[str, List[KnownStackValue]]) -> None:
     code, expected_stack_values = test
     teal = parse_teal(code.strip())
     test_values: List[KnownStackValue] = []
-    for bi in teal.bbs:
+    for bi in teal._bbs_NEW:
         values = construct_stack_ast(bi)
         for ins in bi.instructions:
             test_values.append(values[ins])
@@ -703,7 +703,7 @@ def test_just_detectors(test: Tuple[str, List[KnownStackValue]]) -> None:
 
 if __name__ == "__main__":
     teal_obj = parse_teal(T2)
-    for bb in teal_obj.bbs:
+    for bb in teal_obj._bbs_NEW:
         print(bb)
         result = construct_stack_ast(bb)
         for i in bb.instructions:

--- a/tests/transaction_context/test_transaction_types.py
+++ b/tests/transaction_context/test_transaction_types.py
@@ -322,7 +322,7 @@ def test_tx_types(test: Tuple[str, List[List[int]], int]) -> None:
     code, tx_types_list, idx = test
     teal = parse_teal(code.strip())
 
-    bbs = order_basic_blocks(teal.bbs)
+    bbs = order_basic_blocks(teal._bbs_NEW)
     for b, tx_types in zip(bbs, tx_types_list):
         if idx == -1:
             ctx = b.transaction_context
@@ -504,7 +504,7 @@ def test_tx_types_gtxn(
     code, ex_txn_types_list, ex_gtxn_types_list = test
 
     teal = parse_teal(code.strip())
-    bbs = order_basic_blocks(teal.bbs)
+    bbs = order_basic_blocks(teal._bbs_NEW)
     print("number of blocks:", len(bbs))
     for block_num, b in enumerate(bbs):
         print(block_num, b)


### PR DESCRIPTION
In the previous PR, the transaction context information was computed using the new blocks and results are stored in the old blocks. This PR stores the results in the new blocks and updates necessary tests.