### PR TITLE
Add group support: support of stateless single transactions

### DIFF
--- a/tealer/analyses/dataflow/transaction_context/generic.py
+++ b/tealer/analyses/dataflow/transaction_context/generic.py
@@ -241,6 +241,7 @@ from tealer.teal.instructions.instructions import (
     And,
     Or,
     Not,
+    TealerCustomErrInstruction,
 )
 from tealer.utils.analyses import (
     is_int_push_ins,
@@ -492,7 +493,7 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
                     self._block_contexts[key][block] = self._intersection(
                         key, present_values, true_values
                     )
-            elif isinstance(ins, Err):
+            elif isinstance(ins, (Err, TealerCustomErrInstruction)):
                 # if err, set possible values to NullSet()
                 for key in analysis_keys:
                     self._block_contexts[key][block] = self._null_set(key)

--- a/tealer/detectors/rekeyto.py
+++ b/tealer/detectors/rekeyto.py
@@ -7,13 +7,16 @@ from tealer.detectors.abstract_detector import (
     DetectorClassification,
     DetectorType,
 )
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.output import ExecutionPaths
 
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
-    from tealer.utils.output import ListOutput
+    from tealer.utils.output import ListOutput, GroupTransactionOutput
     from tealer.teal.context.block_transaction_context import BlockTransactionContext
     from tealer.teal.teal import Teal
 
@@ -92,6 +95,14 @@ Validate `RekeyTo` field in the LogicSig.
             # return False if RekeyTo field can have any address.
             # return True if RekeyTo should have some address or zero address
             return not block_ctx.rekeyto.any_addr
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(self.tealer, self, checks_field)
+            )
 
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]

--- a/tealer/execution_context/transactions.py
+++ b/tealer/execution_context/transactions.py
@@ -5,7 +5,7 @@ from tealer.utils.teal_enums import TransactionType
 if TYPE_CHECKING:
     from tealer.teal.functions import Function
 
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods, too-many-instance-attributes
 class Transaction:
     def __init__(self) -> None:
         self.type: TransactionType = TransactionType.Any
@@ -15,6 +15,7 @@ class Transaction:
         self.absoulte_index: Optional[int] = None
         self.relative_indexes: Dict[int, Transaction] = {}
         self.group_transaction: Optional[GroupTransaction] = None
+        self.transacton_id: str = ""
 
 
 # pylint: disable=too-few-public-methods
@@ -22,3 +23,4 @@ class GroupTransaction:
     def __init__(self) -> None:
         self.transactions: List[Transaction] = []
         self.absolute_indexes: Dict[int, Transaction] = {}
+        self.operation_name: str = ""

--- a/tealer/teal/functions.py
+++ b/tealer/teal/functions.py
@@ -59,7 +59,7 @@ class Function:
                 bi.next[0] for bi in caller_blocks if len(bi.next) == 1
             ]
 
-        print(self._subroutine_caller_blocks)
+        # print(self._subroutine_caller_blocks)
 
         # TODO: add exit_blocks
 

--- a/tealer/tealer.py
+++ b/tealer/tealer.py
@@ -49,12 +49,19 @@ def _check_common_things(
 class Tealer:
     """Base class for the tool"""
 
-    def __init__(self, contracts: Dict[str, "Teal"], groups: List["GroupTransaction"]):
+    def __init__(
+        self,
+        contracts: Dict[str, "Teal"],
+        groups: List["GroupTransaction"],
+        output_group: bool = False,
+    ):
         self._contracts = contracts
         self._groups = groups
 
         self._detectors: List[AbstractDetector] = []
         self._printers: List[AbstractPrinter] = []
+        # debug parameter to decide on the type of output reported by the detectors. TODO: Remove later.
+        self._output_group: bool = output_group
 
     @property
     def contracts(self) -> Dict[str, "Teal"]:
@@ -67,6 +74,10 @@ class Tealer:
     @property
     def groups(self) -> List["GroupTransaction"]:
         return self._groups
+
+    @property
+    def output_group(self) -> bool:
+        return self._output_group
 
     # from slither: Slither Class in slither/slither.py
     @property

--- a/tealer/utils/command_line/group_config.py
+++ b/tealer/utils/command_line/group_config.py
@@ -59,7 +59,7 @@ class GroupConfigFunction:
 @dataclass
 class GroupConfigContract:
     name: str
-    file_path: str
+    file_path: Path
     contract_type: str
     version: int
     subroutines: List[str]
@@ -81,7 +81,7 @@ class GroupConfigContract:
                 f'Contract name: {name}\n\nFollowing Required fields are absent: {", ".join(absent_fields)}'
             )
 
-        file_path: str = contract["file_path"]
+        file_path: Path = Path(contract["file_path"])
         contract_type: str = contract["type"]
         version: int = contract["version"]
         subroutines: List[str] = contract["subroutines"]
@@ -221,10 +221,37 @@ class GroupConfigTransaction:
 
 
 @dataclass
+class GroupConfigGroup:
+    operation: str
+    transactions: List[GroupConfigTransaction]
+
+    @staticmethod
+    def from_yaml(group: Dict[str, Any]) -> "GroupConfigGroup":
+        absent_fields = check_fields_are_present(["operation", "transactions"], group)
+        if absent_fields:
+            raise InvalidGroupConfiguration(
+                f'Group:\n\nFollowing Required fields are absent: {", ".join(absent_fields)}'
+            )
+
+        operation = group["operation"]
+        parsed_transactions = []
+        for transaction in group["transactions"]:
+            parsed_transactions.append(GroupConfigTransaction.from_yaml(transaction))
+
+        return GroupConfigGroup(operation, parsed_transactions)
+
+    def to_yaml(self) -> Dict[str, Any]:
+        return {
+            "operation": self.operation,
+            "transactions": [transaction.to_yaml() for transaction in self.transactions],
+        }
+
+
+@dataclass
 class GroupConfig:
     name: str
     contracts: List[GroupConfigContract]
-    groups: List[List[GroupConfigTransaction]]
+    groups: List[GroupConfigGroup]
 
     @staticmethod
     def from_yaml(config: Dict[str, Any]) -> "GroupConfig":
@@ -239,10 +266,7 @@ class GroupConfig:
             contracts.append(GroupConfigContract.from_yaml(contract))
         groups = []
         for group in config["groups"]:
-            parsed_group = []
-            for transaction in group:
-                parsed_group.append(GroupConfigTransaction.from_yaml(transaction))
-            groups.append(parsed_group)
+            groups.append(GroupConfigGroup.from_yaml(group))
 
         return GroupConfig(name, contracts, groups)
 
@@ -250,7 +274,7 @@ class GroupConfig:
         return {
             "name": self.name,
             "contracts": [contract.to_yaml() for contract in self.contracts],
-            "groups": [[transaction.to_yaml() for transaction in group] for group in self.groups],
+            "groups": [group.to_yaml() for group in self.groups],
         }
 
 
@@ -267,6 +291,9 @@ def read_config_from_file(file: Path) -> GroupConfig:
         d = yaml.safe_load(f.read())
     try:
         parsed_config = GroupConfig.from_yaml(d)
+        # given file_path is relative path of the contract from config file.
+        for contract in parsed_config.contracts:
+            contract.file_path = file.parent / contract.file_path
         return parsed_config
     except InvalidGroupConfiguration as err:
         print(f"\nInvalidGroupConfiguration:\n\n{err}")

--- a/tealer/utils/output.py
+++ b/tealer/utils/output.py
@@ -31,9 +31,12 @@ from tealer.teal.instructions.instructions import BZ, BNZ, Callsub, Retsub
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
     from tealer.teal.subroutine import Subroutine
+    from tealer.teal.functions import Function
     from tealer.teal.teal import Teal
     from tealer.teal.instructions.instructions import Instruction
     from tealer.detectors.abstract_detector import AbstractDetector
+    from tealer.execution_context.transactions import GroupTransaction, Transaction
+
 
 ROOT_OUTPUT_DIRECTORY = Path("tealer-export")
 
@@ -478,7 +481,7 @@ class ExecutionPaths(Output):
 
     @property
     def detector(self) -> "AbstractDetector":
-        return self.detector
+        return self._detector
 
     def _filename(self, path_index: int) -> Path:
         return Path(f"{self.detector.NAME}-{path_index}.dot")
@@ -588,6 +591,84 @@ class ExecutionPaths(Output):
 
         result["paths"] = paths
         return result
