### PR TITLE
Update cfg-to-dot conversion functions to use new CFG

### DIFF
--- a/tealer/detectors/utils.py
+++ b/tealer/detectors/utils.py
@@ -235,13 +235,4 @@ def detect_missing_tx_field_validations(
     paths_without_check: List[List["BasicBlock"]] = []
     search_paths(entry_block, [], paths_without_check, [(None, teal._main_NEW)], [[]])
 
-    # convert the path from new blocks to old blocks
-    converted_paths = []
-    d = {bb.idx: bb for bb in teal.bbs}
-    for path in paths_without_check:
-        s = []
-        for bb in path:
-            s.append(d[bb.idx])
-        converted_paths.append(s)
-
-    return converted_paths
+    return paths_without_check

--- a/tealer/printers/full_cfg.py
+++ b/tealer/printers/full_cfg.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 
 from tealer.printers.abstract_printer import AbstractPrinter
-from tealer.utils.output import full_cfg_to_dot, ROOT_OUTPUT_DIRECTORY, full_cfg_to_dot_NEW
+from tealer.utils.output import full_cfg_to_dot, ROOT_OUTPUT_DIRECTORY
 
 
 class PrinterCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
@@ -27,8 +27,4 @@ class PrinterCFG(AbstractPrinter):  # pylint: disable=too-few-public-methods
         filename = dest / Path("full_cfg.dot")
 
         print(f"\nCFG exported to file: {filename}")
-        full_cfg_to_dot(self.teal.bbs, filename=filename)
-
-        print("New CFG to file: new-cfg.dot")
-        with open("new-cfg.dot", "w", encoding="utf-8") as f:
-            f.write(full_cfg_to_dot_NEW(self.teal))
+        full_cfg_to_dot(self.teal, filename=filename)

--- a/tealer/printers/transaction_context.py
+++ b/tealer/printers/transaction_context.py
@@ -76,7 +76,7 @@ class PrinterTransactionContext(AbstractPrinter):  # pylint: disable=too-few-pub
         config = CFGDotConfig()
         config.bb_additional_comments = get_info
         # generate a Full CFG with all group-size, group-index comments
-        full_cfg_to_dot(self.teal.bbs, config, filename)
+        full_cfg_to_dot(self.teal, config, filename)
         # Also generate shortened CFGs with group-size and group-index comments.
         all_subroutines_to_dot(
             self.teal, dest, config, "txn_ctx"

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -698,7 +698,7 @@ def _identify_subroutine_blocks_NEW(entry_block: "BasicBlock") -> List["BasicBlo
         subroutines_blocks.append(bb)
 
         for next_bb in bb.next:
-            if next_bb not in subroutines_blocks:
+            if next_bb not in subroutines_blocks and next_bb not in stack:
                 stack.append(next_bb)
 
     return subroutines_blocks


### PR DESCRIPTION
The updated function output dot files similar to previous function. The only difference is the updated functions use the new CFG blocks. The output is same as examples in the [Printer documentation](https://github.com/crytic/tealer/wiki/Printer-documentation).