### PR TITLE
Remove old code for constructing old CFG

### DIFF
--- a/plugin_example/rekey_plugin/tealer_rekey_plugin/detectors/rekeyto_stateless.py
+++ b/plugin_example/rekey_plugin/tealer_rekey_plugin/detectors/rekeyto_stateless.py
@@ -87,6 +87,6 @@ Add a check in the contract code verifying that `RekeyTo` property of any transa
     def detect(self) -> "SupportedOutput":
 
         paths_without_check: List[List["BasicBlock"]] = []
-        self._check_rekey_to(self.teal.bbs[0], [], paths_without_check)
+        self._check_rekey_to(self.teal._bbs_NEW[0], [], paths_without_check)
 
         return ExecutionPaths(self.teal, self, paths_without_check)

--- a/tealer/teal/basic_blocks.py
+++ b/tealer/teal/basic_blocks.py
@@ -122,28 +122,6 @@ class BasicBlock:  # pylint: disable=too-many-instance-attributes,too-many-publi
         self._idx = i
 
     @property
-    def callsub_block(self) -> Optional["BasicBlock"]:
-        """If this block is the return point of a subroutine, `callsub_block` is the block
-        that called the subroutine.
-        """
-        return self._callsub_block
-
-    @callsub_block.setter
-    def callsub_block(self, b: "BasicBlock") -> None:
-        self._callsub_block = b
-
-    @property
-    def sub_return_point(self) -> Optional["BasicBlock"]:
-        """If a subroutine is executed after this block i.e exit instruction is callsub.
-        then, sub_return_point will be basic block that will be executed after the subroutine.
-        """
-        return self._sub_return_point
-
-    @sub_return_point.setter
-    def sub_return_point(self, b: "BasicBlock") -> None:
-        self._sub_return_point = b
-
-    @property
     def cost(self) -> int:
         """cost of executing all instructions in this basic block"""
         return sum(ins.cost for ins in self.instructions)

--- a/tealer/teal/instructions/instructions.py
+++ b/tealer/teal/instructions/instructions.py
@@ -72,7 +72,6 @@ class Instruction:  # pylint: disable=too-many-instance-attributes
         self._bb: Optional["BasicBlock"] = None
         self._version: int = 1
         self._mode: ContractType = ContractType.ANY
-        self._callsub_ins: Optional["Instruction"] = None
 
     def add_prev(self, prev_ins: "Instruction") -> None:
         """Add instruction that may execute just before this instruction.
@@ -1739,30 +1738,8 @@ class Callsub(InstructionWithLabel):
 
     def __init__(self, label: str):
         super().__init__(label)
-        self._return_point: Optional[Instruction] = None
         self._version: int = 4
         self._called_subroutine: Optional["Subroutine"] = None
-
-    @property
-    def return_point(self) -> Optional[Instruction]:
-        """Return point of this call instruction.
-
-        Execution returns to the next instruction of the call instruction
-        after executing the called subroutine. This property returns instance
-        of that instruction. This is helpful in construction of contract CFG and
-        subroutine CFGs.
-        """
-        # TODO: raise Error if return_point is None
-        # if self._return_point is None:
-        # return point is accessed before assignment
-        # raise TealerException(f"Callsub return point is accessed before assignment: {str(self)}")
-        return self._return_point
-
-    @return_point.setter
-    def return_point(self, ins: Instruction) -> None:
-        if self._return_point is not None:
-            raise ValueError("Return point already set")
-        self._return_point = ins
 
     @property
     def called_subroutine(self) -> "Subroutine":

--- a/tealer/teal/parse_teal.py
+++ b/tealer/teal/parse_teal.py
@@ -98,72 +98,6 @@ def _detect_contract_type(instructions: List[Instruction]) -> ContractType:
     return ContractType.ANY
 
 
-def create_bb(instructions: List[Instruction], all_bbs: List[BasicBlock]) -> None:
-    """Construct basic blocks and add basic block sequential links.
-
-    This function is the third pass of the teal parser. Instructions are
-    divided into basic blocks based on the following rules:
-
-    * A new basic block is created for each Label instruction.
-    * Instructions B, Err, Return, Callsub, Retsub are exit instructions
-        of a basic block. A new basic block is created for instructions
-        following them.
-    * A instruction with multiple next instructions is a exit instruction
-        of the basic block. A new basic block is created for instructions
-        following them.
-
-    This function also adds sequential links between the constructed basic
-    blocks. Two sequential basic blocks are linked if the exit instruction
-    of the first basic block is sequentially previous instruction to the
-    entry instruction of the second basic block.
-
-    This is a "in place" function, given arguments are modified with the
-    data this function is supposed to return.
-
-    Args:
-        instructions: List of parsed instruction objects.
-        all_bbs: List of BasicBlock objects representing the teal contract.
-            This is an "in place" argument, the basic blocks created in
-            the function are appended to this list in the order they are created.
-    """
-
-    bb: Optional[BasicBlock] = BasicBlock()
-    if bb:  # to make mypy happy
-        all_bbs.append(bb)
-    for ins in instructions:
-
-        if isinstance(ins, Label) or not bb:
-            # use bb if it is empty instead of creating new BasicBlock.
-            if bb is None or len(bb.instructions) != 0:
-                next_bb = BasicBlock()
-                all_bbs.append(next_bb)
-                if bb:
-                    bb.add_next(next_bb)
-                    next_bb.add_prev(bb)
-                bb = next_bb
-        bb.add_instruction(ins)
-        ins.bb = bb
-
-        if ins.callsub_ins is not None and ins.bb is not None:
-            # callsub is before this instruction in the code. so, bb should have been assigned
-            # already
-            callsub_basic_block = ins.callsub_ins.bb
-            if callsub_basic_block is not None:
-                ins.bb.callsub_block = callsub_basic_block
-                callsub_basic_block.sub_return_point = ins.bb
-
-        if len(ins.next) > 1 and not isinstance(ins, Retsub):
-            if not isinstance(ins.next[0], Label):
-                next_bb = BasicBlock()
-                all_bbs.append(next_bb)
-                bb.add_next(next_bb)
-                next_bb.add_prev(bb)
-                bb = next_bb
-
-        if len(ins.next) == 0 or isinstance(ins, (B, Err, Return, Callsub, Retsub)):
-            bb = None
-
-
 def create_bb_NEW(instructions: List[Instruction], all_bbs: List[BasicBlock]) -> None:
     """Construct basic blocks and add basic block default edges.
 