+
+
+class GroupTransactionOutput(Output):
+    def __init__(
+        self,
+        detector: "AbstractDetector",
+        group: "GroupTransaction",
+        transactions: Dict["Transaction", List["Function"]],
+    ) -> None:
+        self._detector = detector
+        self._group = group
+        self._transactions = transactions
+
+    @property
+    def detector(self) -> "AbstractDetector":
+        return self._detector
+
+    @property
+    def group_transaction(self) -> "GroupTransaction":
+        return self._group
+
+    @property
+    def transactions(self) -> Dict["Transaction", List["Function"]]:
+        return self._transactions
+
+    def filter_paths(self, filter_regex: str) -> None:
+        pass
+
+    def to_json(self) -> Dict:
+        transactions = {}
+        for txn in self._transactions:
+            contracts = []
+            for function in self._transactions[txn]:
+                contracts.append(
+                    {
+                        "contract": function.contract.contract_name,
+                        "function": function.function_name,
+                    }
+                )
+            transactions[txn.transacton_id] = contracts
+
+        result = {
+            "type": "GroupTransactionOutput",
+            "description": detector_terminal_description(self.detector),
+            "check": self.detector.NAME,
+            "impact": str(self.detector.IMPACT),
+            "confidence": str(self.detector.CONFIDENCE),
+            "help": self.detector.WIKI_RECOMMENDATION.strip(),
+            "operation": self._group.operation_name,
+            "transactions": transactions,
+        }
+        return result
+
+    def generate_output(self, dest: Path) -> bool:
+        """
+        Generate the output
+
+        Args:
+            dest: Not used, no files are generated for GroupTransactionOutput
+
+        Returns:
+            Returns true if something was generated - False if there is nothing to be written.
+        """
+        print(detector_terminal_description(self.detector))
+        print(
+            f"\tFollowing transactions of the operation {self._group.operation_name} are vulnerable:\n"
+        )
+
+        for txn in self._transactions:
+            print(f"\tTransaction {txn.transacton_id}")
+            if self._transactions[txn]:
+                # contract was given by the user.
+                for function in self._transactions[txn]:
+                    print(f"\t\tContract: {function.contract.contract_name}")
+                    print(f"\t\tFunction: {function.function_name}")
+                    print("\n")
+
+        return True
 
 
 ListOutput = List[Output]

