### PR TITLE
Remove unreachable blocks from CFG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "requests",
         "pyyaml",
     ],
-    extras_require={"dev": ["pylint==2.13.4", "black==22.3.0", "mypy==0.942"]},
+    extras_require={"dev": ["pylint==2.13.4", "black==22.3.0", "mypy==0.942", "pytest-cov"]},
     license="AGPL-3.0",
     long_description=long_description,
     entry_points={"console_scripts": ["tealer = tealer.__main__:main"]},

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -126,10 +126,6 @@ def test_parsing(target: str) -> None:
 # pylint: disable=too-many-locals
 @pytest.mark.parametrize("target", TARGETS)  # type: ignore
 def test_copy_main_cfg(target: str) -> None:
-    if target == "tests/parsing/teal4-test3.teal":
-        # the contract has unreachable blocks. Unreachable are
-        # part of main.blocks but they are absent in copied_blocks.
-        return
     with open(target, encoding="utf-8") as f:
         teal = parse_teal(f.read())
     copied_main = copy_main_cfg(teal)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -126,7 +126,6 @@ def test_parsing(target: str) -> None:
         print(i, i.stack_push_size)
 
 
-
 # pylint: disable=too-many-locals
 @pytest.mark.parametrize("target", TARGETS)  # type: ignore
 def test_copy_main_cfg(target: str) -> None:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -118,9 +118,13 @@ def test_parsing(target: str) -> None:
     with open(target, encoding="utf-8") as f:
         teal = parse_teal(f.read())
     # print instruction to trigger __str__ on each ins
+    # print stack pop/push to trigger the function on each ins
     for i in teal.instructions:
         assert not isinstance(i, instructions.UnsupportedInstruction), f'ins "{i}" is not supported'
         print(i, i.cost)
+        print(i, i.stack_pop_size)
+        print(i, i.stack_push_size)
+
 
 
 # pylint: disable=too-many-locals

--- a/tests/test_parsing_using_pyteal.py
+++ b/tests/test_parsing_using_pyteal.py
@@ -26,6 +26,9 @@ TARGETS = [
 def test_parsing_using_pyteal(target: str) -> None:
     teal = parse_teal(target)
     # print instruction to trigger __str__ on each ins
+    # print stack pop/push to trigger the function on each ins
     for i in teal.instructions:
         assert not isinstance(i, instructions.UnsupportedInstruction), f'ins "{i}" is not supported'
         print(i, i.cost)
+        print(i, i.stack_pop_size)
+        print(i, i.stack_push_size)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,10 +15,14 @@ def order_basic_blocks(bbs: List[BasicBlock]) -> List[BasicBlock]:
 
 def cmp_basic_blocks(b1: BasicBlock, b2: BasicBlock) -> bool:
     if len(b1.instructions) != len(b2.instructions):
+        print(
+            f"number of instructions are different: {len(b1.instructions)}, {len(b2.instructions)}"
+        )
         return False
 
     for ins1, ins2 in zip(b1.instructions, b2.instructions):
         if not cmp_instructions(ins1, ins2):
+            print(f"instructions comparison faile: {ins1}, {ins2}")
             return False
 
     return True
@@ -26,35 +30,39 @@ def cmp_basic_blocks(b1: BasicBlock, b2: BasicBlock) -> bool:
 
 def cmp_cfg(bbs1: List[BasicBlock], bbs2: List[BasicBlock]) -> bool:
     if len(bbs1) != len(bbs2):
+        print(f"number of blocks are different: {len(bbs1)}, {len(bbs2)}")
         return False
     bbs1, bbs2 = map(order_basic_blocks, (bbs1, bbs2))
 
     for bb1, bb2 in zip(bbs1, bbs2):
-        print("1")
+        print(f"comparing bb1: {bb1.idx}, bb2: {bb2.idx}\nbb1:\n{bb1}\nbb2:\n{bb2}\n")
         if not cmp_basic_blocks(bb1, bb2):
             return False
-        print("2")
 
         if len(bb1.prev) != len(bb2.prev):
+            print(f"number of prev blocks are different: {len(bb1.prev)}, {len(bb2.prev)}")
             print(bb1.prev)
             print(bb2.prev)
             return False
-        print("3")
 
         if len(bb1.next) != len(bb2.next):
+            print(f"number of next blocks are different: {len(bb1.next)}, {len(bb2.next)}")
+            print(bb1.next)
+            print(bb2.next)
             return False
 
         bbs_prev_1, bbs_prev_2 = map(order_basic_blocks, (bb1.prev, bb2.prev))
-        print(bb1.idx, "Reached")
         for bbp1, bbp2 in zip(bbs_prev_1, bbs_prev_2):
-            print(bbp1.entry_instr.line, bbp2.entry_instr.line)
             if bbp1.entry_instr.line != bbp2.entry_instr.line:
+                print("entry lines of previous blocks is different")
+                print(bbp1.entry_instr.line, bbp2.entry_instr.line)
                 return False
 
         bbs_next_1, bbs_next_2 = map(order_basic_blocks, (bb1.next, bb2.next))
         for bbn1, bbn2 in zip(bbs_next_1, bbs_next_2):
-            print(bbn1.entry_instr.line, bbn2.entry_instr.line)
             if bbn1.entry_instr.line != bbn2.entry_instr.line:
+                print("entry lines of next blocks is different")
+                print(bbn1.entry_instr.line, bbn2.entry_instr.line)
                 return False
 
     return True


### PR DESCRIPTION
Previously, the blocks which are unreachable from the contract entry block are still part of the `teal.blocks` and other reachable blocks would have them as `previous` blocks.

This PR updates the parsing to remove unreachable blocks and instructions part of those blocks.