### PR TITLE
Update detectors to check if the other transactions in the group check the transaction using absolute or relative indexes

### DIFF
--- a/tealer/analyses/dataflow/transaction_context/addr_fields.py
+++ b/tealer/analyses/dataflow/transaction_context/addr_fields.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Set, Tuple, Callable
 from tealer.analyses.dataflow.transaction_context.generic import DataflowTransactionContext
 from tealer.analyses.dataflow.transaction_context.utils.key_helpers import (
     get_gtxn_at_index_key,
-    is_txn_or_gtxn,
+    is_value_matches_key,
 )
 from tealer.teal.instructions.instructions import (
     Eq,
@@ -153,24 +153,20 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
             return self._universal_set(), self._universal_set()
 
         if isinstance(arg1, UnknownStackValue):
-            if not isinstance(arg2, UnknownStackValue) and not is_txn_or_gtxn(
-                key, arg2.instruction
-            ):
+            if not isinstance(arg2, UnknownStackValue) and not is_value_matches_key(key, arg2):
                 # arg1 is unknown and arg2 is not related to "key"
                 return self._universal_set(), self._universal_set()
             # arg2 is related to "key" but arg1 is unknown
             asserted_addresses = set([SOME_ADDRESS])
         elif isinstance(arg2, UnknownStackValue):
-            if not isinstance(arg1, UnknownStackValue) and not is_txn_or_gtxn(
-                key, arg1.instruction
-            ):
+            if not isinstance(arg1, UnknownStackValue) and not is_value_matches_key(key, arg1):
                 # arg2 is unknown and arg1 is not related to "key"
                 return self._universal_set(), self._universal_set()
             # arg1 is related to "key" but arg2 is unknown
             asserted_addresses = set([SOME_ADDRESS])
-        elif is_txn_or_gtxn(key, arg1.instruction):
+        elif is_value_matches_key(key, arg1):
             asserted_addresses = self._get_asserted_address(arg2.instruction)
-        elif is_txn_or_gtxn(key, arg2.instruction):
+        elif is_value_matches_key(key, arg2):
             asserted_addresses = self._get_asserted_address(arg1.instruction)
 
         if asserted_addresses is None:

--- a/tealer/analyses/dataflow/transaction_context/addr_fields.py
+++ b/tealer/analyses/dataflow/transaction_context/addr_fields.py
@@ -4,6 +4,8 @@ from tealer.analyses.dataflow.transaction_context.generic import DataflowTransac
 from tealer.analyses.dataflow.transaction_context.utils.key_helpers import (
     get_gtxn_at_index_key,
     is_value_matches_key,
+    get_absolute_index_key,
+    get_relative_index_key,
 )
 from tealer.teal.instructions.instructions import (
     Eq,
@@ -14,6 +16,7 @@ from tealer.teal.instructions.instructions import (
 from tealer.teal.global_field import ZeroAddress, CreatorAddress
 from tealer.utils.algorand_constants import ZERO_ADDRESS
 from tealer.analyses.utils.stack_ast_builder import KnownStackValue, UnknownStackValue
+from tealer.utils.algorand_constants import MAX_GROUP_SIZE
 
 if TYPE_CHECKING:
     from tealer.teal.instructions.instructions import Instruction
@@ -207,4 +210,25 @@ class AddrFields(DataflowTransactionContext):  # pylint: disable=too-few-public-
                     self._set_addr_values(
                         addr_field_obj(self._function.transaction_context(block).gtxn_context(idx)),
                         addr_values,
+                    )
+
+                    abs_addr_values = self._block_contexts[get_absolute_index_key(idx, key)][block]
+                    self._set_addr_values(
+                        addr_field_obj(
+                            self._function.transaction_context(block).absolute_context(idx)
+                        ),
+                        abs_addr_values,
+                    )
+
+                for offset in range(-(MAX_GROUP_SIZE - 1), MAX_GROUP_SIZE):
+                    if offset == 0:
+                        continue
+                    rel_addr_values = self._block_contexts[get_relative_index_key(offset, key)][
+                        block
+                    ]
+                    self._set_addr_values(
+                        addr_field_obj(
+                            self._function.transaction_context(block).relative_context(offset)
+                        ),
+                        rel_addr_values,
                     )

--- a/tealer/analyses/dataflow/transaction_context/fee_field.py
+++ b/tealer/analyses/dataflow/transaction_context/fee_field.py
@@ -5,6 +5,8 @@ from tealer.analyses.dataflow.transaction_context.generic import DataflowTransac
 from tealer.analyses.dataflow.transaction_context.utils.key_helpers import (
     get_gtxn_at_index_key,
     is_value_matches_key,
+    get_absolute_index_key,
+    get_relative_index_key,
 )
 from tealer.teal.instructions.instructions import (
     Eq,
@@ -207,3 +209,28 @@ class FeeField(DataflowTransactionContext):
                     self._function.transaction_context(block).gtxn_context(
                         idx
                     ).max_fee = max_fee.value
+
+                abs_max_fee = self._block_contexts[get_absolute_index_key(idx, FEE_KEY)][block]
+                assert isinstance(abs_max_fee, FeeValue)
+                if abs_max_fee.is_unknown:
+                    self._function.transaction_context(block).absolute_context(
+                        idx
+                    ).max_fee_unknown = True
+                else:
+                    self._function.transaction_context(block).absolute_context(
+                        idx
+                    ).max_fee = abs_max_fee.value
+
+            for offset in range(-(MAX_GROUP_SIZE - 1), MAX_GROUP_SIZE):
+                if offset == 0:
+                    continue
+                rel_max_fee = self._block_contexts[get_relative_index_key(offset, FEE_KEY)][block]
+                assert isinstance(rel_max_fee, FeeValue)
+                if rel_max_fee.is_unknown:
+                    self._function.transaction_context(block).relative_context(
+                        offset
+                    ).max_fee_unknown = True
+                else:
+                    self._function.transaction_context(block).relative_context(
+                        offset
+                    ).max_fee = rel_max_fee.value

--- a/tealer/analyses/dataflow/transaction_context/fee_field.py
+++ b/tealer/analyses/dataflow/transaction_context/fee_field.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from tealer.analyses.dataflow.transaction_context.generic import DataflowTransactionContext
 from tealer.analyses.dataflow.transaction_context.utils.key_helpers import (
     get_gtxn_at_index_key,
-    is_txn_or_gtxn,
+    is_value_matches_key,
 )
 from tealer.teal.instructions.instructions import (
     Eq,
@@ -149,29 +149,25 @@ class FeeField(DataflowTransactionContext):
                 return FeeValue(), FeeValue()
 
             if isinstance(arg1, UnknownStackValue):
-                if not isinstance(arg2, UnknownStackValue) and not is_txn_or_gtxn(
-                    key, arg2.instruction
-                ):
+                if not isinstance(arg2, UnknownStackValue) and not is_value_matches_key(key, arg2):
                     # arg1 is unknown and arg2 is not related to "key"
                     return FeeValue(), FeeValue()
                 # arg2 is related to key and arg1 is some unknown value
                 compared_value = FeeValue(is_unknown=True)
             elif isinstance(arg2, UnknownStackValue):
-                if not isinstance(arg1, UnknownStackValue) and not is_txn_or_gtxn(
-                    key, arg1.instruction
-                ):
+                if not isinstance(arg1, UnknownStackValue) and not is_value_matches_key(key, arg1):
                     # arg2 is unknown and arg1 is not related to "key"
                     return FeeValue(), FeeValue()
                 # arg1 is related to "key" and arg2 is some unknown int value
                 compared_value = FeeValue(is_unknown=True)
-            elif is_txn_or_gtxn(key, arg1.instruction):
+            elif is_value_matches_key(key, arg1):
                 is_int, value = is_int_push_ins(arg2.instruction)
                 if is_int and isinstance(value, int):
                     compared_value = FeeValue(value=value)
                 else:
                     compared_value = FeeValue(is_unknown=True)
 
-            elif is_txn_or_gtxn(key, arg2.instruction):
+            elif is_value_matches_key(key, arg2):
                 is_int, value = is_int_push_ins(arg1.instruction)
                 if is_int and isinstance(value, int):
                     compared_value = FeeValue(value=value)

--- a/tealer/analyses/dataflow/transaction_context/generic.py
+++ b/tealer/analyses/dataflow/transaction_context/generic.py
@@ -231,6 +231,8 @@ from collections import defaultdict
 
 from tealer.analyses.dataflow.transaction_context.utils.key_helpers import (
     get_gtxn_at_index_key,
+    get_absolute_index_key,
+    get_relative_index_key,
 )
 from tealer.teal.instructions.instructions import (
     Assert,
@@ -783,6 +785,12 @@ class DataflowTransactionContext(ABC):  # pylint: disable=too-few-public-methods
         for key in self.KEYS_WITH_GTXN:
             for ind in range(MAX_GROUP_SIZE):
                 gtx_keys.append(get_gtxn_at_index_key(ind, key))
+                gtx_keys.append(get_absolute_index_key(ind, key))
+
+            for offset in range(-(MAX_GROUP_SIZE - 1), MAX_GROUP_SIZE):
+                if offset == 0:
+                    continue
+                gtx_keys.append(get_relative_index_key(offset, key))
 
         all_keys = self.BASE_KEYS + gtx_keys
 

--- a/tealer/analyses/dataflow/transaction_context/txn_types.py
+++ b/tealer/analyses/dataflow/transaction_context/txn_types.py
@@ -1,16 +1,14 @@
-from typing import TYPE_CHECKING, List, Set, Tuple, Dict, Type
+from typing import TYPE_CHECKING, List, Set, Tuple, Dict
 
 from tealer.analyses.dataflow.transaction_context.generic import DataflowTransactionContext
 from tealer.analyses.dataflow.transaction_context.utils.key_helpers import (
     get_gtxn_at_index_key,
-    is_gtxn_at_index_key,
-    get_ind_base_for_gtxn_at_key,
+    get_ind_base_for_gtxn_type_keys,
+    is_value_matches_key,
 )
 from tealer.teal.instructions.instructions import (
     Eq,
     Neq,
-    Txn,
-    Gtxn,
     Not,
 )
 from tealer.teal.instructions.transaction_field import (
@@ -54,8 +52,8 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
     UNIVERSAL_SETS: Dict[str, List] = universal_sets
 
     def _universal_set(self, key: str) -> Set:
-        if is_gtxn_at_index_key(key):
-            _, base_key = get_ind_base_for_gtxn_at_key(key)
+        if key not in self.BASE_KEYS:
+            _, base_key = get_ind_base_for_gtxn_type_keys(key)
             return set(self.UNIVERSAL_SETS[base_key])
         return set(self.UNIVERSAL_SETS[key])
 
@@ -67,28 +65,6 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
 
     def _intersection(self, key: str, a: Set, b: Set) -> Set:
         return a & b
-
-    @classmethod
-    def _is_ins_tx_field(
-        cls, key: str, ins: "Instruction", field: Type["TransactionField"]
-    ) -> bool:
-        """return True if ins is "txn {field}" or ins is gtxn {idx} field
-
-        Args:
-            key: The analysis key. Used to find if the analysis is value of `gtxn` instruction and
-                is for the correct transaction index.
-            ins: The instruction.
-            field: The transaction field class.
-
-        Returns:
-            Returns True if key is for txn field and instruction is "txn {:field:}". And if key is
-            for a gtxn instruction, return True if instruction and the key have the same index and the
-            field accessed by the instruction is :field:.
-        """
-        if is_gtxn_at_index_key(key):
-            idx, _ = get_ind_base_for_gtxn_at_key(key)
-            return isinstance(ins, Gtxn) and ins.idx == idx and isinstance(ins.field, field)
-        return isinstance(ins, Txn) and isinstance(ins.field, field)
 
     def _get_asserted_transaction_types(  # pylint: disable=too-many-branches, too-many-locals
         self, key: str, ins_stack_value: KnownStackValue
@@ -130,7 +106,7 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
         U = set(self.UNIVERSAL_SETS[self.TRANSACTION_TYPE_KEY])
 
         ins1 = ins_stack_value.instruction
-        if self._is_ins_tx_field(key, ins1, ApplicationID):
+        if is_value_matches_key(key, ins_stack_value, ApplicationID):
             # txn ApplicationID pushes 0 if this Application creation transaction elses pushes nonzero
             return set(APPLICATION_TRANSACTION_TYPES) - set(
                 [TealerTransactionType.ApplCreation]
@@ -141,7 +117,7 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
             if isinstance(not_arg, UnknownStackValue):
                 return set(U), set(U)
             ins2 = not_arg.instruction
-            if self._is_ins_tx_field(key, ins2, ApplicationID):
+            if is_value_matches_key(key, not_arg, ApplicationID):
                 # txn ApplicationID
                 # !
                 # return
@@ -167,34 +143,34 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
                 return set(U), set(U)
 
             true_values, false_values = None, None
-            if self._is_ins_tx_field(key, ins2, ApplicationID):
+            if is_value_matches_key(key, arg1, ApplicationID):
                 # TODO: ApplicationCreation transaction can be NoOp or OptIn
                 true_values, false_values = set([TealerTransactionType.ApplCreation]), set(
                     APPLICATION_TRANSACTION_TYPES
                 ) - set([TealerTransactionType.ApplCreation])
-            elif self._is_ins_tx_field(key, ins3, ApplicationID):
+            elif is_value_matches_key(key, arg2, ApplicationID):
                 # TODO: ApplicationCreation transaction can be NoOp or OptIn
                 true_values, false_values = set([TealerTransactionType.ApplCreation]), set(
                     APPLICATION_TRANSACTION_TYPES
                 ) - set([TealerTransactionType.ApplCreation])
 
-            if self._is_ins_tx_field(key, ins2, TypeEnum) and value_3 is not None:
+            if is_value_matches_key(key, arg1, TypeEnum) and value_3 is not None:
                 compared_type = transaction_type_to_tealer_type(value_3)
                 true_values, false_values = set([compared_type]), set(
                     TYPEENUM_TRANSACTION_TYPES
                 ) - set([compared_type])
-            elif self._is_ins_tx_field(key, ins3, TypeEnum) and value_2 is not None:
+            elif is_value_matches_key(key, arg2, TypeEnum) and value_2 is not None:
                 compared_type = transaction_type_to_tealer_type(value_2)
                 true_values, false_values = set([compared_type]), set(
                     TYPEENUM_TRANSACTION_TYPES
                 ) - set([compared_type])
 
-            if self._is_ins_tx_field(key, ins2, OnCompletion) and value_3 is not None:
+            if is_value_matches_key(key, arg1, OnCompletion) and value_3 is not None:
                 compared_on_completion = oncompletion_to_tealer_type(value_3)
                 true_values, false_values = set([compared_on_completion]), set(
                     APPLICATION_TRANSACTION_TYPES
                 ) - set([compared_on_completion])
-            elif self._is_ins_tx_field(key, ins3, OnCompletion) and value_2 is not None:
+            elif is_value_matches_key(key, arg2, OnCompletion) and value_2 is not None:
                 compared_on_completion = oncompletion_to_tealer_type(value_2)
                 true_values, false_values = set([compared_on_completion]), set(
                     APPLICATION_TRANSACTION_TYPES

--- a/tealer/analyses/dataflow/transaction_context/utils/group_helpers.py
+++ b/tealer/analyses/dataflow/transaction_context/utils/group_helpers.py
@@ -1,0 +1,143 @@
+from typing import TYPE_CHECKING, Tuple, Optional
+from dataclasses import dataclass
+
+from tealer.teal.instructions.instructions import (
+    Txn,  # self, normal field
+    Gtxn,  # txn index is part of the instruction, normal field
+    # Txna,   # self, array field, array index in the instruction
+    # Gtxna,  # txn index is part of the instruction, array field, array index in the instruction
+    Gtxns,  # txn index is taken from stack, normal field
+    # Gtxnsa, # txn index is taken from stack, normal field, array index in the instruction
+    # Txnas,  # self, array field, array index from stack
+    # Gtxnas, # txn index is part of the instruction, array field, array index from stack
+    # Gtxnsas, # txn index from stack, array field, array index from stack.
+    Sub,
+    Add,
+)
+from tealer.utils.comparable_enum import ComparableEnum
+from tealer.analyses.utils.stack_ast_builder import KnownStackValue, UnknownStackValue
+from tealer.teal.instructions.transaction_field import GroupIndex
+from tealer.utils.analyses import is_int_push_ins
+
+if TYPE_CHECKING:
+    from tealer.teal.instructions.transaction_field import TransactionField
+
+
+class IndexType(ComparableEnum):
+    Self = 0
+    Absolute = 1
+    Relative = 2
+
+    Unknown = 777
+
+
+@dataclass
+class TransactionIndex:
+    index_type: IndexType
+    # value should be ignored for Self and Unknown index types.
+    value: int
+
+
+def get_index_and_field(
+    value: KnownStackValue,
+) -> Tuple[bool, Optional["TransactionIndex"], Optional["TransactionField"]]:
+    """Given a stack value, check if the value pushed is a transaction field. if so, return transaction index and the field.
+
+    Args:
+        value: The stack value.
+
+    Returns:
+        bool: True if the pushed value is a transaction field else False
+        TransactionIndex: Index of the transaction
+        TransactionField: The transaction field that will be pushed.
+    """
+    # TODO: probably could cache
+    # our analysis does not concern array fields, so ignoring those instructions for now.
+    if not isinstance(value.instruction, (Txn, Gtxn, Gtxns)):
+        return False, None, None
+
+    field = value.instruction.field
+    if isinstance(value.instruction, Txn):
+        return True, TransactionIndex(IndexType.Self, 0), field
+
+    if isinstance(value.instruction, Gtxn):
+        return True, TransactionIndex(IndexType.Absolute, value.instruction.idx), field
+
+    # Gtxns instruction
+    index_stack_value = value.args[0]
+    # happens when the Gtxns instruction is the first instruction of the block.
+    if isinstance(index_stack_value, UnknownStackValue):
+        return True, TransactionIndex(IndexType.Unknown, 0), field
+
+    index = _get_index(index_stack_value)
+    return True, index, field
+
+
+def _get_index(index_stack_value: KnownStackValue) -> "TransactionIndex":
+    # index patterns
+    # Txn.group_index() -> Self
+    # Int(n) -> Absolute index
+    # Txn.group_index() +/- Int(n) -> Relative / Unknown
+
+    # TODO: if there was some kind of analysis to calculate index implemented, call that function to fetch the index directly.
+    # There is no need for such analysis. below patterns cover most of the contracts.
+    # Txn.group_index() -> txn GroupIndex
+    if isinstance(index_stack_value.instruction, Txn) and isinstance(
+        index_stack_value.instruction.field, GroupIndex
+    ):
+        # Self
+        return TransactionIndex(IndexType.Self, 0)
+
+    pushes_int, int_value = is_int_push_ins(index_stack_value.instruction)
+    if pushes_int and isinstance(int_value, int):
+        # index_stack_value is an integer and the index is known to the tool
+        return TransactionIndex(IndexType.Absolute, int_value)
+
+    if pushes_int and not isinstance(int_value, int):
+        # pushes an integer but we don't its value. Unknown index.
+        return TransactionIndex(IndexType.Unknown, 0)
+
+    # does not push an literal int value.
+    # check for relative index patterns.
+    # Txn.group_index() - Int(n)
+    if isinstance(index_stack_value.instruction, Sub):
+        arg1, arg2 = index_stack_value.args[0], index_stack_value.args[1]
+        # index value is arg1 - arg2.
+        if isinstance(arg1, UnknownStackValue) or isinstance(arg2, UnknownStackValue):
+            return TransactionIndex(IndexType.Unknown, 0)
+        if not (
+            isinstance(arg1.instruction, Txn) and isinstance(arg1.instruction.field, GroupIndex)
+        ):
+            return TransactionIndex(IndexType.Unknown, 0)
+
+        # first argument is Txn.group_index()
+        is_int, int_value = is_int_push_ins(arg2.instruction)
+        if is_int and isinstance(int_value, int):
+            offset = -int_value  # pylint: disable=invalid-unary-operand-type
+            return TransactionIndex(IndexType.Relative, offset)
+        return TransactionIndex(IndexType.Unknown, 0)
+
+    # Txn.group_index() + Int(n)
+    if isinstance(index_stack_value.instruction, Add):
+        arg1, arg2 = index_stack_value.args[0], index_stack_value.args[1]
+        # index value is arg1 + arg2.
+        if isinstance(arg1, UnknownStackValue) or isinstance(arg2, UnknownStackValue):
+            return TransactionIndex(IndexType.Unknown, 0)
+        offset_arg = arg2
+        if not (
+            isinstance(arg1.instruction, Txn) and isinstance(arg1.instruction.field, GroupIndex)
+        ):
+            if not (
+                isinstance(arg2.instruction, Txn) and isinstance(arg2.instruction.field, GroupIndex)
+            ):
+                return TransactionIndex(IndexType.Unknown, 0)
+            # Int(n) + Txn.group_index()
+            offset_arg = arg1
+
+        is_int, int_value = is_int_push_ins(offset_arg.instruction)
+        if is_int and isinstance(int_value, int):
+            offset = int_value
+            return TransactionIndex(IndexType.Relative, offset)
+        return TransactionIndex(IndexType.Unknown, 0)
+
+    return TransactionIndex(IndexType.Unknown, 0)

--- a/tealer/analyses/dataflow/transaction_context/utils/key_helpers.py
+++ b/tealer/analyses/dataflow/transaction_context/utils/key_helpers.py
@@ -1,5 +1,4 @@
 """
-
 For a given field multiple types of possible values can be calculated.
 The possible values of the field of the transaction
     1. executing the contract/function irrespective of the transaction's group index.
@@ -10,16 +9,17 @@ The possible values of the field of the transaction
 see transaction_context/__init__.py for more information.
 """
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, Optional, Type
 
-from tealer.teal.instructions.instructions import (
-    Txn,
-    Gtxn,
-)
 from tealer.teal.instructions.parse_transaction_field import TX_FIELD_TXT_TO_OBJECT
+from tealer.analyses.dataflow.transaction_context.utils.group_helpers import (
+    IndexType,
+    get_index_and_field,
+)
 
 if TYPE_CHECKING:
-    from tealer.teal.instructions.instructions import Instruction
+    from tealer.analyses.utils.stack_ast_builder import KnownStackValue
+    from tealer.teal.instructions.transaction_field import TransactionField
 
 
 def get_gtxn_at_index_key(idx: int, base_key: str) -> str:
@@ -47,11 +47,11 @@ def is_gtxn_at_index_key(analysis_key: str) -> bool:
     return analysis_key.startswith("GTXN_AT_INDEX")
 
 
-def get_ind_base_for_gtxn_at_key(analysis_key: str) -> Tuple[int, str]:
-    """Calculate the index and base key for the txn_at_index type key.
+def get_ind_base_for_gtxn_type_keys(analysis_key: str) -> Tuple[int, str]:
+    """Calculate the index and base key for the txn_at_index, absolute, relative type keys.
 
     Args:
-        analysis_key: A key used to represent type (2) information.
+        analysis_key: A key
 
     Returns:
         Returns the transaction index and the base key for the analysis_key.
@@ -61,8 +61,6 @@ def get_ind_base_for_gtxn_at_key(analysis_key: str) -> Tuple[int, str]:
     return int(ind), base_key
 
 
-# This function is not used currently. Will be used when group transaction support is added
-# for absolute indexes.
 def get_absolute_index_key(idx: int, base_key: str) -> str:
     """Analysis to represent type (3) information for base_key field
 
@@ -76,8 +74,18 @@ def get_absolute_index_key(idx: int, base_key: str) -> str:
     return f"GTXN_ABS_{idx:02d}_{base_key}"
 
 
-# This function is not used currently. Will be used when group transaction support is added
-# for relative indexes.
+def is_absolute_index_key(analysis_key: str) -> bool:
+    """Return True if the analysis key represents type (3) information
+
+    Args:
+        analysis_key: The key.
+
+    Returns:
+        Returns True if analysis_key is a absolute type of key.
+    """
+    return analysis_key.startswith("GTXN_ABS_")
+
+
 def get_relative_index_key(offset: int, base_key: str) -> str:
     """Analysis to represent type (2) information for base_key field
 
@@ -91,27 +99,84 @@ def get_relative_index_key(offset: int, base_key: str) -> str:
     return f"GTXN_RELATIVE_{offset:02d}_{base_key}"
 
 
-# TODO: The function is copied as it is from DataflowTransactionContext. Update the implementation
-# when adding support for absolute indices and relative indices.
-def is_txn_or_gtxn(analysis_key: str, ins: "Instruction") -> bool:
-    """return True if ins is of form txn {key} or gtxn {ind} {key} else False
-
-    "key" should be string representation of the field. e.g if field is RekeyTo, then
-    key should also be "RekeyTo".
+def is_relative_index_key(analysis_key: str) -> bool:
+    """Return True if the analysis key represents type (4) information
 
     Args:
-        analysis_key: The key used to represent values of a field in the analysis.
-        ins: An instruction.
+        analysis_key: The key.
 
     Returns:
-        Returns True if the instruction :ins: access the value of the field tracked by
-        the key :key:.
+        Returns True if analysis_key is a relative type of key.
     """
-    if is_gtxn_at_index_key(analysis_key):
-        idx, field = get_ind_base_for_gtxn_at_key(analysis_key)
-        return (
-            isinstance(ins, Gtxn)
-            and ins.idx == idx
-            and isinstance(ins.field, TX_FIELD_TXT_TO_OBJECT[field])
-        )
-    return isinstance(ins, Txn) and isinstance(ins.field, TX_FIELD_TXT_TO_OBJECT[analysis_key])
+    return analysis_key.startswith("GTXN_RELATIVE_")
+
+
+# pylint: disable=too-many-branches
+def is_value_matches_key(
+    analysis_key: str,
+    stack_value: "KnownStackValue",
+    key_field: Optional[Type["TransactionField"]] = None,
+) -> bool:
+    """return True if the stack_value is value of the field tracked by the analysis_key else False.
+
+    Type of keys:
+        Self: The value of the current transaction irrespective of its index in the group
+        GTXN_AT_INDEX: The value of the transaction field executing this contract when this transaction is at the index.
+        Absolute: The field value of the transaction at an absolute index irrespective of the contract being executed at that index.
+        Relative: The field value of the transaction at an offset from the current transaction irrespective of the contract being executed at that offset.
+
+    Args:
+        analysis_key: The key tracking a field
+        stack_value: The value currently being checked
+        key_field: The transaction field if it cannot be calculated from the analysis_key
+
+    Returns:
+        Returns True if the stack_value is the value of the field tracked by the analysis_key else False.
+    """
+    value_is_field, value_index, value_field = get_index_and_field(stack_value)
+    if not value_is_field:
+        return False
+    assert value_index is not None and value_field is not None
+    if value_index.index_type == IndexType.Unknown:
+        return False
+
+    if key_field is None:
+        if (
+            is_gtxn_at_index_key(analysis_key)
+            or is_absolute_index_key(analysis_key)
+            or is_relative_index_key(analysis_key)
+        ):
+
+            _, field_str = get_ind_base_for_gtxn_type_keys(analysis_key)
+        else:
+            field_str = analysis_key
+        field = TX_FIELD_TXT_TO_OBJECT[field_str]
+    else:
+        field = key_field
+
+    if not isinstance(value_field, field):
+        return False
+
+    if is_gtxn_at_index_key(analysis_key) or is_absolute_index_key(analysis_key):
+        # difference between Gtxn_at_key and absolute_index comes from merging of Type(1) information before propagating.
+        # It is handled in DataflowTransactionContext._update_gtxn_constraints
+        if value_index.index_type != IndexType.Absolute:
+            return False
+
+        idx, _ = get_ind_base_for_gtxn_type_keys(analysis_key)
+        if value_index.value == idx:
+            return True
+        return False
+
+    if is_relative_index_key(analysis_key):
+        if value_index.index_type != IndexType.Relative:
+            return False
+        offset, _ = get_ind_base_for_gtxn_type_keys(analysis_key)
+        if value_index.value == offset:
+            return True
+        return False
+
+    # Txn/Self key
+    if value_index.index_type == IndexType.Self:
+        return True
+    return False

--- a/tealer/execution_context/transactions.py
+++ b/tealer/execution_context/transactions.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Optional, Dict, List
 
 from tealer.utils.teal_enums import TransactionType
 
+# from tealer.exceptions import TealerException
+
 if TYPE_CHECKING:
     from tealer.teal.functions import Function
 
@@ -13,6 +15,7 @@ class Transaction:
         self.logic_sig: Optional["Function"] = None
         self.application: Optional["Function"] = None
         self.absoulte_index: Optional[int] = None
+        # t1.relative_indexes[-1] = t2 => t2.group_index() == t1.group_index() - 1
         self.relative_indexes: Dict[int, Transaction] = {}
         self.group_transaction: Optional[GroupTransaction] = None
         self.transacton_id: str = ""
@@ -23,4 +26,41 @@ class GroupTransaction:
     def __init__(self) -> None:
         self.transactions: List[Transaction] = []
         self.absolute_indexes: Dict[int, Transaction] = {}
+        # {t1: (t2, -2)} => t1.group_index() == t2.group_index() - 2
+        self.group_relative_indexes: Dict[Transaction, Dict[Transaction, int]] = {}
         self.operation_name: str = ""
+
+
+def fill_group_relative_indexes(group: "GroupTransaction") -> None:
+    # group_relative_indexes: Dict[Transaction, Dict[Transaction, int]] = {}
+    for txn in group.transactions:
+        group.group_relative_indexes[txn] = {}
+
+    for txn in group.transactions:
+        for offset in txn.relative_indexes:
+            other_txn = txn.relative_indexes[offset]
+            # other_txn.group_index() = txn.group_index() + offset
+            group.group_relative_indexes[other_txn][txn] = offset
+
+
+# def fill_indexes(group: GroupTransaction):
+#     """Calculate the absolute indexes and relative indexes using the indexes from the config.
+
+#     """
+
+#     for txn in group.transactions:
+#         if txn.absoulte_index is not None:
+#             for offset in txn.relative_indexes:
+#                 other_txn = txn.relative_indexes[offset]
+#                 other_txn_abs = txn.absoulte_index + offset
+#                 if other_txn.absoulte_index is None:
+#                     other_txn.absoulte_index = other_txn_abs
+#                     group.absolute_indexes[other_txn_abs] = other_txn
+#                 # else:
+#                 #     if other_txn.absoulte_index != other_txn_abs:
+#                         # raise TealerException("Invalid group configuration")
+#         for offset in txn.relative_indexes:
+#             other_txn = txn.relative_indexes[offset]
+#             this_txn_offset = -1 * offset
+#             if this_txn_offset not in other_txn.relative_indexes:
+#                 other_txn.relative_indexes[this_txn_offset] = txn

--- a/tealer/teal/instructions/parse_transaction_field.py
+++ b/tealer/teal/instructions/parse_transaction_field.py
@@ -17,10 +17,10 @@ Attributes:
     ARRAY_TX_FIELD_TXT_TO_OBJECT: Map(dict) from string representation
         of array transaction field to the corresponding class.
 """
-
+from typing import Dict, Type
 from tealer.teal.instructions import transaction_field
 
-TX_FIELD_TXT_TO_OBJECT = {
+TX_FIELD_TXT_TO_OBJECT: Dict[str, Type[transaction_field.TransactionField]] = {
     "Sender": transaction_field.Sender,
     "Fee": transaction_field.Fee,
     "FirstValid": transaction_field.FirstValid,

--- a/tealer/utils/command_line/common.py
+++ b/tealer/utils/command_line/common.py
@@ -74,7 +74,11 @@ from tealer.utils.teal_enums import ContractType, contract_type_from_txt
 from tealer.tealer import Tealer
 
 # from tealer.utils.output import subroutine_to_dot
-from tealer.execution_context.transactions import Transaction, GroupTransaction
+from tealer.execution_context.transactions import (
+    Transaction,
+    GroupTransaction,
+    fill_group_relative_indexes,
+)
 
 if TYPE_CHECKING:
     from tealer.teal.functions import Function
@@ -322,8 +326,13 @@ def init_tealer_from_config(config: "GroupConfig") -> "Tealer":
                     txn_obj.relative_indexes[offset] = txn_id_to_obj[other_txn_id]
 
             if txn_obj.absoulte_index is not None:
+                if txn_obj.absoulte_index in group_obj.absolute_indexes:
+                    raise TealerException(
+                        f"Two transactions have same absolute index {txn_obj.transacton_id}, {group_obj.absolute_indexes[txn_obj.absoulte_index].transacton_id}"
+                    )
                 group_obj.absolute_indexes[txn_obj.absoulte_index] = txn_obj
 
+        fill_group_relative_indexes(group_obj)
         group_objs_list.append(group_obj)
 
     return Tealer(contracts, group_objs_list, output_group=True)

--- a/tests/group_transactions/basic/config.yaml
+++ b/tests/group_transactions/basic/config.yaml
@@ -17,8 +17,8 @@ contracts:
         dispatch_path: ["B0", "B1", "B2", "B3", "B71"]
       - name: app1_case_5
         dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B70"]
-      # - name: app1_case_6
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B69"]
+      - name: app1_case_6
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B69"]
       # - name: app1_case_7
       #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B68"]
       # - name: app1_case_8
@@ -93,8 +93,8 @@ contracts:
         dispatch_path: ["B0", "B1", "B57"]
       - name: lsig1_case_5
         dispatch_path: ["B0", "B1", "B2", "B56"]
-  #     - name: lsig1_case_6
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B55"]
+      - name: lsig1_case_6
+        dispatch_path: ["B0", "B1", "B2", "B3", "B55"]
   #     - name: lsig1_case_7
   #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B54"]
   #     - name: lsig1_case_8
@@ -257,16 +257,16 @@ groups:
         logic_sig:
           contract: LogicSig_1
           function: lsig1_case_5
-  # - operation: case_6
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_6
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_6
+  - operation: case_6
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_6
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_6
   # - operation: case_7
   #   transactions:
   #     - txn_id: T1

--- a/tests/group_transactions/basic/config.yaml
+++ b/tests/group_transactions/basic/config.yaml
@@ -19,64 +19,64 @@ contracts:
         dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B70"]
       - name: app1_case_6
         dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B69"]
-      # - name: app1_case_7
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B68"]
-      # - name: app1_case_8
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B67"]
-      # - name: app1_case_9
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B66"]
-      # - name: app1_case_10
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B65"]
-      # - name: app1_case_11
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B64"]
-      # - name: app1_case_12
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B63"]
-      # - name: app1_case_13
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B62"]
-      # - name: app1_case_14
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B61"]
-      # - name: app1_case_15
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B60"]
-      # - name: app1_case_16
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B59"]
-      # - name: app1_case_17
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B58"]
-      # - name: app1_case_18
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B57"]
-      # - name: app1_case_19
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B56"]
-      # - name: app1_case_20
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B55"]
-      # - name: app1_case_21
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B54"]
-      # - name: app1_case_22
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B53"]
-      # - name: app1_case_23
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B52"]
-      # - name: app1_case_24
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B51"]
-      # - name: app1_case_25
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B50"]
-      # - name: app1_case_26
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B49"]
-      # - name: app1_case_27
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B48"]
-      # - name: app1_case_28
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B47"]
-      # - name: app1_case_29
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B46"]
-      # - name: app1_case_30
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B45"]
-      # - name: app1_case_31
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B44"]
-      # - name: app1_case_32
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B43"]
-      # - name: app1_case_33
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B42"]
-      # - name: app1_case_34
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B41"]
-      # - name: app1_case_35
-      #   dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B34", "B40"]
+      - name: app1_case_7
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B68"]
+      - name: app1_case_8
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B67"]
+      - name: app1_case_9
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B66"]
+      - name: app1_case_10
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B65"]
+      - name: app1_case_11
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B64"]
+      - name: app1_case_12
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B63"]
+      - name: app1_case_13
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B62"]
+      - name: app1_case_14
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B61"]
+      - name: app1_case_15
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B60"]
+      - name: app1_case_16
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B59"]
+      - name: app1_case_17
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B58"]
+      - name: app1_case_18
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B57"]
+      - name: app1_case_19
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B56"]
+      - name: app1_case_20
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B55"]
+      - name: app1_case_21
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B54"]
+      - name: app1_case_22
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B53"]
+      - name: app1_case_23
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B52"]
+      - name: app1_case_24
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B51"]
+      - name: app1_case_25
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B50"]
+      - name: app1_case_26
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B49"]
+      - name: app1_case_27
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B48"]
+      - name: app1_case_28
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B47"]
+      - name: app1_case_29
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B46"]
+      - name: app1_case_30
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B45"]
+      - name: app1_case_31
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B44"]
+      - name: app1_case_32
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B43"]
+      - name: app1_case_33
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B42"]
+      - name: app1_case_34
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B41"]
+      - name: app1_case_35
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B34", "B40"]
       - name: app1_case_36
         dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B29", "B30", "B31", "B32", "B33", "B34", "B35", "B39"]
       - name: app1_case_37
@@ -95,120 +95,120 @@ contracts:
         dispatch_path: ["B0", "B1", "B2", "B56"]
       - name: lsig1_case_6
         dispatch_path: ["B0", "B1", "B2", "B3", "B55"]
-  #     - name: lsig1_case_7
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B54"]
-  #     - name: lsig1_case_8
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B53"]
-  #     - name: lsig1_case_9
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B52"]
-  #     - name: lsig1_case_10
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B51"]
-  #     - name: lsig1_case_14
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B50"]
-  #     - name: lsig1_case_15
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B49"]
-  #     - name: lsig1_case_16
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B48"]
-  #     - name: lsig1_case_17
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B47"]
-  #     - name: lsig1_case_18
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B46"]
-  #     - name: lsig1_case_19
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B45"]
-  #     - name: lsig1_case_20
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B44"]
-  #     - name: lsig1_case_21
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B43"]
-  #     - name: lsig1_case_22
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B42"]
-  #     - name: lsig1_case_26
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B41"]
-  #     - name: lsig1_case_27
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B40"]
-  #     - name: lsig1_case_28
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B39"]
-  #     - name: lsig1_case_29
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B38"]
-  #     - name: lsig1_case_30
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B37"]
-  #     - name: lsig1_case_31
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B36"]
-  #     - name: lsig1_case_32
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B35"]
-  #     - name: lsig1_case_33
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B34"]
-  #     - name: lsig1_case_34
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B33"]
-  #     - name: lsig1_case_35
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B32"]
+      - name: lsig1_case_7
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B54"]
+      - name: lsig1_case_8
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B53"]
+      - name: lsig1_case_9
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B52"]
+      - name: lsig1_case_10
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B51"]
+      - name: lsig1_case_14
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B50"]
+      - name: lsig1_case_15
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B49"]
+      - name: lsig1_case_16
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B48"]
+      - name: lsig1_case_17
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B47"]
+      - name: lsig1_case_18
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B46"]
+      - name: lsig1_case_19
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B45"]
+      - name: lsig1_case_20
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B44"]
+      - name: lsig1_case_21
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B43"]
+      - name: lsig1_case_22
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B42"]
+      - name: lsig1_case_26
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B41"]
+      - name: lsig1_case_27
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B40"]
+      - name: lsig1_case_28
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B39"]
+      - name: lsig1_case_29
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B38"]
+      - name: lsig1_case_30
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B37"]
+      - name: lsig1_case_31
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B36"]
+      - name: lsig1_case_32
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B35"]
+      - name: lsig1_case_33
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B34"]
+      - name: lsig1_case_34
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B33"]
+      - name: lsig1_case_35
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B32"]
       - name: lsig1_case_36
         dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B31"]
       - name: lsig1_case_37
         dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B30"]
-  # - name: LogicSig_2
-  #   file_path: logicsig_2.teal
-  #   type: LogicSig
-  #   version: 7
-  #   subroutines: []
-  #   functions:
-  #     - name: lsig2_case_7
-  #       dispatch_path: ["B0", "B58"]
-  #     - name: lsig2_case_8
-  #       dispatch_path: ["B0", "B1", "B57"]
-  #     - name: lsig2_case_9
-  #       dispatch_path: ["B0", "B1", "B2", "B56"]
-  #     - name: lsig2_case_10
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B55"]
-  #     - name: lsig2_case_11
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B54"]
-  #     - name: lsig2_case_12
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B53"]
-  #     - name: lsig2_case_13
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B52"]
-  #     - name: lsig2_case_14
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B51"]
-  #     - name: lsig2_case_15
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B50"]
-  #     - name: lsig2_case_16
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B49"]
-  #     - name: lsig2_case_17
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B48"]
-  #     - name: lsig2_case_18
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B47"]
-  #     - name: lsig2_case_19
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B46"]
-  #     - name: lsig2_case_20
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B45"]
-  #     - name: lsig2_case_21
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B44"]
-  #     - name: lsig2_case_22
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B43"]
-  #     - name: lsig2_case_23
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B42"]
-  #     - name: lsig2_case_24
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B41"]
-  #     - name: lsig2_case_25
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B40"]
-  #     - name: lsig2_case_26
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B39"]
-  #     - name: lsig2_case_27
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B38"]
-  #     - name: lsig2_case_28
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B37"]
-  #     - name: lsig2_case_29
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B36"]
-  #     - name: lsig2_case_30
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B35"]
-  #     - name: lsig2_case_31
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B34"]
-  #     - name: lsig2_case_32
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B33"]
-  #     - name: lsig2_case_33
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B32"]
-  #     - name: lsig2_case_34
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B31"]
-  #     - name: lsig2_case_35
-  #       dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B30"]
+  - name: LogicSig_2
+    file_path: logicsig_2.teal
+    type: LogicSig
+    version: 7
+    subroutines: []
+    functions:
+      - name: lsig2_case_7
+        dispatch_path: ["B0", "B58"]
+      - name: lsig2_case_8
+        dispatch_path: ["B0", "B1", "B57"]
+      - name: lsig2_case_9
+        dispatch_path: ["B0", "B1", "B2", "B56"]
+      - name: lsig2_case_10
+        dispatch_path: ["B0", "B1", "B2", "B3", "B55"]
+      - name: lsig2_case_11
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B54"]
+      - name: lsig2_case_12
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B53"]
+      - name: lsig2_case_13
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B52"]
+      - name: lsig2_case_14
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B51"]
+      - name: lsig2_case_15
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B50"]
+      - name: lsig2_case_16
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B49"]
+      - name: lsig2_case_17
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B48"]
+      - name: lsig2_case_18
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B47"]
+      - name: lsig2_case_19
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B46"]
+      - name: lsig2_case_20
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B45"]
+      - name: lsig2_case_21
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B44"]
+      - name: lsig2_case_22
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B43"]
+      - name: lsig2_case_23
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B42"]
+      - name: lsig2_case_24
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B41"]
+      - name: lsig2_case_25
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B40"]
+      - name: lsig2_case_26
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B39"]
+      - name: lsig2_case_27
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B38"]
+      - name: lsig2_case_28
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B37"]
+      - name: lsig2_case_29
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B36"]
+      - name: lsig2_case_30
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B35"]
+      - name: lsig2_case_31
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B34"]
+      - name: lsig2_case_32
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B33"]
+      - name: lsig2_case_33
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B32"]
+      - name: lsig2_case_34
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B31"]
+      - name: lsig2_case_35
+        dispatch_path: ["B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10", "B11", "B12", "B13", "B14", "B15", "B16", "B17", "B18", "B19", "B20", "B21", "B22", "B23", "B24", "B25", "B26", "B27", "B28", "B30"]
 # group configurations
 groups:
   - operation: case_1
@@ -267,536 +267,551 @@ groups:
         logic_sig:
           contract: LogicSig_1
           function: lsig1_case_6
-  # - operation: case_7
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_7
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_7
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_7
-  #       absolute_index: 1
-  # - operation: case_8
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_8
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_8
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_8
-  #       absolute_index: 1
+  - operation: case_7
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_7
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_7
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_7
+        absolute_index: 1
+  - operation: case_8
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_8
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_8
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_8
+        absolute_index: 1
 
-  # - operation: case_9
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_9
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_9
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_9
-  #       absolute_index: 1
+  - operation: case_9
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_9
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_9
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_9
+        absolute_index: 1
       
-  # - operation: case_10
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_10
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_10
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_10
-  #       absolute_index: 1      
+  - operation: case_10
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_10
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_10
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_10
+        absolute_index: 1      
 
-  # - operation: case_11
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_11
-  #       has_logic_sig: true
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_11
-  #       absolute_index: 1      
+  - operation: case_11
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_11
+        has_logic_sig: true
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_11
+        absolute_index: 1      
 
-  # - operation: case_12
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_12
-  #       has_logic_sig: true
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_12
-  #       absolute_index: 1      
+  - operation: case_12
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_12
+        has_logic_sig: true
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_12
+        absolute_index: 1      
 
-  # - operation: case_13
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_13
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_13
-  #       absolute_index: 1      
+  - operation: case_13
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_13
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_13
+        absolute_index: 1      
 
-  # - operation: case_14
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_14
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_14
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_14
-  #       absolute_index: 1
+  - operation: case_14
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_14
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_14
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_14
+        absolute_index: 1
 
-  # - operation: case_15
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_15
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_15
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_15
-  #       absolute_index: 1
+  - operation: case_15
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_15
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_15
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_15
+        absolute_index: 1
 
-  # - operation: case_16
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_16
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_16
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_16
-  #       absolute_index: 1
+  - operation: case_16
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_16
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_16
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_16
+        absolute_index: 1
 
-  # - operation: case_17
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_17
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_17
-  #       absolute_index: 0
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_17
-  #       absolute_index: 1
+  - operation: case_17
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_17
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_17
+        absolute_index: 0
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_17
+        absolute_index: 1
 
-  # - operation: case_18
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_18
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_18
-  #       absolute_index: 0
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 4
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_18
+  - operation: case_18
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_18
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_18
+        absolute_index: 0
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 4
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_18
 
-  # - operation: case_19
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_19
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_19
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_19
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: -4
+  - operation: case_19
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_19
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_19
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 4
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_19
+        # The user should not be required to give this offset.
+        # TODO: Tealer should compute maximum information about the indexes
+        # from the limited information given by the user.
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -4
 
-  # - operation: case_20
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_20
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_20
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_20
-  #       absolute_index: 1
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: 5
+  - operation: case_20
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_20
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_20
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_20
+        absolute_index: 1
+        relative_indexes:
+          - other_txn_id: T1
+            offset: 5
         
-  # - operation: case_21
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_21
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_21
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 2
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_21
+  - operation: case_21
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_21
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_21
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 2
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_21
 
-  # - operation: case_22
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_22
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_22
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_22
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: -1
+  - operation: case_22
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_22
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_22
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_22
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -1
 
-  # - operation: case_23
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_23
-  #       has_logic_sig: true
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_23
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: -1
+  - operation: case_23
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_23
+        has_logic_sig: true
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_23
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -1
 
-  # - operation: case_24
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_24
-  #       has_logic_sig: true
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_24
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: -1
+  - operation: case_24
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_24
+        has_logic_sig: true
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_24
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -1
 
-  # - operation: case_25
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_25
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_25
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: -1
+  - operation: case_25
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_25
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_25
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -1
 
-  # - operation: case_26
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_26
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_26
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: -1
+  - operation: case_26
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_26
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_26
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_26
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -1
 
-  # - operation: case_27
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_27
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_27
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 1
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_27
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: -1
+  - operation: case_27
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_27
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_27
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 1
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_27
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -1
 
-  # - operation: case_28
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_28
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_28
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 5
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_28
+  - operation: case_28
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_28
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_28
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 5
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_28
 
-  # - operation: case_29
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_29
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_29
-  #       absolute_index: 0
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 3
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_29
+  - operation: case_29
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_29
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_29
+        absolute_index: 0
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 3
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_29
 
-  # - operation: case_30
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_30
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_30
-  #       absolute_index: 0
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 4
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_30
+  - operation: case_30
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_30
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_30
+        absolute_index: 0
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 4
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_30
 
-  # - operation: case_31
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_31
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_31
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 4
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_31
+  - operation: case_31
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_31
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_31
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 4
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_31
+        # The user should not be required to give this offset.
+        # TODO: Tealer should compute maximum information about the indexes
+        # from the limited information given by the user.
+        relative_indexes:
+          - other_txn_id: T1
+            offset: -4
 
-  # - operation: case_32
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_32
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_32
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 5
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_32
+  - operation: case_32
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_32
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_32
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 5
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_32
 
-  # - operation: case_33
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_33
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_33
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_33
-  #       absolute_index: 1
-  #       relative_indexes:
-  #         - other_txn_id: T1
-  #           offset: 5
+  - operation: case_33
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_33
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_33
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_33
+        absolute_index: 1
+        relative_indexes:
+          - other_txn_id: T1
+            offset: 5
 
-  # - operation: case_34
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_34
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_34
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 2
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_34
+  - operation: case_34
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_34
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_34
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 2
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_34
 
-  # - operation: case_35
-  #   transactions:
-  #     - txn_id: T1
-  #       txn_type: appl
-  #       application:
-  #         contract: App_1
-  #         function: app1_case_35
-  #       logic_sig:
-  #         contract: LogicSig_1
-  #         function: lsig1_case_35
-  #       absolute_index: 0
-  #       relative_indexes:
-  #         - other_txn_id: T2
-  #           offset: 3
-  #     - txn_id: T2
-  #       txn_type: pay
-  #       logic_sig:
-  #         contract: LogicSig_2
-  #         function: lsig2_case_35
+  - operation: case_35
+    transactions:
+      - txn_id: T1
+        txn_type: appl
+        application:
+          contract: App_1
+          function: app1_case_35
+        logic_sig:
+          contract: LogicSig_1
+          function: lsig1_case_35
+        absolute_index: 0
+        relative_indexes:
+          - other_txn_id: T2
+            offset: 3
+      - txn_id: T2
+        txn_type: pay
+        logic_sig:
+          contract: LogicSig_2
+          function: lsig2_case_35
 
   - operation: case_36
     transactions:

--- a/tests/group_transactions/basic/expected_output.yaml
+++ b/tests/group_transactions/basic/expected_output.yaml
@@ -9,92 +9,89 @@ operations:
   - operation: case_3
     vulnerable_transactions:
       - txn_id: T1
-  # - operation: case_9
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_9
-  # - operation: case_12
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  # - operation: case_13
-  #   vulnerable_transactions:
-  #     - txn_id: T2
-  #       contracts:
-  #         - contract: LogicSig_2
-  #           function: lsig2_case_13
-  # - operation: case_14
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_14  
-  #     - txn_id: T2
-  #       contracts:
-  #         - contract: LogicSig_2
-  #           function: lsig2_case_14
-  # - operation: case_17
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_17
-  # - operation: case_21
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_21
-  # - operation: case_24
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_21
-  # - operation: case_25
-  #   vulnerable_transactions:
-  #     - txn_id: T2
-  #       contracts:
-  #         - contract: LogicSig_2
-  #           function: lsig2_case_25
-  # - operation: case_26
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_26
-  #     - txn_id: T2
-  #       contracts:
-  #         - contract: LogicSig_2
-  #           function: lsig2_case_26
-  # - operation: case_28
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_28
-  # - operation: case_29
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_29
-  # - operation: case_32
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_32
-  # - operation: case_34
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_34
-  # - operation: case_35
-  #   vulnerable_transactions:
-  #     - txn_id: T1
-  #       contracts:
-  #         - contract: LogicSig_1
-  #           function: lsig1_case_35
+  - operation: case_9
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_9
+  - operation: case_12
+    vulnerable_transactions:
+      - txn_id: T1
+  - operation: case_13
+    vulnerable_transactions:
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_13
+  - operation: case_14
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_14  
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_14
+  - operation: case_17
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_17
+  - operation: case_21
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_21
+  - operation: case_24
+    vulnerable_transactions:
+      - txn_id: T1
+  - operation: case_25
+    vulnerable_transactions:
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_25
+  - operation: case_26
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_26
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_26
+  - operation: case_28
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_28
+  - operation: case_29
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_29
+  - operation: case_32
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_32
+  - operation: case_34
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_34
+  - operation: case_35
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: LogicSig_1
+            function: lsig1_case_35

--- a/tests/group_transactions/test_group_support.py
+++ b/tests/group_transactions/test_group_support.py
@@ -36,14 +36,15 @@ def test_instructions_output_detectors(test: Tuple[Path, Type[AbstractDetector],
     for i in output:
         assert isinstance(i, GroupTransactionOutput)
         reported_output.append(i)
+        i.generate_output(Path("."))
 
     # expected output is also sorted by operation name
     reported_output = sorted(reported_output, key=lambda x: x.group_transaction.operation_name)
-
+    expected_output_operations = sorted(expected_output.operations, key=lambda x: x.operation)
     # same number of groups/operations are reported as vulnerable
-    assert len(reported_output) == len(expected_output.operations)
+    assert len(reported_output) == len(expected_output_operations)
 
-    for expected_operation, reported_operation in zip(expected_output.operations, reported_output):
+    for expected_operation, reported_operation in zip(expected_output_operations, reported_output):
         # reported same operation
         assert expected_operation.operation == reported_operation.group_transaction.operation_name
         # reported same transactions


### PR DESCRIPTION
The first commit adds helper functions to retrieve the index and field a transaction access instruction pushes on to the stack.
The indexes are divided into three categories:
1. Self - Txn.field()
2. Absolute - Gtxn[Int(x)].field()
3. Relative - Gtxn[Txn.group_index() -/+ offset].field()

Given an instruction, the helper function returns the index of the transaction this instruction is accessing and the field it accesses.

The second commit updates the transaction field analysis to track the values of the transaction at an absolute index and at a relative index from the contract. The detectors use this information to consider the validations performed by other transactions in the group. The detectors would not report if an application in the group validates the rekeyto of the logic-sig in a different transaction.

The `tests/group_transactions/basic/logicsig_1.py` lists different patterns to access the fields. The detectors now identify all such patterns.