--- a/tests/group_transactions/basic/app_1.py
+++ b/tests/group_transactions/basic/app_1.py
@@ -1,0 +1,250 @@
+from pyteal import *
+from pathlib import Path
+
+
+def app1_case_1() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_2() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_3() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_4() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_5() -> Expr:
+    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def app1_case_6() -> Expr:
+    return Seq(
+        [Assert(Gtxn[Txn.group_index()].rekey_to() == Global.zero_address()), Return(Int(1))]
+    )
+
+
+def app1_case_7() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[0].rekey_to() == Global.zero_address(),
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def app1_case_8() -> Expr:
+    return Seq([Assert(Gtxn[0].rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def app1_case_9() -> Expr:
+    return Seq([Assert(Gtxn[1].rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def app1_case_10() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_11() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_12() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_13() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_14() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_15() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_16() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_17() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_18() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[0].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(4)].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def app1_case_19() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() + Int(4)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def app1_case_20() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[1].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def app1_case_21() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() + Int(2)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def app1_case_22() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_23() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_24() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_25() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_26() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_27() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_28() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def app1_case_29() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_30() -> Expr:
+    return Seq([Assert(Gtxn[0].rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def app1_case_31() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_32() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_33() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_34() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_35() -> Expr:
+    return Return(Int(1))
+
+
+def app1_case_36() -> Expr:
+    return Seq([Assert(Gtxn[4].rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def app1_case_37() -> Expr:
+    return Return(Int(1))
+
+
+def approval_program() -> Expr:
+    test_case = Btoi(Txn.application_args[Int(0)])
+    return Seq(
+        [
+            Assert(Txn.on_completion() == OnComplete.NoOp),
+            Cond(
+                [test_case == Int(1), app1_case_1()],
+                [test_case == Int(2), app1_case_2()],
+                [test_case == Int(3), app1_case_3()],
+                [test_case == Int(4), app1_case_4()],
+                [test_case == Int(5), app1_case_5()],
+                [test_case == Int(6), app1_case_6()],
+                [test_case == Int(7), app1_case_7()],
+                [test_case == Int(8), app1_case_8()],
+                [test_case == Int(9), app1_case_9()],
+                [test_case == Int(10), app1_case_10()],
+                [test_case == Int(11), app1_case_11()],
+                [test_case == Int(12), app1_case_12()],
+                [test_case == Int(13), app1_case_13()],
+                [test_case == Int(14), app1_case_14()],
+                [test_case == Int(15), app1_case_15()],
+                [test_case == Int(16), app1_case_16()],
+                [test_case == Int(17), app1_case_17()],
+                [test_case == Int(18), app1_case_18()],
+                [test_case == Int(19), app1_case_19()],
+                [test_case == Int(20), app1_case_20()],
+                [test_case == Int(21), app1_case_21()],
+                [test_case == Int(22), app1_case_22()],
+                [test_case == Int(23), app1_case_23()],
+                [test_case == Int(24), app1_case_24()],
+                [test_case == Int(25), app1_case_25()],
+                [test_case == Int(26), app1_case_26()],
+                [test_case == Int(27), app1_case_27()],
+                [test_case == Int(28), app1_case_28()],
+                [test_case == Int(29), app1_case_29()],
+                [test_case == Int(30), app1_case_30()],
+                [test_case == Int(31), app1_case_31()],
+                [test_case == Int(32), app1_case_32()],
+                [test_case == Int(33), app1_case_33()],
+                [test_case == Int(34), app1_case_34()],
+                [test_case == Int(35), app1_case_35()],
+                [test_case == Int(36), app1_case_36()],
+                [test_case == Int(37), app1_case_37()],
+            ),
+        ]
+    )
+
+
+def compile(output_file: Path) -> None:
+    teal = compileTeal(approval_program(), mode=Mode.Application, version=7)
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write(teal)
+
+
+if __name__ == "__main__":
+    compile(Path("app_1.teal"))

--- a/tests/group_transactions/basic/app_1.py
+++ b/tests/group_transactions/basic/app_1.py
@@ -1,3 +1,5 @@
+# pylint: disable=undefined-variable
+# type: ignore[name-defined]
 from pyteal import *
 from pathlib import Path
 

--- a/tests/group_transactions/basic/app_1.py
+++ b/tests/group_transactions/basic/app_1.py
@@ -1,7 +1,7 @@
 # pylint: disable=undefined-variable
 # type: ignore[name-defined]
-from pyteal import *
 from pathlib import Path
+from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 
 def app1_case_1() -> Expr:
@@ -242,11 +242,11 @@ def approval_program() -> Expr:
     )
 
 
-def compile(output_file: Path) -> None:
+def compile_program(output_file: Path) -> None:
     teal = compileTeal(approval_program(), mode=Mode.Application, version=7)
     with open(output_file, "w", encoding="utf-8") as f:
         f.write(teal)
 
 
 if __name__ == "__main__":
-    compile(Path("app_1.teal"))
+    compile_program(Path("app_1.teal"))

--- a/tests/group_transactions/basic/app_1.teal
+++ b/tests/group_transactions/basic/app_1.teal
@@ -1,0 +1,408 @@
+#pragma version 7
+txn OnCompletion
+int NoOp
+==
+assert
+int 0
+txnas ApplicationArgs
+btoi
+int 1
+==
+bnz main_l74
+int 0
+txnas ApplicationArgs
+btoi
+int 2
+==
+bnz main_l73
+int 0
+txnas ApplicationArgs
+btoi
+int 3
+==
+bnz main_l72
+int 0
+txnas ApplicationArgs
+btoi
+int 4
+==
+bnz main_l71
+int 0
+txnas ApplicationArgs
+btoi
+int 5
+==
+bnz main_l70
+int 0
+txnas ApplicationArgs
+btoi
+int 6
+==
+bnz main_l69
+int 0
+txnas ApplicationArgs
+btoi
+int 7
+==
+bnz main_l68
+int 0
+txnas ApplicationArgs
+btoi
+int 8
+==
+bnz main_l67
+int 0
+txnas ApplicationArgs
+btoi
+int 9
+==
+bnz main_l66
+int 0
+txnas ApplicationArgs
+btoi
+int 10
+==
+bnz main_l65
+int 0
+txnas ApplicationArgs
+btoi
+int 11
+==
+bnz main_l64
+int 0
+txnas ApplicationArgs
+btoi
+int 12
+==
+bnz main_l63
+int 0
+txnas ApplicationArgs
+btoi
+int 13
+==
+bnz main_l62
+int 0
+txnas ApplicationArgs
+btoi
+int 14
+==
+bnz main_l61
+int 0
+txnas ApplicationArgs
+btoi
+int 15
+==
+bnz main_l60
+int 0
+txnas ApplicationArgs
+btoi
+int 16
+==
+bnz main_l59
+int 0
+txnas ApplicationArgs
+btoi
+int 17
+==
+bnz main_l58
+int 0
+txnas ApplicationArgs
+btoi
+int 18
+==
+bnz main_l57
+int 0
+txnas ApplicationArgs
+btoi
+int 19
+==
+bnz main_l56
+int 0
+txnas ApplicationArgs
+btoi
+int 20
+==
+bnz main_l55
+int 0
+txnas ApplicationArgs
+btoi
+int 21
+==
+bnz main_l54
+int 0
+txnas ApplicationArgs
+btoi
+int 22
+==
+bnz main_l53
+int 0
+txnas ApplicationArgs
+btoi
+int 23
+==
+bnz main_l52
+int 0
+txnas ApplicationArgs
+btoi
+int 24
+==
+bnz main_l51
+int 0
+txnas ApplicationArgs
+btoi
+int 25
+==
+bnz main_l50
+int 0
+txnas ApplicationArgs
+btoi
+int 26
+==
+bnz main_l49
+int 0
+txnas ApplicationArgs
+btoi
+int 27
+==
+bnz main_l48
+int 0
+txnas ApplicationArgs
+btoi
+int 28
+==
+bnz main_l47
+int 0
+txnas ApplicationArgs
+btoi
+int 29
+==
+bnz main_l46
+int 0
+txnas ApplicationArgs
+btoi
+int 30
+==
+bnz main_l45
+int 0
+txnas ApplicationArgs
+btoi
+int 31
+==
+bnz main_l44
+int 0
+txnas ApplicationArgs
+btoi
+int 32
+==
+bnz main_l43
+int 0
+txnas ApplicationArgs
+btoi
+int 33
+==
+bnz main_l42
+int 0
+txnas ApplicationArgs
+btoi
+int 34
+==
+bnz main_l41
+int 0
+txnas ApplicationArgs
+btoi
+int 35
+==
+bnz main_l40
+int 0
+txnas ApplicationArgs
+btoi
+int 36
+==
+bnz main_l39
+int 0
+txnas ApplicationArgs
+btoi
+int 37
+==
+bnz main_l38
+err
+main_l38:
+int 1
+return
+main_l39:
+gtxn 4 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l40:
+int 1
+return
+main_l41:
+int 1
+return
+main_l42:
+int 1
+return
+main_l43:
+int 1
+return
+main_l44:
+int 1
+return
+main_l45:
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l46:
+int 1
+return
+main_l47:
+txn GroupIndex
+int 5
++
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l48:
+int 1
+return
+main_l49:
+int 1
+return
+main_l50:
+int 1
+return
+main_l51:
+int 1
+return
+main_l52:
+int 1
+return
+main_l53:
+int 1
+return
+main_l54:
+txn GroupIndex
+int 2
++
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l55:
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l56:
+txn GroupIndex
+int 4
++
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l57:
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+txn GroupIndex
+int 4
++
+gtxns RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l58:
+int 1
+return
+main_l59:
+int 1
+return
+main_l60:
+int 1
+return
+main_l61:
+int 1
+return
+main_l62:
+int 1
+return
+main_l63:
+int 1
+return
+main_l64:
+int 1
+return
+main_l65:
+int 1
+return
+main_l66:
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l67:
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l68:
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l69:
+txn GroupIndex
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l70:
+txn RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l71:
+int 1
+return
+main_l72:
+int 1
+return
+main_l73:
+int 1
+return
+main_l74:
+int 1
+return

--- a/tests/group_transactions/basic/config.yaml
+++ b/tests/group_transactions/basic/config.yaml
@@ -1,0 +1,823 @@
+name: Basic
+contracts:
+  # app_1.py
+  - name: App_1
+    file_path: app_1.teal
+    type: ApprovalProgram
+    version: 7
+    subroutines: []
+    functions:
+      - name: app1_case_1
+        dispatch_path: ["B0", "B74"]
+      - name: app1_case_2
+        dispatch_path: ["B0", "B1", "B73"]
+      - name: app1_case_3
+        dispatch_path: ["B0", "B1", "B2", "B72"]
+      - name: app1_case_4
+        dispatch_path: ["B0", "B1", "B2", "B3", "B71"]
+      - name: app1_case_5
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B70"]
+      # - name: app1_case_6
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B69"]
+      # - name: app1_case_7
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B68"]
+      # - name: app1_case_8
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B67"]
+      # - name: app1_case_9
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B66"]
+      # - name: app1_case_10
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B65"]
+      # - name: app1_case_11
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B64"]
+      # - name: app1_case_12
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B63"]
+      # - name: app1_case_13
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B62"]
+      # - name: app1_case_14
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B61"]
+      # - name: app1_case_15
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B60"]
+      # - name: app1_case_16
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B59"]
+      # - name: app1_case_17
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B58"]
+      # - name: app1_case_18
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B57"]
+      # - name: app1_case_19
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B56"]
+      # - name: app1_case_20
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B55"]
+      # - name: app1_case_21
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B54"]
+      # - name: app1_case_22
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B53"]
+      # - name: app1_case_23
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B52"]
+      # - name: app1_case_24
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B51"]
+      # - name: app1_case_25
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B50"]
+      # - name: app1_case_26
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B49"]
+      # - name: app1_case_27
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B48"]
+      # - name: app1_case_28
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B47"]
+      # - name: app1_case_29
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B46"]
+      # - name: app1_case_30
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B45"]
+      # - name: app1_case_31
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B44"]
+      # - name: app1_case_32
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B43"]
+      # - name: app1_case_33
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B42"]
+      # - name: app1_case_34
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B41"]
+      # - name: app1_case_35
+      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B34", "B40"]
+      - name: app1_case_36
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B34", "B35", "B39"]
+      - name: app1_case_37
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B34", "B35", "B36", "B38"]
+  - name: LogicSig_1
+    file_path: logicsig_1.teal
+    type: LogicSig
+    version: 7
+    subroutines: []
+    functions:
+      - name: lsig1_case_1
+        dispatch_path: ["B0", "B58"]
+      - name: lsig1_case_2
+        dispatch_path: ["B0", "B1", "B57"]
+      - name: lsig1_case_5
+        dispatch_path: ["B0", "B1", "B2", "B56"]
+  #     - name: lsig1_case_6
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B55"]
+  #     - name: lsig1_case_7
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B54"]
+  #     - name: lsig1_case_8
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B53"]
+  #     - name: lsig1_case_9
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B52"]
+  #     - name: lsig1_case_10
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B51"]
+  #     - name: lsig1_case_14
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B50"]
+  #     - name: lsig1_case_15
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B49"]
+  #     - name: lsig1_case_16
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B48"]
+  #     - name: lsig1_case_17
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B47"]
+  #     - name: lsig1_case_18
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B46"]
+  #     - name: lsig1_case_19
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B45"]
+  #     - name: lsig1_case_20
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B44"]
+  #     - name: lsig1_case_21
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B43"]
+  #     - name: lsig1_case_22
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B42"]
+  #     - name: lsig1_case_26
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B41"]
+  #     - name: lsig1_case_27
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B40"]
+  #     - name: lsig1_case_28
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B39"]
+  #     - name: lsig1_case_29
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B38"]
+  #     - name: lsig1_case_30
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B37"]
+  #     - name: lsig1_case_31
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B36"]
+  #     - name: lsig1_case_32
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B35"]
+  #     - name: lsig1_case_33
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B34"]
+  #     - name: lsig1_case_34
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B33"]
+  #     - name: lsig1_case_35
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B32"]
+      - name: lsig1_case_36
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B31"]
+      - name: lsig1_case_37
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B30"]
+  # - name: LogicSig_2
+  #   file_path: logicsig_2.teal
+  #   type: LogicSig
+  #   version: 7
+  #   subroutines: []
+  #   functions:
+  #     - name: lsig2_case_7
+  #       dispatch_path: ["B0", "B58"]
+  #     - name: lsig2_case_8
+  #       dispatch_path: ["B0", "B1", "B57"]
+  #     - name: lsig2_case_9
+  #       dispatch_path: ["B0", "B1", "B2", "B56"]
+  #     - name: lsig2_case_10
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B55"]
+  #     - name: lsig2_case_11
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B54"]
+  #     - name: lsig2_case_12
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B53"]
+  #     - name: lsig2_case_13
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B52"]
+  #     - name: lsig2_case_14
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B51"]
+  #     - name: lsig2_case_15
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B50"]
+  #     - name: lsig2_case_16
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B49"]
+  #     - name: lsig2_case_17
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B48"]
+  #     - name: lsig2_case_18
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B47"]
+  #     - name: lsig2_case_19
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B46"]
+  #     - name: lsig2_case_20
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B45"]
+  #     - name: lsig2_case_21
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B44"]
+  #     - name: lsig2_case_22
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B43"]
+  #     - name: lsig2_case_23
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B42"]
+  #     - name: lsig2_case_24
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B41"]
+  #     - name: lsig2_case_25
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B40"]
+  #     - name: lsig2_case_26
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B39"]
+  #     - name: lsig2_case_27
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B38"]
+  #     - name: lsig2_case_28
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B37"]
+  #     - name: lsig2_case_29
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B36"]
+  #     - name: lsig2_case_30
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B35"]
+  #     - name: lsig2_case_31
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B34"]
+  #     - name: lsig2_case_32
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B33"]
+  #     - name: lsig2_case_33
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B32"]
+  #     - name: lsig2_case_34
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B31"]
+  #     - name: lsig2_case_35
+  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B30"]
+# group configurations
+groups:
+  - operation: case_1
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_1
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_1
+  - operation: case_2
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_2
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_2
+  - operation: case_3
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_3
+        has_logic_sig: true
+  - operation: case_4
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_4
+        # has_logic_sig is false.
+  - operation: case_5
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_5
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_5
+  # - operation: case_6
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_6
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_6
+  # - operation: case_7
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_7
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_7
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_7
+  #       absolute_index: 1
+  # - operation: case_8
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_8
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_8
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_8
+  #       absolute_index: 1
+
+  # - operation: case_9
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_9
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_9
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_9
+  #       absolute_index: 1
+      
+  # - operation: case_10
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_10
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_10
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_10
+  #       absolute_index: 1      
+
+  # - operation: case_11
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_11
+  #       has_logic_sig: true
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_11
+  #       absolute_index: 1      
+
+  # - operation: case_12
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_12
+  #       has_logic_sig: true
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_12
+  #       absolute_index: 1      
+
+  # - operation: case_13
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_13
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_13
+  #       absolute_index: 1      
+
+  # - operation: case_14
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_14
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_14
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_14
+  #       absolute_index: 1
+
+  # - operation: case_15
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_15
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_15
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_15
+  #       absolute_index: 1
+
+  # - operation: case_16
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_16
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_16
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_16
+  #       absolute_index: 1
+
+  # - operation: case_17
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_17
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_17
+  #       absolute_index: 0
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_17
+  #       absolute_index: 1
+
+  # - operation: case_18
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_18
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_18
+  #       absolute_index: 0
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 4
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_18
+
+  # - operation: case_19
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_19
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_19
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_19
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: -4
+
+  # - operation: case_20
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_20
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_20
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_20
+  #       absolute_index: 1
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: 5
+        
+  # - operation: case_21
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_21
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_21
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 2
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_21
+
+  # - operation: case_22
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_22
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_22
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_22
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: -1
+
+  # - operation: case_23
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_23
+  #       has_logic_sig: true
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_23
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: -1
+
+  # - operation: case_24
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_24
+  #       has_logic_sig: true
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_24
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: -1
+
+  # - operation: case_25
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_25
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_25
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: -1
+
+  # - operation: case_26
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_26
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_26
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: -1
+
+  # - operation: case_27
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_27
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_27
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 1
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_27
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: -1
+
+  # - operation: case_28
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_28
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_28
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 5
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_28
+
+  # - operation: case_29
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_29
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_29
+  #       absolute_index: 0
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 3
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_29
+
+  # - operation: case_30
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_30
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_30
+  #       absolute_index: 0
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 4
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_30
+
+  # - operation: case_31
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_31
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_31
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 4
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_31
+
+  # - operation: case_32
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_32
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_32
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 5
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_32
+
+  # - operation: case_33
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_33
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_33
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_33
+  #       absolute_index: 1
+  #       relative_indexes:
+  #         - other_txn_id: T1
+  #           offset: 5
+
+  # - operation: case_34
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_34
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_34
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 2
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_34
+
+  # - operation: case_35
+  #   transactions:
+  #     - txn_id: T1
+  #       txn_type: appl
+  #       application:
+  #         contract: App_1
+  #         function: app1_case_35
+  #       logic_sig:
+  #         contract: LogicSig_1
+  #         function: lsig1_case_35
+  #       absolute_index: 0
+  #       relative_indexes:
+  #         - other_txn_id: T2
+  #           offset: 3
+  #     - txn_id: T2
+  #       txn_type: pay
+  #       logic_sig:
+  #         contract: LogicSig_2
+  #         function: lsig2_case_35
+
+  - operation: case_36
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_36
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_36
+        absolute_index: 4
+
+  - operation: case_37
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_37
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_37
+        absolute_index: 1

--- a/tests/group_transactions/basic/expected_output.yaml
+++ b/tests/group_transactions/basic/expected_output.yaml
@@ -1,0 +1,100 @@
+name: BasicRekeyTo
+operations:
+  - operation: case_2
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_2
+  - operation: case_3
+    vulnerable_transactions:
+      - txn_id: T1
+  # - operation: case_9
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_9
+  # - operation: case_12
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  # - operation: case_13
+  #   vulnerable_transactions:
+  #     - txn_id: T2
+  #       contracts:
+  #         - contract: LogicSig_2
+  #           function: lsig2_case_13
+  # - operation: case_14
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_14  
+  #     - txn_id: T2
+  #       contracts:
+  #         - contract: LogicSig_2
+  #           function: lsig2_case_14
+  # - operation: case_17
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_17
+  # - operation: case_21
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_21
+  # - operation: case_24
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_21
+  # - operation: case_25
+  #   vulnerable_transactions:
+  #     - txn_id: T2
+  #       contracts:
+  #         - contract: LogicSig_2
+  #           function: lsig2_case_25
+  # - operation: case_26
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_26
+  #     - txn_id: T2
+  #       contracts:
+  #         - contract: LogicSig_2
+  #           function: lsig2_case_26
+  # - operation: case_28
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_28
+  # - operation: case_29
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_29
+  # - operation: case_32
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_32
+  # - operation: case_34
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_34
+  # - operation: case_35
+  #   vulnerable_transactions:
+  #     - txn_id: T1
+  #       contracts:
+  #         - contract: LogicSig_1
+  #           function: lsig1_case_35

--- a/tests/group_transactions/basic/logicsig_1.py
+++ b/tests/group_transactions/basic/logicsig_1.py
@@ -1,3 +1,5 @@
+# pylint: disable=undefined-variable
+# type: ignore[name-defined]
 """
 case 1:
     - Single transaction.
@@ -429,14 +431,12 @@ case 37:
     - Application does not check anything.
     - Logic checks the field using absolute index.
     - Absolute index is given in the config.
-    
+
 Expected:
     Not Vulnerable
 """
-# pylint: disable=undefined-variable
-# type: ignore[name-defined]
-from pyteal import *
 from pathlib import Path
+from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 
 def lsig1_case_1() -> Expr:
@@ -737,11 +737,11 @@ def logic_sig() -> Expr:
     )
 
 
-def compile(output_file: Path) -> None:
+def compile_program(output_file: Path) -> None:
     teal = compileTeal(logic_sig(), mode=Mode.Signature, version=7)
     with open(output_file, "w", encoding="utf-8") as f:
         f.write(teal)
 
 
 if __name__ == "__main__":
-    compile(Path("logicsig_1.teal"))
+    compile_program(Path("logicsig_1.teal"))

--- a/tests/group_transactions/basic/logicsig_1.py
+++ b/tests/group_transactions/basic/logicsig_1.py
@@ -1,0 +1,746 @@
+"""
+case 1:
+    - Single transaction.
+    - app_1 and logicsig_1 is executed
+    - logicsig_1 checks the rekeyto field
+    - app_1 does not do anything.
+
+Expected:
+    - The detector should not report it as vulnerable.
+
+
+case 2:
+    - Single transaction.
+    - Application and LogicSig does not check the RekeyTo field
+
+Expected:
+    - The detector should report it as vulnerable
+
+
+case 3:
+    - Single transaction.
+    - Only application is called
+    - has_logic_sig is set to True but the logic_sig contract is not given.
+
+Expected:
+    The detector should report the operation as vulnerable. Even if the detector does not the logic sig being executed, the operation should be considered
+    vulnerable because a logic sig will be vulnerable to Rekeying.
+
+
+case 4:
+    - Single transaction.
+    - Application is called
+    - has_logic_sig is set to False.
+
+Expected:
+    The detector should report the operation as NOT VULNERABLE. Applications are not vulnerable to rekeying.
+
+
+case 5:
+    - Single transaction
+    - Application checks the rekeyto field
+    - LogicSig checks that application is called
+
+Expected:
+    NOT VULNERABLE.
+
+
+case 6:
+    - Single transaction
+    - Application access the rekeyto field using `Gtxn[Txn.group_index()].rekey_to()`.
+    - LogicSig checks the application is called.
+
+Expected:
+    Not Vulnerable
+
+
+case 7:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application checks the rekeyto field of 0th transaction and 1st transaction using absolute indices.
+        - LogicSig checks the application id
+    - Second transaction (pay)(index: 1):
+        - LogicSig does not check anything.
+
+Expected:
+    Not Vulnerable
+
+
+case 8:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application checks the rekeyto field of 0th transaction using absolute index.
+        - LogicSig checks the application id
+    - Second transaction (pay)(index: 1):
+        - LogicSig checks it's rekeyto field.
+
+Expected:
+    Not Vulnerable
+
+
+case 9:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application checks the rekeyto field of 1st transaction using absolute index.
+        - LogicSig checks the application id
+    - Second transaction (pay)(index: 1):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    The first transaction is vulnerable. The second transaction should not be reported
+
+
+case 10:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - LogicSig checks the application id
+    - Second transaction (pay)(index: 1):
+        - LogicSig checks the fields of both transactions using absolute indices.
+
+Expected:
+    Not Vulnerable
+
+
+case 11:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - has_logic_sig is True.
+    - Second transaction (pay)(index: 1):
+        - LogicSig checks the fields of both transactions using absolute indices
+
+Expected:
+    Not Vulnerable
+
+
+case 12:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - has_logic_sig is True.
+    - Second transaction (pay)(index: 1):
+        - LogicSig checks the fields of its own transaction field.
+
+Expected:
+    Vulnerable.
+    Only the first transaction is reported as vulnerable.
+
+
+case 13:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+    - Second transaction (pay)(index: 1):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    Second transaction is reported as vulnerable
+
+
+case 14:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - LogicSig does not check anything.
+    - Second transaction (pay)(index: 1):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    Both First and Second transactions are reported as vulnerable.
+
+
+case 15:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 0th transaction and 1st transaction using absolute indices
+    - Second transaction (pay)(index: 1):
+        - LogicSig does not check anything.
+
+Expected:
+    Not Vulnerable
+
+
+case 16:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 0th transaction using absolute index.
+    - Second transaction (pay)(index: 1):
+        - LogicSig checks it's rekeyto field.
+
+Expected:
+    Not Vulnerable
+
+
+case 17:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 1st transaction using absolute index.
+    - Second transaction (pay)(index: 1):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    The first transaction is vulnerable. The second transaction should not be reported
+
+
+case 18:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application checks the rekeyto field of 0th transaction using absolute index and 1st transaction using relative index(+4).
+        - LogicSig checks the application id
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Not Vulnerable
+
+
+case 19:
+    - Two transactions
+    - First transaction (appl):
+        - Application checks the rekeyto field of 1st transaction using relative index(+4).
+        - LogicSig checks the application id
+    - Second transaction (pay):
+        - LogicSig checks rekey field of the previous transaction using (-4) relative index.
+
+Expected:
+    Not Vulnerable
+
+
+case 20:
+    - Two transactions
+    - First transaction (appl):
+        - Application checks the rekeyto field of 1st transaction using absolute index.
+        - LogicSig checks the application id
+    - Second transaction (pay)(index: 1):
+        - LogicSig checks rekey field of the first transaction using (+5) relative index.
+
+Expected:
+    Not Vulnerable
+
+
+case 21:
+    - Two transactions
+    - First transaction (appl):
+        - Application checks the rekeyto field of 1st transaction using relative index(+2).
+        - LogicSig checks the application id
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    The first transaction is vulnerable. The second transaction should not be reported
+
+
+case 22:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - LogicSig checks the application id
+    - Second transaction (pay):
+        - LogicSig checks the field of previous transaction using relative index(-1) and its own field directly.
+
+Expected:
+    Not Vulnerable
+
+
+case 23:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - has_logic_sig is True.
+    - Second transaction (pay):
+        - LogicSig checks the field of previous transaction using relative index(-1) and its own field directly.
+
+Expected:
+    Not Vulnerable
+
+
+case 24:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - has_logic_sig is True.
+    - Second transaction (pay):
+        - LogicSig checks the fields of its own transaction field.
+
+Expected:
+    Vulnerable.
+    Only the first transaction is reported as vulnerable.
+
+
+case 25:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    Second transaction is reported as vulnerable
+
+
+case 26:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - LogicSig does not check anything.
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    Both First and Second transactions are reported as vulnerable.
+
+
+case 27:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of its own transaction and 1st transaction using relative index(+1)
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Not Vulnerable
+
+
+case 28:
+    - Two transactions
+    - First transaction (appl):
+        - Application checks the rekeyto field of 1st transaction using relative index(+5).
+        - LogicSig checks the application id
+    - Second transaction (pay):
+        - LogicSig checks rekey field of the previous transaction using (-4) relative index.
+
+Expected:
+    Vulnerable.
+    Second transaction uses the wrong index. First contract will be vulnerable.
+
+
+case 29:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 1st transaction using relative index(+3).
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    The first transaction is vulnerable. The second transaction should not be reported
+
+
+case 30:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application checks the rekeyto field of 0th transaction using absolute index
+        - LogicSig checks the application id and field of 1st transaction using relative index(+4).
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Not Vulnerable
+
+
+case 31:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 1st transaction using relative index(+4).
+    - Second transaction (pay):
+        - LogicSig checks rekey field of the previous transaction using (-4) relative index.
+
+Expected:
+    Not Vulnerable
+
+
+case 32:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 1st transaction using relative index(+5)
+    - Second transaction (pay):
+        - LogicSig checks rekey field of the previous transaction using (-4) relative index.
+
+Expected:
+    Vulnerable.
+    Second transaction uses the wrong index. First contract will be vulnerable.
+
+
+case 33:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 1st transaction using absolute index.
+    - Second transaction (pay)(index: 1):
+        - LogicSig checks rekey field of the 0th transaction using (+5) relative index.
+
+Expected:
+    Not Vulnerable
+
+
+case 34:
+    - Two transactions
+    - First transaction (appl):
+        - Application does not check anything
+        - LogicSig checks the rekeyto field of 1st transaction using relative index(+2).
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    The first transaction is vulnerable. The second transaction should not be reported
+
+
+case 35:
+    - Two transactions
+    - First transaction (appl)(index: 0):
+        - Application does not check anything.
+        - LogicSig checks the rekeyto field of 1st transaction using relative index(+3).
+    - Second transaction (pay):
+        - LogicSig does not check anything.
+
+Expected:
+    Vulnerable.
+    The first transaction is vulnerable. The second transaction should not be reported
+
+
+case 36:
+    - Single transaction (index: 4).
+    - Application checks the field using absolute index.
+    - LogicSig checks the application id
+    - Absolute index is given in the config
+
+Expected:
+    Not Vulnerable
+
+
+case 37:
+    - Single transaction (index: 1)
+    - Application does not check anything.
+    - Logic checks the field using absolute index.
+    - Absolute index is given in the config.
+    
+Expected:
+    Not Vulnerable
+"""
+
+from pyteal import *
+from pathlib import Path
+
+
+def lsig1_case_1() -> Expr:
+    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def lsig1_case_2() -> Expr:
+    return Return(Int(1))
+
+
+def lsig1_case_5() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_6() -> Expr:
+    return lsig1_case_5()
+
+
+def lsig1_case_7() -> Expr:
+    return lsig1_case_5()
+
+
+def lsig1_case_8() -> Expr:
+    return lsig1_case_5()
+
+
+def lsig1_case_9() -> Expr:
+    return lsig1_case_5()
+
+
+def lsig1_case_10() -> Expr:
+    return lsig1_case_5()
+
+
+def lsig1_case_14() -> Expr:
+    return Return(Int(1))
+
+
+def lsig1_case_15() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    # int 0; gtxns RekeyTo
+                    Gtxn[Int(0)].rekey_to() == Global.zero_address(),
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_16() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[0].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_17() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[1].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_18() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_19() -> Expr:
+    return lsig1_case_18()
+
+
+def lsig1_case_20() -> Expr:
+    return lsig1_case_18()
+
+
+def lsig1_case_21() -> Expr:
+    return lsig1_case_18()
+
+
+def lsig1_case_22() -> Expr:
+    return lsig1_case_18()
+
+
+def lsig1_case_26() -> Expr:
+    return Return(Int(1))
+
+
+def lsig1_case_27() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(1)].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_28() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_29() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(3)].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_30() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                    Gtxn[Txn.group_index() + Int(4)].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_31() -> Expr:
+    return lsig1_case_30()
+
+
+def lsig1_case_32() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                    Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_33() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_34() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(2)].rekey_to() == Global.zero_address(),
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_35() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(3)].rekey_to() == Global.zero_address(),
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_36() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.application_id() == Int(1337),
+                    Txn.on_completion() == OnComplete.NoOp,
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig1_case_37() -> Expr:
+    return Seq([Assert(Gtxn[1].rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def logic_sig() -> Expr:
+    test_case = Btoi(Arg(0))
+    return Seq(
+        [
+            Cond(
+                [test_case == Int(1), lsig1_case_1()],
+                [test_case == Int(2), lsig1_case_2()],
+                # [test_case == Int(3), lsig1_case_3()],
+                # [test_case == Int(4), lsig1_case_4()],
+                [test_case == Int(5), lsig1_case_5()],
+                [test_case == Int(6), lsig1_case_6()],
+                [test_case == Int(7), lsig1_case_7()],
+                [test_case == Int(8), lsig1_case_8()],
+                [test_case == Int(9), lsig1_case_9()],
+                [test_case == Int(10), lsig1_case_10()],
+                # [test_case == Int(11), lsig1_case_11()],
+                # [test_case == Int(12), lsig1_case_12()],
+                # [test_case == Int(13), lsig1_case_13()],
+                [test_case == Int(14), lsig1_case_14()],
+                [test_case == Int(15), lsig1_case_15()],
+                [test_case == Int(16), lsig1_case_16()],
+                [test_case == Int(17), lsig1_case_17()],
+                [test_case == Int(18), lsig1_case_18()],
+                [test_case == Int(19), lsig1_case_19()],
+                [test_case == Int(20), lsig1_case_20()],
+                [test_case == Int(21), lsig1_case_21()],
+                [test_case == Int(22), lsig1_case_22()],
+                # [test_case == Int(23), lsig1_case_23()],
+                # [test_case == Int(24), lsig1_case_24()],
+                # [test_case == Int(25), lsig1_case_25()],
+                [test_case == Int(26), lsig1_case_26()],
+                [test_case == Int(27), lsig1_case_27()],
+                [test_case == Int(28), lsig1_case_28()],
+                [test_case == Int(29), lsig1_case_29()],
+                [test_case == Int(30), lsig1_case_30()],
+                [test_case == Int(31), lsig1_case_31()],
+                [test_case == Int(32), lsig1_case_32()],
+                [test_case == Int(33), lsig1_case_33()],
+                [test_case == Int(34), lsig1_case_34()],
+                [test_case == Int(35), lsig1_case_35()],
+                [test_case == Int(36), lsig1_case_36()],
+                [test_case == Int(37), lsig1_case_37()],
+            )
+        ]
+    )
+
+
+def compile(output_file: Path) -> None:
+    teal = compileTeal(logic_sig(), mode=Mode.Signature, version=7)
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write(teal)
+
+
+if __name__ == "__main__":
+    compile(Path("logicsig_1.teal"))

--- a/tests/group_transactions/basic/logicsig_1.py
+++ b/tests/group_transactions/basic/logicsig_1.py
@@ -433,7 +433,8 @@ case 37:
 Expected:
     Not Vulnerable
 """
-
+# pylint: disable=undefined-variable
+# type: ignore[name-defined]
 from pyteal import *
 from pathlib import Path
 

--- a/tests/group_transactions/basic/logicsig_1.teal
+++ b/tests/group_transactions/basic/logicsig_1.teal
@@ -1,0 +1,468 @@
+#pragma version 7
+arg 0
+btoi
+int 1
+==
+bnz main_l58
+arg 0
+btoi
+int 2
+==
+bnz main_l57
+arg 0
+btoi
+int 5
+==
+bnz main_l56
+arg 0
+btoi
+int 6
+==
+bnz main_l55
+arg 0
+btoi
+int 7
+==
+bnz main_l54
+arg 0
+btoi
+int 8
+==
+bnz main_l53
+arg 0
+btoi
+int 9
+==
+bnz main_l52
+arg 0
+btoi
+int 10
+==
+bnz main_l51
+arg 0
+btoi
+int 14
+==
+bnz main_l50
+arg 0
+btoi
+int 15
+==
+bnz main_l49
+arg 0
+btoi
+int 16
+==
+bnz main_l48
+arg 0
+btoi
+int 17
+==
+bnz main_l47
+arg 0
+btoi
+int 18
+==
+bnz main_l46
+arg 0
+btoi
+int 19
+==
+bnz main_l45
+arg 0
+btoi
+int 20
+==
+bnz main_l44
+arg 0
+btoi
+int 21
+==
+bnz main_l43
+arg 0
+btoi
+int 22
+==
+bnz main_l42
+arg 0
+btoi
+int 26
+==
+bnz main_l41
+arg 0
+btoi
+int 27
+==
+bnz main_l40
+arg 0
+btoi
+int 28
+==
+bnz main_l39
+arg 0
+btoi
+int 29
+==
+bnz main_l38
+arg 0
+btoi
+int 30
+==
+bnz main_l37
+arg 0
+btoi
+int 31
+==
+bnz main_l36
+arg 0
+btoi
+int 32
+==
+bnz main_l35
+arg 0
+btoi
+int 33
+==
+bnz main_l34
+arg 0
+btoi
+int 34
+==
+bnz main_l33
+arg 0
+btoi
+int 35
+==
+bnz main_l32
+arg 0
+btoi
+int 36
+==
+bnz main_l31
+arg 0
+btoi
+int 37
+==
+bnz main_l30
+err
+main_l30:
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l31:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l32:
+txn GroupIndex
+int 3
++
+gtxns RekeyTo
+global ZeroAddress
+==
+txn ApplicationID
+int 1337
+==
+&&
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l33:
+txn GroupIndex
+int 2
++
+gtxns RekeyTo
+global ZeroAddress
+==
+txn ApplicationID
+int 1337
+==
+&&
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l34:
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+txn ApplicationID
+int 1337
+==
+&&
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l35:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+txn GroupIndex
+int 5
++
+gtxns RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l36:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+txn GroupIndex
+int 4
++
+gtxns RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l37:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+txn GroupIndex
+int 4
++
+gtxns RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l38:
+txn GroupIndex
+int 3
++
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l39:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l40:
+txn RekeyTo
+global ZeroAddress
+==
+txn GroupIndex
+int 1
++
+gtxns RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l41:
+int 1
+return
+main_l42:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l43:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l44:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l45:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l46:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l47:
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l48:
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l49:
+int 0
+gtxns RekeyTo
+global ZeroAddress
+==
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l50:
+int 1
+return
+main_l51:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l52:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l53:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l54:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l55:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l56:
+txn ApplicationID
+int 1337
+==
+txn OnCompletion
+int NoOp
+==
+&&
+assert
+int 1
+return
+main_l57:
+int 1
+return
+main_l58:
+txn RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return

--- a/tests/group_transactions/basic/logicsig_2.py
+++ b/tests/group_transactions/basic/logicsig_2.py
@@ -1,7 +1,7 @@
 # pylint: disable=undefined-variable
 # type: ignore[name-defined]
-from pyteal import *
 from pathlib import Path
+from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 
 def lsig2_case_7() -> Expr:
@@ -220,11 +220,11 @@ def logic_sig() -> Expr:
     )
 
 
-def compile(output_file: Path) -> None:
+def compile_program(output_file: Path) -> None:
     teal = compileTeal(logic_sig(), mode=Mode.Signature, version=7)
     with open(output_file, "w", encoding="utf-8") as f:
         f.write(teal)
 
 
 if __name__ == "__main__":
-    compile(Path("logicsig_2.teal"))
+    compile_program(Path("logicsig_2.teal"))

--- a/tests/group_transactions/basic/logicsig_2.py
+++ b/tests/group_transactions/basic/logicsig_2.py
@@ -1,3 +1,5 @@
+# pylint: disable=undefined-variable
+# type: ignore[name-defined]
 from pyteal import *
 from pathlib import Path
 

--- a/tests/group_transactions/basic/logicsig_2.py
+++ b/tests/group_transactions/basic/logicsig_2.py
@@ -1,0 +1,228 @@
+from pyteal import *
+from pathlib import Path
+
+
+def lsig2_case_7() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_8() -> Expr:
+    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def lsig2_case_9() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_10() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[0].rekey_to() == Global.zero_address(),
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_11() -> Expr:
+    return lsig2_case_10()
+
+
+def lsig2_case_12() -> Expr:
+    return Seq([Assert(Gtxn[1].rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def lsig2_case_13() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_14() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_15() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_16() -> Expr:
+    return Seq(
+        [
+            Assert(Txn.rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_17() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_18() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_19() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_20() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_21() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_22() -> Expr:
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() - Int(1)].rekey_to() == Global.zero_address(),
+                    Txn.rekey_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_23() -> Expr:
+    return lsig2_case_22()
+
+
+def lsig2_case_24() -> Expr:
+    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+
+
+def lsig2_case_25() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_26() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_27() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_28() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_29() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_30() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_31() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_32() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_33() -> Expr:
+    return Seq(
+        [
+            Assert(Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address()),
+            Return(Int(1)),
+        ]
+    )
+
+
+def lsig2_case_34() -> Expr:
+    return Return(Int(1))
+
+
+def lsig2_case_35() -> Expr:
+    return Return(Int(1))
+
+
+def logic_sig() -> Expr:
+    test_case = Btoi(Arg(0))
+    return Seq(
+        [
+            Cond(
+                # [test_case == Int(1), lsig2_case_1()],
+                # [test_case == Int(2), lsig2_case_2()],
+                # [test_case == Int(3), lsig2_case_3()],
+                # [test_case == Int(4), lsig2_case_4()],
+                # [test_case == Int(5), lsig2_case_5()],
+                # [test_case == Int(6), lsig2_case_6()],
+                [test_case == Int(7), lsig2_case_7()],
+                [test_case == Int(8), lsig2_case_8()],
+                [test_case == Int(9), lsig2_case_9()],
+                [test_case == Int(10), lsig2_case_10()],
+                [test_case == Int(11), lsig2_case_11()],
+                [test_case == Int(12), lsig2_case_12()],
+                [test_case == Int(13), lsig2_case_13()],
+                [test_case == Int(14), lsig2_case_14()],
+                [test_case == Int(15), lsig2_case_15()],
+                [test_case == Int(16), lsig2_case_16()],
+                [test_case == Int(17), lsig2_case_17()],
+                [test_case == Int(18), lsig2_case_18()],
+                [test_case == Int(19), lsig2_case_19()],
+                [test_case == Int(20), lsig2_case_20()],
+                [test_case == Int(21), lsig2_case_21()],
+                [test_case == Int(22), lsig2_case_22()],
+                [test_case == Int(23), lsig2_case_23()],
+                [test_case == Int(24), lsig2_case_24()],
+                [test_case == Int(25), lsig2_case_25()],
+                [test_case == Int(26), lsig2_case_26()],
+                [test_case == Int(27), lsig2_case_27()],
+                [test_case == Int(28), lsig2_case_28()],
+                [test_case == Int(29), lsig2_case_29()],
+                [test_case == Int(30), lsig2_case_30()],
+                [test_case == Int(31), lsig2_case_31()],
+                [test_case == Int(32), lsig2_case_32()],
+                [test_case == Int(33), lsig2_case_33()],
+                [test_case == Int(34), lsig2_case_34()],
+                [test_case == Int(35), lsig2_case_35()],
+            )
+        ]
+    )
+
+
+def compile(output_file: Path) -> None:
+    teal = compileTeal(logic_sig(), mode=Mode.Signature, version=7)
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write(teal)
+
+
+if __name__ == "__main__":
+    compile(Path("logicsig_2.teal"))

--- a/tests/group_transactions/basic/logicsig_2.teal
+++ b/tests/group_transactions/basic/logicsig_2.teal
@@ -1,0 +1,330 @@
+#pragma version 7
+arg 0
+btoi
+int 7
+==
+bnz main_l58
+arg 0
+btoi
+int 8
+==
+bnz main_l57
+arg 0
+btoi
+int 9
+==
+bnz main_l56
+arg 0
+btoi
+int 10
+==
+bnz main_l55
+arg 0
+btoi
+int 11
+==
+bnz main_l54
+arg 0
+btoi
+int 12
+==
+bnz main_l53
+arg 0
+btoi
+int 13
+==
+bnz main_l52
+arg 0
+btoi
+int 14
+==
+bnz main_l51
+arg 0
+btoi
+int 15
+==
+bnz main_l50
+arg 0
+btoi
+int 16
+==
+bnz main_l49
+arg 0
+btoi
+int 17
+==
+bnz main_l48
+arg 0
+btoi
+int 18
+==
+bnz main_l47
+arg 0
+btoi
+int 19
+==
+bnz main_l46
+arg 0
+btoi
+int 20
+==
+bnz main_l45
+arg 0
+btoi
+int 21
+==
+bnz main_l44
+arg 0
+btoi
+int 22
+==
+bnz main_l43
+arg 0
+btoi
+int 23
+==
+bnz main_l42
+arg 0
+btoi
+int 24
+==
+bnz main_l41
+arg 0
+btoi
+int 25
+==
+bnz main_l40
+arg 0
+btoi
+int 26
+==
+bnz main_l39
+arg 0
+btoi
+int 27
+==
+bnz main_l38
+arg 0
+btoi
+int 28
+==
+bnz main_l37
+arg 0
+btoi
+int 29
+==
+bnz main_l36
+arg 0
+btoi
+int 30
+==
+bnz main_l35
+arg 0
+btoi
+int 31
+==
+bnz main_l34
+arg 0
+btoi
+int 32
+==
+bnz main_l33
+arg 0
+btoi
+int 33
+==
+bnz main_l32
+arg 0
+btoi
+int 34
+==
+bnz main_l31
+arg 0
+btoi
+int 35
+==
+bnz main_l30
+err
+main_l30:
+int 1
+return
+main_l31:
+int 1
+return
+main_l32:
+txn GroupIndex
+int 5
++
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l33:
+txn GroupIndex
+int 4
+-
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l34:
+txn GroupIndex
+int 4
+-
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l35:
+int 1
+return
+main_l36:
+int 1
+return
+main_l37:
+txn GroupIndex
+int 4
+-
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l38:
+int 1
+return
+main_l39:
+int 1
+return
+main_l40:
+int 1
+return
+main_l41:
+txn RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l42:
+txn GroupIndex
+int 1
+-
+gtxns RekeyTo
+global ZeroAddress
+==
+txn RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l43:
+txn GroupIndex
+int 1
+-
+gtxns RekeyTo
+global ZeroAddress
+==
+txn RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l44:
+int 1
+return
+main_l45:
+txn GroupIndex
+int 5
++
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l46:
+txn GroupIndex
+int 4
+-
+gtxns RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l47:
+int 1
+return
+main_l48:
+int 1
+return
+main_l49:
+txn RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l50:
+int 1
+return
+main_l51:
+int 1
+return
+main_l52:
+int 1
+return
+main_l53:
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l54:
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l55:
+gtxn 0 RekeyTo
+global ZeroAddress
+==
+gtxn 1 RekeyTo
+global ZeroAddress
+==
+&&
+assert
+int 1
+return
+main_l56:
+int 1
+return
+main_l57:
+txn RekeyTo
+global ZeroAddress
+==
+assert
+int 1
+return
+main_l58:
+int 1
+return

--- a/tests/group_transactions/test_group_support.py
+++ b/tests/group_transactions/test_group_support.py
@@ -1,0 +1,82 @@
+from typing import Tuple, List, Type
+from pathlib import Path
+import pytest
+
+
+from tealer.detectors.abstract_detector import AbstractDetector
+from tealer.detectors.all_detectors import MissingRekeyTo
+from tealer.utils.command_line.group_config import read_config_from_file
+from tealer.utils.command_line.common import init_tealer_from_config
+from tealer.utils.output import GroupTransactionOutput
+
+from tests.group_transactions.utils import expected_output_from_file
+
+
+# config, detector, expected output
+ALL_TESTS: List[Tuple[Path, Type[AbstractDetector], Path]] = [
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        MissingRekeyTo,
+        Path("tests/group_transactions/basic/expected_output.yaml"),
+    )
+]
+
+
+@pytest.mark.parametrize("test", ALL_TESTS)
+def test_instructions_output_detectors(test: Tuple[Path, Type[AbstractDetector], Path]) -> None:
+    config_path, detector, expected_output_file_path = test
+
+    expected_output = expected_output_from_file(expected_output_file_path)
+    tealer = init_tealer_from_config(read_config_from_file(config_path))
+    tealer.register_detector(detector)
+    output = tealer.run_detectors()[0]
+
+    reported_output: List["GroupTransactionOutput"] = []
+    for i in output:
+        assert isinstance(i, GroupTransactionOutput)
+        reported_output.append(i)
+
+    # expected output is also sorted by operation name
+    reported_output = sorted(reported_output, key=lambda x: x.group_transaction.operation_name)
+
+    # same number of groups/operations are reported as vulnerable
+    assert len(reported_output) == len(expected_output.operations)
+
+    for expected_operation, reported_operation in zip(expected_output.operations, reported_output):
+        # reported same operation
+        assert expected_operation.operation == reported_operation.group_transaction.operation_name
+        # reported same transactions
+        assert len(expected_operation.vulnerable_transactions) == len(
+            reported_operation.transactions.keys()
+        )
+        expected_transactions = sorted(
+            expected_operation.vulnerable_transactions, key=lambda x: x.transaction_id
+        )
+        reported_transactions = sorted(
+            list(reported_operation.transactions.keys()), key=lambda x: x.transacton_id
+        )
+
+        for expected_txn, reported_txn in zip(expected_transactions, reported_transactions):
+            # same transaction id
+            assert expected_txn.transaction_id == reported_txn.transacton_id
+            # same contracts
+            expected_contracts = sorted(
+                expected_txn.contracts, key=lambda x: (x.contract_name, x.function_name)
+            )
+            reported_contracts = sorted(
+                reported_operation.transactions[reported_txn],
+                key=lambda x: (x.contract.contract_name, x.function_name),
+            )
+
+            assert len(expected_contracts) == len(reported_contracts)
+            for expected_contract, reported_contract in zip(expected_contracts, reported_contracts):
+                # same contract name and function name
+                assert expected_contract.contract_name == reported_contract.contract.contract_name
+                assert expected_contract.function_name == reported_contract.function_name
+
+    # for i in output:
+    #     # assert isinstance(output, Gr)
+    #     out = i.to_json()
+    #     print(out["operation"])
+    #     print(out["transactions"])
+    # assert(False)

--- a/tests/group_transactions/test_group_support.py
+++ b/tests/group_transactions/test_group_support.py
@@ -22,7 +22,8 @@ ALL_TESTS: List[Tuple[Path, Type[AbstractDetector], Path]] = [
 ]
 
 
-@pytest.mark.parametrize("test", ALL_TESTS)
+# pylint: disable=too-many-locals
+@pytest.mark.parametrize("test", ALL_TESTS)  # type: ignore
 def test_instructions_output_detectors(test: Tuple[Path, Type[AbstractDetector], Path]) -> None:
     config_path, detector, expected_output_file_path = test
 

--- a/tests/group_transactions/utils.py
+++ b/tests/group_transactions/utils.py
@@ -1,0 +1,84 @@
+from typing import Dict, Any, List, Optional
+from dataclasses import dataclass
+from pathlib import Path
+import yaml
+
+
+class InvalidTestCase(Exception):
+    pass
+
+
+@dataclass
+class OutputContract:
+    contract_name: str
+    function_name: str
+
+    @staticmethod
+    def from_yaml(contract: Dict[str, Any]) -> "OutputContract":
+        if "contract" not in contract or "function" not in contract:
+            raise InvalidTestCase(
+                f"Missing required fields in the contract description: {contract}"
+            )
+        return OutputContract(contract["contract"], contract["function"])
+
+
+@dataclass
+class OutputTransaction:
+    transaction_id: str
+    contracts: List[OutputContract]
+
+    @staticmethod
+    def from_yaml(transaction: Dict[str, Any]) -> "OutputTransaction":
+        if "txn_id" not in transaction:
+            raise InvalidTestCase(f'Missing "txn_id" field for the transaction {transaction}')
+
+        contracts = []
+        if "contracts" in transaction:
+            for contract in transaction["contracts"]:
+                contracts.append(OutputContract.from_yaml(contract))
+        return OutputTransaction(
+            transaction["txn_id"],
+            sorted(contracts, key=lambda x: (x.contract_name, x.function_name)),
+        )
+
+
+@dataclass
+class OutputOperation:
+    operation: str
+    vulnerable_transactions: List[OutputTransaction]
+
+    @staticmethod
+    def from_yaml(operation: Dict[str, Any]) -> "OutputOperation":
+        if "operation" not in operation or "vulnerable_transactions" not in operation:
+            raise InvalidTestCase(f"Missing required fields in the operation: {operation}")
+
+        operation_name = operation["operation"]
+
+        vulnerable_transactions = []
+        for transaction in operation["vulnerable_transactions"]:
+            vulnerable_transactions.append(OutputTransaction.from_yaml(transaction))
+
+        return OutputOperation(operation_name, vulnerable_transactions)
+
+
+@dataclass
+class ExpectedOutput:
+    name: str
+    operations: List[OutputOperation]
+
+    @staticmethod
+    def from_yaml(output: Dict[str, Any]) -> "ExpectedOutput":
+        if "name" not in output or "operations" not in output:
+            raise InvalidTestCase(f"Missing required fields in the expected output: {output}")
+
+        name = output["name"]
+        operations = []
+        for operation in output["operations"]:
+            operations.append(OutputOperation.from_yaml(operation))
+        return ExpectedOutput(name, operations)
+
+
+def expected_output_from_file(file_path: Path) -> "ExpectedOutput":
+    with open(file_path, encoding="utf-8") as f:
+        # print(yaml.safe_load(f.read()))
+        return ExpectedOutput.from_yaml(yaml.safe_load(f.read()))

--- a/tests/group_transactions/utils.py
+++ b/tests/group_transactions/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List
 from dataclasses import dataclass
 from pathlib import Path
 import yaml


### PR DESCRIPTION
The PR mainly adds the test cases for the group transaction support. If all the test cases pass, then it could be considered that tealer has the basic support for group transactions. Note: All the test cases are not enabled. Test cases will be enabled progressively with the support for different patterns.

`tests/group_transactions/basic/logicsig_1.py` lists all the test cases.

`tests/group_transactions/*` contains a basic framework to write tests using the group configuration. To add a test, one would write the group configuration for the protocol and write the `expected_output.yaml` file. The `expected_output.yaml` file lists all the vulnerable operations that should be reported by the detector(s).

The config file structure is updated to include the name of the "operation" the group transaction performs.

A new output format `GroupTransactionOutput` is implemented to represent reported output when analyzing a group by the detectors. The output contains the `group`, a list of `transactions` in the group that are vulnerable, and for each transaction list of vulnerable contracts.


The command line handler is updated to run detectors on the config. Previously, the tealer would ignore the detectors, printers when the group_config is given. It is now updated to run the detectors and generate the output.

Sample output:

```sh
$ tealer --detect rekey-to --group-config ./tests/group_transactions/basic/config.yaml
```
<img width="914" alt="Screenshot 2023-09-29 at 1 27 20 PM" src="https://github.com/crytic/tealer/assets/55708799/2434bb0d-0a36-457f-a8aa-5e7659373147">



```

The `.teal` files are generated by PyTeal and need not be reviewed.