@@ -239,118 +173,6 @@ def _add_instruction_comments(ins: Instruction) -> None:
         method_signature.strip('"')  # quotes are not removed while parsing
         method_selector = get_method_selector(method_signature)
         ins.tealer_comments.append(f"method-selector: {method_selector}")
-
-
-def _first_pass(  # pylint: disable=too-many-branches
-    lines: List[str],
-    labels: Dict[str, Label],
-    rets: Dict[str, List[Instruction]],
-    instructions: List[Instruction],
-) -> Tuple[List[Intcblock], List[Bytecblock]]:
-    """Parse instructions and add sequential instruction links.
-
-    This function is the first pass of the teal parser. Source code
-    lines are parsed into corresponding Instruction objects and non-jump
-    instructions are linked. Adding instructions links is linking two
-    instruction objects as previous and next. Non-jump instruction links
-    are links between instructions that are previous, next in terms of
-    execution flow as well as previous, next in terms of source code i.e
-    links that are directly evident from just those two instructions that
-    are continous in source code. Jump links are links between branch
-    instructions and their destination, callsub and their destination,
-    retsub and their return points, etc. This function adds non-jump or
-    sequential instruction links.
-
-    This is a "in place" function, given arguments are modified with the
-    data this function is supposed to return.
-
-    Args:
-        lines: List of source code lines of a teal contract.
-        labels: Dict map from teal label string to the parsed label instruction.
-            instance. This argument is an "in place" argument and will be
-            populated by the function while parsing.
-        rets: Dict map from teal label string of a subroutine to list of it's
-            return point instructions. subroutines are supported from teal v4 and
-            can be called with callsub instruction using the label of the subroutine.
-            The execution flow is passed from the subroutine to next instruction of
-            the callsub after executing the subroutine. This variable stores all those
-            return points(next instruction after callsub) for each subroutine label
-            in the contract.
-            This argument is an "in place" argument and will be populated by the
-            function while parsing.
-        instructions: List of parsed instruction objects.
-            This argument is also an "in place" argument and will be populated
-            by the function while parsing.
-    """
-
-    # First pass over the intructions list: Add non-jump instruction links and collect meta-data
-    idx = 0
-    prev: Optional[Instruction] = None  # Flag: last instruction was an unconditional jump
-    call: Optional[Callsub] = None  # Flag: last instruction was a callsub
-    intcblock_ins: List[Intcblock] = []  # List of intcblock instructions present in the contract
-    bytecblock_ins: List[Bytecblock] = []  # List of bytecblock instructions present in the contract
-
-    instruction_comments: List[str] = []
-    for line in lines:
-        try:
-            if line.strip().startswith("//"):
-                # is a comment without any instruction
-                instruction_comments.append(line)
-                ins = None
-            else:
-                ins = parse_line(line)
-                if ins and instruction_comments:
-                    ins.comments_before_ins = list(instruction_comments)
-                    instruction_comments = []
-        except ParseError as e:
-            print(f"Parse error at line {idx}: {e}")
-            sys.exit(1)
-        idx = idx + 1
-        if not ins:
-            continue
-
-        if isinstance(ins, Intcblock):
-            intcblock_ins.append(ins)
-        elif isinstance(ins, Bytecblock):
-            bytecblock_ins.append(ins)
-
-        ins.line = idx
-        _add_instruction_comments(ins)
-
-        # A label? Add it to the global label list
-        if isinstance(ins, Label):
-            labels[ins.label] = ins
-
-        # If the prev. ins. was anything other than an unconditional jump, then link the two instructions
-        if prev:
-            ins.add_prev(prev)
-            prev.add_next(ins)
-
-        # If the prev. inst was a callsub, add the current instruction as a return point for the callsub label
-        if call:
-            call.return_point = ins
-            if call.label in rets.keys():
-                rets[call.label].append(ins)
-            else:
-                rets[call.label] = [ins]
-            ins.callsub_ins = call  # ins is the return point when call is executed.
-
-        # Now prepare for the next-line instruction
-        # A flag that says that this was an unconditional jump
-        prev = ins
-        if isinstance(ins, (B, Err, Return, Callsub, Retsub)):
-            prev = None
-
-        # A flag that says that this was a callsub
-        call = None
-        if isinstance(ins, Callsub):
-            call = ins
-            if call.label not in rets.keys():
-                rets[call.label] = []
-
-        # Finally, add the instruction to the instruction list
-        instructions.append(ins)
-    return intcblock_ins, bytecblock_ins
 
 
 def _first_pass_NEW(  # pylint: disable=too-many-branches
@@ -441,84 +263,6 @@ def _first_pass_NEW(  # pylint: disable=too-many-branches
     return intcblock_ins, bytecblock_ins
 
 
-def _second_pass(  # pylint: disable=too-many-branches
-    instructions: List[Instruction],
-    labels: Dict[str, Label],
-    rets: Dict[str, List[Instruction]],
-) -> None:
-    """Add jump or non-sequential instruction links.
-
-    This function is second pass of the teal parser. Adding jump links is
-    linking two instruction objects where execution flow is passed
-    from the first instruction to the second instruction because of
-    a jump. A jump is passing execution from one instruction to the
-    next that are not sequential. A execution jump might happen because
-    of branch, callsub, retsub instructions in TEAL. This function links
-    such pairs of instructions as previous, next.
-
-    Args:
-        instructions: List of parsed instruction objects.
-        labels: Dict map from teal label string to the parsed label instruction.
-        rets: Dict map from teal label string of a subroutine to list of it's
-            return point instructions.
-    """
-    logger_parsing.debug("Second Pass")
-    # Second pass over the instructions list: Add instruction links for jumps
-    for ins in instructions:
-
-        # If a labeled jump, link the ins. to its label
-        if isinstance(ins, (B, BZ, BNZ, Callsub)):
-            ins.add_next(labels[ins.label])
-            labels[ins.label].add_prev(ins)
-
-        # if switch or match, link the ins to its labels
-        if isinstance(ins, (Switch, Match)):
-            for ins_label in ins.labels:
-                ins.add_next(labels[ins_label])
-                labels[ins_label].add_prev(ins)
-
-    # link retsub instructions to return points of corresponding subroutines
-    retsubs: Dict[str, List[Retsub]] = {}  # map each subroutine label to list of it's retsubs
-    for subroutine in rets:
-        label = labels[subroutine]
-        retsubs[subroutine] = []
-        logger_parsing.debug(f"    Label = {label}")
-        # use dfs to find all retsub instructions starting from subroutine label instruction
-        stack: List[Instruction] = []
-        visited: List[Instruction] = []
-
-        stack.append(label)
-        while len(stack) > 0:
-            ins = stack.pop()
-            logger_parsing.debug(f"     Ins = {ins}")
-            visited.append(ins)
-
-            if isinstance(ins, Retsub):
-                retsubs[subroutine].append(ins)
-                continue
-
-            if isinstance(ins, Callsub):
-                # don't follow callsub path, which in itself is another subroutine
-                if ins.return_point is None:
-                    continue
-                next_ins = ins.return_point
-                if next_ins not in visited:
-                    stack.append(next_ins)
-            else:
-                for next_ins in ins.next:
-                    logger_parsing.debug(f"     next_ins = {next_ins}")
-
-                    if next_ins not in visited:
-                        stack.append(next_ins)
-
-    # link retsub to return points
-    for subroutine in rets:
-        for return_point in rets[subroutine]:
-            for retsub_ins in retsubs[subroutine]:
-                retsub_ins.add_next(return_point)
-                return_point.add_prev(retsub_ins)
-
-
 def _second_pass_NEW(  # pylint: disable=too-many-branches
     instructions: List[Instruction],
     labels: Dict[str, Label],
@@ -548,54 +292,6 @@ def _second_pass_NEW(  # pylint: disable=too-many-branches
             for ins_label in ins.labels:
                 ins.add_next(labels[ins_label])
                 labels[ins_label].add_prev(ins)
-
-
-def _fourth_pass(instructions: List[Instruction]) -> None:  # pylint: disable=too-many-branches
-    """Add jump or non-sequential basic block links.
-
-    This function is the fourth pass of the teal parser. Jump links
-    are added between two basic blocks if there is a jump link from
-    exit instruction of the first basic block to the entry instruction
-    of the second basic block.
-
-    Args:
-        instructions: List of parsed instruction objects.
-    """
-
-    # Fourth pass over the instructiions list: Add jump-based basic block links
-    for ins in instructions:
-        # A branching instruction with more than one target (other than a retsub)
-        if len(ins.next) > 1 and not isinstance(ins, (Retsub, Switch, Match)):
-            branch = ins.next[1]
-            if branch.bb and ins.bb:
-                branch.bb.add_prev(ins.bb)
-            if ins.bb and branch.bb:
-                ins.bb.add_next(branch.bb)
-        # A single-target branching instruction (b or callsub or bz/bnz appearing as the last instruction in the list)
-        if isinstance(ins, (B, Callsub)) or (
-            ins == instructions[-1] and isinstance(ins, (BZ, BNZ))
-        ):
-            dst = ins.next[0].bb
-            if dst and ins.bb:
-                dst.add_prev(ins.bb)
-            if ins.bb and dst:
-                ins.bb.add_next(dst)
-        # A retsub
-        if isinstance(ins, Retsub):
-            for branch in ins.next:
-                if branch.bb and ins.bb:
-                    branch.bb.add_prev(ins.bb)
-                if ins.bb and branch.bb:
-                    ins.bb.add_next(branch.bb)
-        # switch and match
-        if isinstance(ins, (Switch, Match)):
-            bb = ins.bb
-            for next_ins in ins.next:
-                if next_ins.bb and bb:
-                    if next_ins.bb not in bb.next:
-                        bb.add_next(next_ins.bb)
-                    if bb not in next_ins.bb.prev:
-                        next_ins.bb.add_prev(bb)
 
 
 def _fourth_pass_NEW(basic_blocks: List[BasicBlock]) -> None:  # pylint: disable=too-many-branches
@@ -635,46 +331,6 @@ def _add_basic_blocks_idx(bbs: List[BasicBlock]) -> List[BasicBlock]:
     for i, bb in enumerate(bbs):
         bb.idx = i
     return bbs
-
-
-def _identify_subroutine_blocks(entry_block: "BasicBlock") -> List["BasicBlock"]:
-    """find all the basic blocks part of a subroutine given it's label instruction.
-
-    Args:
-        label ("Label"): label instruction of the subroutine.
-        bbs (List["BasicBlock"]): CFG of the contract.
-
-    Returns:
-        "BasicBlock": Entry block of the subroutine.
-        List["BasicBlock"]: list of all basic blocks part of a subroutine.
-    """
-
-    subroutines_blocks: List["BasicBlock"] = []
-    stack: List["BasicBlock"] = []
-
-    stack.append(entry_block)
-    while len(stack) > 0:
-        bb = stack.pop()
-        subroutines_blocks.append(bb)
-
-        # check for retsub before exploring as retsubs are connected to return points
-        if isinstance(bb.exit_instr, Retsub):
-            continue
-
-        # callsub return point is part of the subroutine
-        if isinstance(bb.exit_instr, Callsub):
-            return_point = bb.exit_instr.return_point
-
-            if return_point and return_point.bb not in subroutines_blocks:
-                if return_point.bb is not None:
-                    stack.append(return_point.bb)
-            continue
-
-        for next_bb in bb.next:
-            if next_bb not in subroutines_blocks:
-                stack.append(next_bb)
-
-    return subroutines_blocks
 
 
 def _identify_subroutine_blocks_NEW(entry_block: "BasicBlock") -> List["BasicBlock"]:
@@ -826,115 +482,6 @@ def parse_teal(  # pylint: disable=too-many-locals
 
     Parsing teal cotracts consists of four passes:
 
-    #. Parses instructions and adds sequential instruction links.
-    #. Adds jump based instruction links.
-    #. Constructs basic blocks and adds sequential basic block links.
-    #. Adds jump based basic block links.
-
-    This function also performs basic version checks on the instructions
-    and fields.
-
-    Teal object is created with the parsed instructions, basic blocks and
-    subroutines identified in the contract.
-
-    Args:
-        source_code: TEAL source code of the contract.
-
-    Returns:
-        Teal object representing the given contract created with the related
-        information.
-    """
-
-    instructions: List[Instruction] = []  # Parsed instructions list
-    labels: Dict[str, Label] = {}  # Global map of label names to label instructions
-    rets: Dict[str, List[Instruction]] = {}  # Lists of return points corresponding to labels
-
-    lines = source_code.splitlines()
-
-    intcblock_ins, bytecblock_ins = _first_pass(lines, labels, rets, instructions)
-    logger_parsing.debug(f"rets = {rets}")
-    _second_pass(instructions, labels, rets)
-    logger_parsing.debug("instruction and nexts")
-    for ins in instructions:
-        logger_parsing.debug(f"     {ins}, next: {ins.next}")
-    # Third pass over the instructions list: Construct the basic blocks and sequential links
-    all_bbs: List[BasicBlock] = []
-    create_bb(instructions, all_bbs)
-
-    _fourth_pass(instructions)
-
-    all_bbs = _add_basic_blocks_idx(all_bbs)
-    mode = _detect_contract_type(instructions)
-
-    version = 1
-    if isinstance(instructions[0], Pragma):
-        version = instructions[0].program_version
-
-    _verify_version(instructions, version)
-
-    subroutines: Dict[str, "Subroutine"] = {}
-    if version >= 4:
-        for subroutine_label in rets:
-            label_ins = labels[subroutine_label]
-            # if label_ins.bb is None:
-            # TODO: Move the `is None` check to `Instruction.bb` property.
-            # Above TODO is done and the following statement is not reachable.
-            # commented for mypy
-            # continue
-            subroutine_entry_block = label_ins.bb
-            # add tealer comment "Subroutine: {label}" to the subroutine entry block
-            subroutine_entry_block.tealer_comments.append(f"Subroutine {subroutine_label}")
-
-            subroutine_blocks = _identify_subroutine_blocks(subroutine_entry_block)
-            subroutines[subroutine_label] = Subroutine(
-                subroutine_label, subroutine_entry_block, subroutine_blocks
-            )
-
-    main_entry_point_blocks = _identify_subroutine_blocks(all_bbs[0])
-    main_program_name = ""
-    main_program = Subroutine(main_program_name, all_bbs[0], main_entry_point_blocks)
-
-    instructions_NEW, all_bbs_NEW, main_NEW, subroutines_NEW = parse_teal_NEW(
-        source_code, contract_name
-    )
-    teal = Teal(
-        instructions,
-        all_bbs,
-        version,
-        mode,
-        main_program,
-        subroutines,
-        instructions_NEW,
-        all_bbs_NEW,
-        main_NEW,
-        subroutines_NEW,
-    )
-
-    # set teal instance to it's basic blocks
-    for bb in teal.bbs + all_bbs_NEW:
-        bb.teal = teal
-        # Add tealer comment of cost and id
-        bb.tealer_comments.insert(0, f"block_id = {bb.idx}; cost = {bb.cost}")
-
-    for subroutine in (
-        [main_program] + teal.subroutines_list + [main_NEW] + list(subroutines_NEW.values())
-    ):
-        subroutine.contract = teal
-
-    teal.contract_name = contract_name
-    _fill_intc_bytec_info(intcblock_ins, bytecblock_ins, all_bbs[0], teal)
-    _apply_transaction_context_analysis(teal)
-
-    return teal
-
-
-def parse_teal_NEW(  # pylint: disable=too-many-locals
-    source_code: str, _contract_name: str = ""
-) -> Tuple[List[Instruction], List[BasicBlock], Subroutine, Dict[str, Subroutine]]:
-    """Parse algorand smart contracts written in teal.
-
-    Parsing teal cotracts consists of four passes:
-
     #. Parses instructions and adds default edges between instructions.
     #. Adds jump edges between links.
     #. Constructs basic blocks and adds default edges between basic block.
@@ -954,7 +501,9 @@ def parse_teal_NEW(  # pylint: disable=too-many-locals
 
     lines = source_code.splitlines()
 
-    _, _ = _first_pass_NEW(lines, labels, subroutine_callsubs, instructions)
+    intcblock_ins, bytecblock_ins = _first_pass_NEW(
+        lines, labels, subroutine_callsubs, instructions
+    )
     logger_parsing.debug(f"subroutine_callsubs = {subroutine_callsubs}")
     _second_pass_NEW(instructions, labels)
     logger_parsing.debug("instruction and nexts")
@@ -968,6 +517,13 @@ def parse_teal_NEW(  # pylint: disable=too-many-locals
     _fourth_pass_NEW(all_bbs)
 
     all_bbs = _add_basic_blocks_idx(all_bbs)
+    mode = _detect_contract_type(instructions)
+
+    version = 1
+    if isinstance(instructions[0], Pragma):
+        version = instructions[0].program_version
+
+    _verify_version(instructions, version)
 
     subroutines: Dict[str, "Subroutine"] = {}
     for subroutine_name in subroutine_callsubs:
@@ -1004,4 +560,18 @@ def parse_teal_NEW(  # pylint: disable=too-many-locals
         if bi._subroutine is None:
             bi.subroutine_NEW = main_program
 
-    return instructions, all_bbs, main_program, subroutines
+    teal = Teal(version, mode, instructions, all_bbs, main_program, subroutines)
+
+    # set teal instance for it's basic blocks
+    for bb in teal._bbs_NEW:
+        bb.teal = teal
+        bb.tealer_comments.insert(0, f"block_id = {bb.idx}; cost = {bb.cost}")
+
+    for subroutine in [main_program] + list(subroutines.values()):
+        subroutine.contract = teal
+
+    teal.contract_name = contract_name
+    _fill_intc_bytec_info(intcblock_ins, bytecblock_ins, teal._main_NEW.entry, teal)
+    _apply_transaction_context_analysis(teal)
+
+    return teal

--- a/tealer/teal/teal.py
+++ b/tealer/teal/teal.py
@@ -10,7 +10,7 @@ Classes:
 """
 
 import logging
-from typing import List, Any, Optional, Type, TYPE_CHECKING, Tuple, Dict
+from typing import List, Any, Type, TYPE_CHECKING, Tuple, Dict
 
 from tealer.detectors.abstract_detector import AbstractDetector, DetectorClassification
 from tealer.printers.abstract_printer import AbstractPrinter
@@ -78,25 +78,16 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        instructions: List[Instruction],
-        bbs: List[BasicBlock],
         version: int,
         mode: ContractType,
-        main: Subroutine,
-        # subroutines: List[List["BasicBlock"]],
-        subroutines: Dict[str, Subroutine],
         # NEW CFG objects
         instructions_NEW: List[Instruction],
         bbs_NEW: List[BasicBlock],
         main_NEW: Subroutine,
         subroutines_NEW: Dict[str, Subroutine],
     ):
-        self._instructions = instructions
-        self._bbs = bbs
         self._version = version
         self._mode = mode
-        self._main = main
-        self._subroutines = subroutines
         self._int_constants: List[int] = []
         self._byte_constants: List[str] = []
 
@@ -108,16 +99,6 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
         self._contract_name: str = ""
         self._detectors: List[AbstractDetector] = []
         self._printers: List[AbstractPrinter] = []
-
-    @property
-    def instructions(self) -> List[Instruction]:
-        """List of instructions of the contract"""
-        return self._instructions
-
-    @property
-    def bbs(self) -> List[BasicBlock]:
-        """CFG of the contract"""
-        return self._bbs
 
     @property
     def version(self) -> int:
@@ -151,31 +132,12 @@ class Teal:  # pylint: disable=too-many-instance-attributes,too-many-public-meth
         self._mode = m
 
     @property
-    def main(self) -> "Subroutine":
-        "Returns subroutine representing the contract entry-point"
-        return self._main
-
-    @property
-    def subroutines(self) -> Dict[str, "Subroutine"]:
-        """Returns dict of subroutine names and corresponding subroutine obj."""
-        return self._subroutines
-
-    @property
-    def subroutines_list(self) -> List["Subroutine"]:
-        """Returns list of all contract's subroutines"""
-        return list(self._subroutines.values())
-
-    @property
     def contract_name(self) -> str:
         return self._contract_name
 
     @contract_name.setter
     def contract_name(self, name: str) -> None:
         self._contract_name = name
-
-    def subroutine(self, name: str) -> Optional["Subroutine"]:
-        """Return subroutine with id/name `name`, return none if subroutine does not exist."""
-        return self._subroutines.get(name, None)
 
     def get_int_constant(self, index: int) -> Tuple[bool, int]:
         """Return int value stored by intcblock instruction

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -48,7 +48,7 @@ ins_list = [
 ]
 
 ins_partitions = [(0, 2), (2, 6), (6, 8), (8, 11), (11, 14), (14, 15)]
-bbs_links = [(0, 4), (4, 1), (1, 2), (1, 3), (2, 5), (3, 5)]
+bbs_links = [(0, 4), (4, 5), (1, 2), (1, 3)]
 
 bbs_edges_new = [(0, 4), (4, 5), (1, 2), (1, 3)]
 
@@ -96,7 +96,7 @@ ins_list = [
 ]
 
 ins_partitions = [(0, 2), (2, 5), (5, 8), (8, 11), (11, 12)]
-bbs_links = [(0, 3), (3, 2), (2, 1), (1, 4)]
+bbs_links = [(0, 3), (3, 4), (2, 1)]
 
 bbs_edges_new = [(0, 3), (3, 4), (2, 1)]
 
@@ -298,10 +298,10 @@ def test_cfg_construction(test: Tuple[str, List[BasicBlock]]) -> None:
     teal = parse_teal(code.strip())
     for bb in cfg:
         print(bb)
-    for bb in teal.bbs:
+    for bb in teal._bbs_NEW:
         print(bb)
     print("*" * 20)
-    assert cmp_cfg(teal.bbs, cfg)
+    assert cmp_cfg(teal._bbs_NEW, cfg)
 
 
 @pytest.mark.parametrize("test", ALL_TESTS_NEW)  # type: ignore

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -56,7 +56,7 @@ def test_just_detectors(test: Tuple[str, Type[AbstractDetector], List[List[int]]
     teal = parse_teal(code.strip())
     teal.register_detector(detector)
     result = teal.run_detectors()[0]
-    for bi in teal.bbs:
+    for bi in teal._bbs_NEW:
         print(
             bi,
             bi.idx,

--- a/tests/test_parsing_using_pyteal.py
+++ b/tests/test_parsing_using_pyteal.py
@@ -26,6 +26,6 @@ TARGETS = [
 def test_parsing_using_pyteal(target: str) -> None:
     teal = parse_teal(target)
     # print instruction to trigger __str__ on each ins
-    for i in teal.instructions:
+    for i in teal._instructions_NEW:
         assert not isinstance(i, instructions.UnsupportedInstruction), f'ins "{i}" is not supported'
         print(i, i.cost)

--- a/tests/test_subroutine_identification.py
+++ b/tests/test_subroutine_identification.py
@@ -51,7 +51,7 @@ ins_list = [
 ]
 
 ins_partitions = [(0, 2), (2, 5), (5, 9), (9, 10), (10, 11), (11, 14), (14, 17), (17, 18)]
-bbs_links = [(0, 6), (6, 2), (2, 3), (2, 5), (3, 1), (1, 4), (4, 7), (5, 7)]
+bbs_links = [(0, 6), (2, 3), (2, 5), (3, 4), (6, 7)]
 
 bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
 MULTIPLE_RETSUB_MAIN = Subroutine("", bbs[0], [bbs[0], bbs[6], bbs[7]])
@@ -91,7 +91,7 @@ ins_list = [
 ]
 
 ins_partitions = [(0, 2), (2, 5), (5, 8), (8, 11), (11, 12)]
-bbs_links = [(0, 3), (3, 2), (2, 1), (1, 4)]
+bbs_links = [(0, 3), (3, 4), (2, 1)]
 
 bbs = construct_cfg(ins_list, ins_partitions, bbs_links)
 SUBROUTINE_BACK_JUMP_MAIN = Subroutine("", bbs[0], [bbs[0], bbs[3], bbs[4]])
@@ -107,12 +107,12 @@ ALL_TESTS = [
 def test_subroutine_identification(test: Tuple[str, Subroutine, Dict[str, Subroutine]]) -> None:
     code, expected_main, expected_subroutines = test
     teal = parse_teal(code.strip())
-    test_main = teal.main
+    test_main = teal._main_NEW
 
     assert cmp_cfg([test_main.entry], [expected_main.entry])
     assert cmp_cfg(test_main.blocks, expected_main.blocks)
 
-    subroutines = teal.subroutines
+    subroutines = teal._subroutines_NEW
     assert len(subroutines.keys()) == len(expected_subroutines.keys())
     assert sorted(subroutines.keys()) == sorted(expected_subroutines.keys())
     for ex_name in expected_subroutines:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -25,7 +25,7 @@ field_info_pattern = re.compile(r"\(version: ([0-9]+)\)")
 def test_instruction_version(target: str) -> None:
     with open(target, encoding="utf-8") as f:
         teal = parse_teal(f.read())
-    for ins in teal.instructions:
+    for ins in teal._instructions_NEW:
         match_obj = instruction_info_pattern.search(ins.comment)
         if match_obj is None:
             continue
@@ -45,7 +45,7 @@ def test_instruction_version(target: str) -> None:
 def test_field_version(target: str) -> None:
     with open(target, encoding="utf-8") as f:
         teal = parse_teal(f.read())
-    for ins in teal.instructions:
+    for ins in teal._instructions_NEW:
         field = getattr(ins, "field", None)
         if field is None:
             continue

--- a/tests/transaction_context/test_group_sizes.py
+++ b/tests/transaction_context/test_group_sizes.py
@@ -72,7 +72,7 @@ ins_list = [
 ]
 
 ins_partitions = [(0, 2), (2, 6), (6, 12), (12, 19), (19, 26), (26, 27)]
-bbs_links = [(0, 4), (4, 1), (1, 2), (1, 3), (2, 5), (3, 5)]
+bbs_links = [(0, 4), (4, 5), (1, 2), (1, 3)]
 
 MULTIPLE_RETSUB_CFG_GROUP_SIZES = [[2], [2], [2], [2], [2], [2]]
 
@@ -126,7 +126,7 @@ ins_list = [
 ]
 
 ins_partitions = [(0, 2), (2, 5), (5, 16), (16, 19), (19, 20)]
-bbs_links = [(0, 3), (3, 2), (2, 1), (1, 4)]
+bbs_links = [(0, 3), (3, 4), (2, 1)]
 
 SUBROUTINE_BACK_JUMP_CFG_GROUP_SIZES = [[1, 3], [1, 3], [1, 3], [1, 3], [1, 3], [1, 3]]
 SUBROUTINE_BACK_JUMP_CFG = construct_cfg(ins_list, ins_partitions, bbs_links)
@@ -287,7 +287,7 @@ def test_group_sizes(test: Tuple[str, List[BasicBlock]]) -> None:
     for bb_tested in cfg_tested:
         print(bb_tested)
     print("*" * 20)
-    assert cmp_cfg(teal.bbs, cfg_tested)
+    assert cmp_cfg(teal._bbs_NEW, cfg_tested)
 
     bbs = order_basic_blocks(teal._bbs_NEW)
     cfg_tested = order_basic_blocks(cfg_tested)


### PR DESCRIPTION
- Removes the old code used to construct the old CFG from parse_teal.py
- Removes the Teal class attributes, BasicBlock class attributes and Instruction class attributes. These attributes are either not needed or the class has other attributes which store the new version(CFG) of the corresponding attribute.

The next PR will re-add some/most of these members that return new objects. The main reason to divide this into PRs is to use the mypy and linters to properly updated all places in code where old objects are being used. The tests may not find all usages. Enabling the `protected-access` in the next PR eases the update.
