### PR TITLE
Simplify output class

### DIFF
--- a/plugin_example/rekey_plugin/tealer_rekey_plugin/detectors/rekeyto_stateless.py
+++ b/plugin_example/rekey_plugin/tealer_rekey_plugin/detectors/rekeyto_stateless.py
@@ -13,7 +13,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -79,7 +79,7 @@ Alice signs the logic-sig to allow recurring payments to Bob.\
 Validate `RekeyTo` field in the LogicSig.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing CloseRemainderTo check.
 
         Returns:
@@ -96,7 +96,7 @@ Validate `RekeyTo` field in the LogicSig.
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/plugin_example/template/tealer_plugin/detectors/example.py
+++ b/plugin_example/template/tealer_plugin/detectors/example.py
@@ -8,7 +8,7 @@ from tealer.detectors.abstract_detector import (
 
 
 if TYPE_CHECKING:
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
 
 
 class Example(AbstractDetector):  # pylint: disable=too-few-public-methods
@@ -28,7 +28,7 @@ class Example(AbstractDetector):  # pylint: disable=too-few-public-methods
     WIKI_EXPLOIT_SCENARIO = ""
     WIKI_RECOMMENDATION = ""  # this will be shown in json output as help message
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """This method will be called if this detector is chosen.
 
         Implement this method to return output in one of the supported formats (ExecutionPaths).

--- a/tealer/detectors/abstract_detector.py
+++ b/tealer/detectors/abstract_detector.py
@@ -50,7 +50,7 @@ from tealer.utils.comparable_enum import ComparableEnum
 
 if TYPE_CHECKING:
     from tealer.tealer import Tealer
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
 
 
 class IncorrectDetectorInitialization(Exception):
@@ -222,7 +222,7 @@ class AbstractDetector(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public
             )
 
     @abc.abstractmethod
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Entry method of detector.
 
         All detectors must override this method with the functionality specific

--- a/tealer/detectors/anyone_can_delete.py
+++ b/tealer/detectors/anyone_can_delete.py
@@ -14,7 +14,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -60,7 +60,7 @@ Eve calls `delete_application` method and deletes the application making its ass
 - Add access controls to the vulnerable method.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths missing validations on sender field AND can delete the application .
 
         Returns:
@@ -80,7 +80,7 @@ Eve calls `delete_application` method and deletes the application making its ass
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/anyone_can_update.py
+++ b/tealer/detectors/anyone_can_update.py
@@ -13,7 +13,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -59,7 +59,7 @@ Eve updates the application by calling `update_application` method and steals al
 - Add access controls to the vulnerable method.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect paths missing validations on sender field AND allows to update the application.
 
         Returns:
@@ -79,7 +79,7 @@ Eve updates the application by calling `update_application` method and steals al
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -13,7 +13,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -75,7 +75,7 @@ Alice signs the logic-sig to allow recurring payments to Bob.\
 Validate `CloseRemainderTo` field in the LogicSig.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing CloseRemainderTo check.
 
         Returns:
@@ -96,7 +96,7 @@ Validate `CloseRemainderTo` field in the LogicSig.
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -13,7 +13,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -75,7 +75,7 @@ Alice signs the logic-sig to allow recurring payments to Bob in USDC.\
 Validate `AssetCloseTo` field in the LogicSig.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing AssetCloseTo check.
 
         Returns:
@@ -96,7 +96,7 @@ Validate `AssetCloseTo` field in the LogicSig.
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -12,7 +12,7 @@ from tealer.utils.algorand_constants import MAX_TRANSACTION_COST
 from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.basic_blocks import BasicBlock
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
@@ -76,7 +76,7 @@ Alice signs the logic-sig to allow recurring payments to Bob.\
 Validate `Fee` field in the LogicSig.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing Fee check.
 
         Returns:
@@ -93,7 +93,7 @@ Validate `Fee` field in the LogicSig.
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/groupsize.py
+++ b/tealer/detectors/groupsize.py
@@ -26,7 +26,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.instructions.instructions import Instruction
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
 
@@ -122,7 +122,7 @@ Eve receives 15 million wrapped-algos instead of 1 million wrapped-algos.\
                 return True
         return False
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing GroupSize check.
 
         Returns:
@@ -153,7 +153,7 @@ Eve receives 15 million wrapped-algos instead of 1 million wrapped-algos.\
         )
         construct_stack_ast.cache_clear()
 
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/is_deletable.py
+++ b/tealer/detectors/is_deletable.py
@@ -13,7 +13,7 @@ from tealer.utils.teal_enums import TealerTransactionType
 from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.basic_blocks import BasicBlock
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
@@ -59,7 +59,7 @@ Eve steals application creator's private key and deletes the application. Applic
 Do not approve `DeleteApplication` type application calls.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing DeleteApplication check.
 
         Returns:
@@ -76,7 +76,7 @@ Do not approve `DeleteApplication` type application calls.
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/is_updatable.py
+++ b/tealer/detectors/is_updatable.py
@@ -13,7 +13,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -59,7 +59,7 @@ Creator updates the application and steals all of its assets.
 Do not approve `UpdateApplication` type application calls.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing UpdateApplication check.
 
         Returns:
@@ -81,7 +81,7 @@ Do not approve `UpdateApplication` type application calls.
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/detectors/rekeyto.py
+++ b/tealer/detectors/rekeyto.py
@@ -13,7 +13,7 @@ from tealer.utils.output import ExecutionPaths
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -79,7 +79,7 @@ Alice signs the logic-sig to allow recurring payments to Bob.\
 Validate `RekeyTo` field in the LogicSig.
 """
 
-    def detect(self) -> "SupportedOutput":
+    def detect(self) -> "ListOutput":
         """Detect execution paths with missing CloseRemainderTo check.
 
         Returns:
@@ -96,7 +96,7 @@ Validate `RekeyTo` field in the LogicSig.
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]
         ] = detect_missing_tx_field_validations_group(self.tealer, checks_field)
-        detector_output: List[ExecutionPaths] = []
+        detector_output: "ListOutput" = []
         for contract, vulnerable_paths in output:
             detector_output.append(ExecutionPaths(contract, self, vulnerable_paths))
 

--- a/tealer/tealer.py
+++ b/tealer/tealer.py
@@ -9,7 +9,7 @@ from tealer.exceptions import TealerException
 
 if TYPE_CHECKING:
     from tealer.teal.teal import Teal
-    from tealer.utils.output import SupportedOutput
+    from tealer.utils.output import ListOutput
     from tealer.execution_context.transactions import GroupTransaction
 
 
@@ -165,7 +165,7 @@ class Tealer:
         self._printers.append(instance)
 
     # from slither: Slither Class in slither/slither.py
-    def run_detectors(self) -> List["SupportedOutput"]:
+    def run_detectors(self) -> List["ListOutput"]:
         """Run all the registered detectors.
 
         Returns:

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -391,15 +391,15 @@ class Output(abc.ABC):
     @property
     @abc.abstractmethod
     def detector(self) -> "AbstractDetector":
-        pass  # pylint: disable=unnecessary-pass
+        pass
 
     @abc.abstractmethod
     def filter_paths(self, filter_regex: str) -> None:
-        pass  # pylint: disable=unnecessary-pass
+        pass
 
     @abc.abstractmethod
     def to_json(self) -> Dict:
-        pass  # pylint: disable=unnecessary-pass
+        pass
 
     @abc.abstractmethod
     def write_to_files(self, dest: Path) -> bool:
@@ -417,7 +417,7 @@ class Output(abc.ABC):
         pass  # pylint: disable=unnecessary-pass
 
 
-class ExecutionPaths(Output):  # pylint: disable=too-many-instance-attributes
+class ExecutionPaths(Output):
     """Detector output class to represent vulnerable execution paths."""
 
     def __init__(self, teal: "Teal", detector: "AbstractDetector", paths: List[List["BasicBlock"]]):

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -414,7 +414,7 @@ class Output(abc.ABC):
             Returns true if something was written - False if there is nothing to be written
         """
 
-        pass  # pylint: disable=unnecessary-pass
+        return False  # this statement is needed for darglint
 
 
 class ExecutionPaths(Output):

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -34,13 +34,16 @@ def test_detectors(test: Tuple[str, Type[AbstractDetector], List[List[BasicBlock
     code, detector, expected_paths = test
     tealer = init_tealer_from_single_contract(code.strip(), "test")
     tealer.register_detector(detector)
-    result = tealer.run_detectors()[0]
-    if not isinstance(result, ExecutionPaths):
-        result = result[0]
-    assert len(result.paths) == len(expected_paths)
-    for path, ex_path in zip(result.paths, expected_paths):
-        assert cmp_cfg(path, ex_path)
+    result = tealer.run_detectors()[0][0]
 
+    if isinstance(result, ExecutionPaths):
+        assert len(result.paths) == len(expected_paths)
+        for path, ex_path in zip(result.paths, expected_paths):
+            assert cmp_cfg(path, ex_path)
+
+    else:
+        # Not implemented yet
+        assert False
 
 ALL_NEW_TESTS: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     *new_can_close_account_tests,
@@ -58,15 +61,18 @@ def test_just_detectors(test: Tuple[str, Type[AbstractDetector], List[List[int]]
     code, detector, expected_paths = test
     tealer = init_tealer_from_single_contract(code.strip(), "test")
     tealer.register_detector(detector)
-    result = tealer.run_detectors()[0]
-    if not isinstance(result, ExecutionPaths):
-        result = result[0]
+    result = tealer.run_detectors()[0][0]
 
-    print(f"count: result = {len(result.paths)}, expected = {len(expected_paths)}")
-    assert len(result.paths) == len(expected_paths)
-    for path, expected_path in zip(result.paths, expected_paths):
-        print(f"path length: result = {len(path)}, expected = {len(expected_path)}")
-        print(f"path ids: result = {path}, expected = {expected_path}")
-        assert len(path) == len(expected_path)
-        for bi, expected_idx in zip(path, expected_path):
-            assert bi.idx == expected_idx
+    if isinstance(result, ExecutionPaths):
+        print(f"count: result = {len(result.paths)}, expected = {len(expected_paths)}")
+        assert len(result.paths) == len(expected_paths)
+        for path, expected_path in zip(result.paths, expected_paths):
+            print(f"path length: result = {len(path)}, expected = {len(expected_path)}")
+            print(f"path ids: result = {path}, expected = {expected_path}")
+            assert len(path) == len(expected_path)
+            for bi, expected_idx in zip(path, expected_path):
+                assert bi.idx == expected_idx
+
+    else:
+        # Not implemented yet
+        assert False

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -45,6 +45,7 @@ def test_detectors(test: Tuple[str, Type[AbstractDetector], List[List[BasicBlock
         # Not implemented yet
         assert False
 
+
 ALL_NEW_TESTS: List[Tuple[str, Type[AbstractDetector], List[List[int]]]] = [
     *new_can_close_account_tests,
     *new_missing_rekeyto_tests,


### PR DESCRIPTION
- All the detectors return already a list of executed paths, so there is no need for `SupportedOutput = Union[ExecutionPaths, List[ExecutionPaths]]`. Removing this union generally simplifies the detector output manipulation
- Create a base class `Output` with `abc`. `ExecutionPaths` inherits from it. Right now this is not useful for this PR, but it will allow us to create outputs type that don't rely on the notion of path (ex: if the bug just highlight a basic block). This also will make more clear what functions are needed to make an output, versus the functions that are just needed by this type of output (ex: `paths` might only be needed for `ExecutionPaths`) 
- Generally remove the properties in `ExecutionPaths`. Most of them were used only once, and internally, so this remove the code complexity 
- `write_to_files` returns now a bool, so that there is no need to access `paths`.  `write_to_files` was actually also checking for `len(paths)`