### PR TITLE
Update all stateless detectors to work on the group configuration

### DIFF
--- a/tealer/detectors/can_close_account.py
+++ b/tealer/detectors/can_close_account.py
@@ -7,9 +7,13 @@ from tealer.detectors.abstract_detector import (
     DetectorClassification,
     DetectorType,
 )
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 from tealer.utils.output import ExecutionPaths
+from tealer.utils.teal_enums import TransactionType
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
@@ -91,6 +95,19 @@ Validate `CloseRemainderTo` field in the LogicSig.
             return not (
                 block_ctx.closeto.any_addr
                 and TealerTransactionType.Pay in block_ctx.transaction_types
+            )
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(
+                    self.tealer,
+                    self,
+                    checks_field,
+                    [TransactionType.Any, TransactionType.Unknown, TransactionType.Pay],
+                )
             )
 
         output: List[

--- a/tealer/detectors/can_close_asset.py
+++ b/tealer/detectors/can_close_asset.py
@@ -7,9 +7,13 @@ from tealer.detectors.abstract_detector import (
     DetectorClassification,
     DetectorType,
 )
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 from tealer.utils.output import ExecutionPaths
+from tealer.utils.teal_enums import TransactionType
 
 if TYPE_CHECKING:
     from tealer.teal.basic_blocks import BasicBlock
@@ -91,6 +95,19 @@ Validate `AssetCloseTo` field in the LogicSig.
             return not (
                 block_ctx.assetcloseto.any_addr
                 and TealerTransactionType.Axfer in block_ctx.transaction_types
+            )
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(
+                    self.tealer,
+                    self,
+                    checks_field,
+                    [TransactionType.Any, TransactionType.Unknown, TransactionType.Axfer],
+                )
             )
 
         output: List[

--- a/tealer/detectors/fee_check.py
+++ b/tealer/detectors/fee_check.py
@@ -7,7 +7,10 @@ from tealer.detectors.abstract_detector import (
     DetectorClassification,
     DetectorType,
 )
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.algorand_constants import MAX_TRANSACTION_COST
 from tealer.utils.output import ExecutionPaths
 
@@ -89,6 +92,14 @@ Validate `Fee` field in the LogicSig.
             # returns True if fee is bounded by some unknown value
             # or is bounded by some known value less than maximum transaction cost.
             return block_ctx.max_fee_unknown or block_ctx.max_fee <= MAX_TRANSACTION_COST
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(self.tealer, self, checks_field)
+            )
 
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]

--- a/tealer/utils/command_line/common.py
+++ b/tealer/utils/command_line/common.py
@@ -79,6 +79,8 @@ from tealer.execution_context.transactions import (
     GroupTransaction,
     fill_group_relative_indexes,
 )
+from tealer.utils.command_line.group_config import USER_CONFIG_TRANSACTION_TYPES
+
 
 if TYPE_CHECKING:
     from tealer.teal.functions import Function
@@ -284,6 +286,7 @@ def init_tealer_from_config(config: "GroupConfig") -> "Tealer":
         for txn in txn_config.transactions:
             txn_obj = Transaction()
             txn_obj.transacton_id = txn.txn_id
+            txn_obj.type = USER_CONFIG_TRANSACTION_TYPES[txn.txn_type]
             if txn.has_logic_sig is not None:
                 txn_obj.has_logic_sig = txn.has_logic_sig
             txn_obj.absoulte_index = txn.absolute_index

--- a/tealer/utils/command_line/group_config.py
+++ b/tealer/utils/command_line/group_config.py
@@ -2,8 +2,9 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Dict, Any, Optional
-
 import yaml
+
+from tealer.utils.teal_enums import TransactionType
 
 
 GROUP_CONFIG_CONTRACT_TYPES = [
@@ -12,7 +13,15 @@ GROUP_CONFIG_CONTRACT_TYPES = [
     "ClearStateProgram",
 ]
 
-USER_CONFIG_TRANSACTION_TYPES = ["pay", "keyreg", "acfg", "axfer", "afrz", "appl", "txn"]
+USER_CONFIG_TRANSACTION_TYPES = {
+    "pay": TransactionType.Pay,
+    "keyreg": TransactionType.KeyReg,
+    "acfg": TransactionType.Acfg,
+    "axfer": TransactionType.Axfer,
+    "afrz": TransactionType.Afrz,
+    "appl": TransactionType.Appl,
+    "txn": TransactionType.Any,
+}
 
 
 class InvalidGroupConfiguration(Exception):
@@ -160,6 +169,10 @@ class GroupConfigTransaction:
 
         txn_id = transaction["txn_id"]
         txn_type = transaction["txn_type"]
+        if txn_type not in USER_CONFIG_TRANSACTION_TYPES:
+            raise InvalidGroupConfiguration(
+                f"Transaction: Unknown transaction type {txn_type} of transaction {txn_id}"
+            )
         application = transaction.get("application")
         has_logic_sig = transaction.get("has_logic_sig")
         logic_sig = transaction.get("logic_sig")

--- a/tests/group_transactions/basic/app_1.py
+++ b/tests/group_transactions/basic/app_1.py
@@ -21,12 +21,34 @@ def app1_case_4() -> Expr:
 
 
 def app1_case_5() -> Expr:
-    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.rekey_to() == Global.zero_address(),
+                    Txn.fee() < Int(10000),
+                    Txn.close_remainder_to() == Global.zero_address(),
+                    Txn.asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def app1_case_6() -> Expr:
     return Seq(
-        [Assert(Gtxn[Txn.group_index()].rekey_to() == Global.zero_address()), Return(Int(1))]
+        [
+            Assert(
+                And(
+                    Gtxn[Txn.group_index()].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index()].fee() < Int(10000),
+                    Gtxn[Txn.group_index()].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index()].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
     )
 
 
@@ -37,6 +59,12 @@ def app1_case_7() -> Expr:
                 And(
                     Gtxn[0].rekey_to() == Global.zero_address(),
                     Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[Int(0)].fee() < Int(100000),
+                    Gtxn[1].fee() < Int(1000),
+                    Gtxn[Int(0)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[1].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Int(0)].asset_close_to() == Global.zero_address(),
+                    Gtxn[1].asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -45,11 +73,35 @@ def app1_case_7() -> Expr:
 
 
 def app1_case_8() -> Expr:
-    return Seq([Assert(Gtxn[0].rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[0].rekey_to() == Global.zero_address(),
+                    Gtxn[0].fee() < Int(10000),
+                    Gtxn[0].close_remainder_to() == Global.zero_address(),
+                    Gtxn[0].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def app1_case_9() -> Expr:
-    return Seq([Assert(Gtxn[1].rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[1].fee() < Int(10000),
+                    Gtxn[1].close_remainder_to() == Global.zero_address(),
+                    Gtxn[1].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def app1_case_10() -> Expr:
@@ -91,6 +143,12 @@ def app1_case_18() -> Expr:
                 And(
                     Gtxn[0].rekey_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(4)].rekey_to() == Global.zero_address(),
+                    Gtxn[0].fee() < Int(10000),
+                    Gtxn[Txn.group_index() + Int(4)].fee() < Int(10000),
+                    Gtxn[0].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(4)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[0].asset_close_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(4)].asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -102,6 +160,9 @@ def app1_case_19() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() + Int(4)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(4)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() + Int(4)].asset_close_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(4)].close_remainder_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -111,6 +172,9 @@ def app1_case_20() -> Expr:
     return Seq(
         [
             Assert(Gtxn[1].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[1].fee() < Int(10000)),
+            Assert(Gtxn[1].asset_close_to() == Global.zero_address()),
+            Assert(Gtxn[1].close_remainder_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -120,6 +184,9 @@ def app1_case_21() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() + Int(2)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(2)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() + Int(2)].asset_close_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(2)].close_remainder_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -153,6 +220,9 @@ def app1_case_28() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -163,7 +233,19 @@ def app1_case_29() -> Expr:
 
 
 def app1_case_30() -> Expr:
-    return Seq([Assert(Gtxn[0].rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[0].rekey_to() == Global.zero_address(),
+                    Gtxn[0].fee() < Int(10000),
+                    Gtxn[0].close_remainder_to() == Global.zero_address(),
+                    Gtxn[0].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def app1_case_31() -> Expr:
@@ -187,7 +269,19 @@ def app1_case_35() -> Expr:
 
 
 def app1_case_36() -> Expr:
-    return Seq([Assert(Gtxn[4].rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[4].rekey_to() == Global.zero_address(),
+                    Gtxn[4].fee() < Int(10000),
+                    Gtxn[4].close_remainder_to() == Global.zero_address(),
+                    Gtxn[4].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def app1_case_37() -> Expr:

--- a/tests/group_transactions/basic/app_1.teal
+++ b/tests/group_transactions/basic/app_1.teal
@@ -233,6 +233,18 @@ main_l39:
 gtxn 4 RekeyTo
 global ZeroAddress
 ==
+gtxn 4 Fee
+int 10000
+<
+&&
+gtxn 4 CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 4 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -255,6 +267,18 @@ main_l45:
 gtxn 0 RekeyTo
 global ZeroAddress
 ==
+gtxn 0 Fee
+int 10000
+<
+&&
+gtxn 0 CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 0 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -266,6 +290,27 @@ txn GroupIndex
 int 5
 +
 gtxns RekeyTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 5
++
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 5
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 5
++
+gtxns CloseRemainderTo
 global ZeroAddress
 ==
 assert
@@ -297,10 +342,43 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 2
++
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 2
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 2
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
 int 1
 return
 main_l55:
 gtxn 1 RekeyTo
+global ZeroAddress
+==
+assert
+gtxn 1 Fee
+int 10000
+<
+assert
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+assert
+gtxn 1 CloseRemainderTo
 global ZeroAddress
 ==
 assert
@@ -314,6 +392,27 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 4
++
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 4
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 4
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
 int 1
 return
 main_l57:
@@ -324,6 +423,39 @@ txn GroupIndex
 int 4
 +
 gtxns RekeyTo
+global ZeroAddress
+==
+&&
+gtxn 0 Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 4
++
+gtxns Fee
+int 10000
+<
+&&
+gtxn 0 CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 4
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 0 AssetCloseTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 4
++
+gtxns AssetCloseTo
 global ZeroAddress
 ==
 &&
@@ -358,6 +490,18 @@ main_l66:
 gtxn 1 RekeyTo
 global ZeroAddress
 ==
+gtxn 1 Fee
+int 10000
+<
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -365,6 +509,18 @@ main_l67:
 gtxn 0 RekeyTo
 global ZeroAddress
 ==
+gtxn 0 Fee
+int 10000
+<
+&&
+gtxn 0 CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 0 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -376,6 +532,33 @@ gtxn 1 RekeyTo
 global ZeroAddress
 ==
 &&
+int 0
+gtxns Fee
+int 100000
+<
+&&
+gtxn 1 Fee
+int 1000
+<
+&&
+int 0
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+int 0
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -384,6 +567,21 @@ txn GroupIndex
 gtxns RekeyTo
 global ZeroAddress
 ==
+txn GroupIndex
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -391,6 +589,18 @@ main_l70:
 txn RekeyTo
 global ZeroAddress
 ==
+txn Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return

--- a/tests/group_transactions/basic/config.yaml
+++ b/tests/group_transactions/basic/config.yaml
@@ -296,7 +296,7 @@ groups:
           function: lsig1_case_8
         absolute_index: 0
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_8
@@ -364,7 +364,7 @@ groups:
         has_logic_sig: true
         absolute_index: 0
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_12
@@ -397,7 +397,7 @@ groups:
           function: lsig1_case_14
         absolute_index: 0
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_14
@@ -415,7 +415,7 @@ groups:
           function: lsig1_case_15
         absolute_index: 0
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_15
@@ -433,7 +433,7 @@ groups:
           function: lsig1_case_16
         absolute_index: 0
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_16
@@ -472,7 +472,7 @@ groups:
           - other_txn_id: T2
             offset: 4
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_18
@@ -552,7 +552,7 @@ groups:
           contract: LogicSig_1
           function: lsig1_case_22
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_22
@@ -602,7 +602,7 @@ groups:
           contract: App_1
           function: app1_case_25
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_25
@@ -665,7 +665,7 @@ groups:
           - other_txn_id: T2
             offset: 5
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_28
@@ -724,7 +724,7 @@ groups:
           - other_txn_id: T2
             offset: 4
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_31
@@ -749,7 +749,7 @@ groups:
           - other_txn_id: T2
             offset: 5
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_32
@@ -808,7 +808,7 @@ groups:
           - other_txn_id: T2
             offset: 3
       - txn_id: T2
-        txn_type: pay
+        txn_type: axfer
         logic_sig:
           contract: LogicSig_2
           function: lsig2_case_35

--- a/tests/group_transactions/basic/expected_output_asset_close_to.yaml
+++ b/tests/group_transactions/basic/expected_output_asset_close_to.yaml
@@ -1,0 +1,15 @@
+name: BasicRekeyTo
+operations:
+  - operation: case_14
+    vulnerable_transactions:
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_14
+  - operation: case_25
+    vulnerable_transactions:
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_25
+  

--- a/tests/group_transactions/basic/expected_output_close_to.yaml
+++ b/tests/group_transactions/basic/expected_output_close_to.yaml
@@ -1,0 +1,15 @@
+name: BasicRekeyTo
+operations:
+  - operation: case_13
+    vulnerable_transactions:
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_13
+  - operation: case_26
+    vulnerable_transactions:
+      - txn_id: T2
+        contracts:
+          - contract: LogicSig_2
+            function: lsig2_case_26
+  

--- a/tests/group_transactions/basic/logicsig_1.py
+++ b/tests/group_transactions/basic/logicsig_1.py
@@ -9,6 +9,9 @@ case 1:
 
 Expected:
     - The detector should not report it as vulnerable.
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not < Int(10000)t Vulnerable - AssetCloseTo
 
 
 case 2:
@@ -17,7 +20,10 @@ case 2:
 
 Expected:
     - The detector should report it as vulnerable
-
+    Vulnerable - RekeyTo
+    Vulnerable - Fee
+    Nor Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 3:
     - Single transaction.
@@ -27,7 +33,10 @@ case 3:
 Expected:
     The detector should report the operation as vulnerable. Even if the detector does not the logic sig being executed, the operation should be considered
     vulnerable because a logic sig will be vulnerable to Rekeying.
-
+    Vulnerable - RekeyTo
+    Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 4:
     - Single transaction.
@@ -36,7 +45,10 @@ case 4:
 
 Expected:
     The detector should report the operation as NOT VULNERABLE. Applications are not vulnerable to rekeying.
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 5:
     - Single transaction
@@ -44,7 +56,11 @@ case 5:
     - LogicSig checks that application is called
 
 Expected:
-    NOT VULNERABLE.
+    NOT VULNERABLE - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
+
 
 
 case 6:
@@ -53,8 +69,10 @@ case 6:
     - LogicSig checks the application is called.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 7:
     - Two transactions
@@ -65,20 +83,24 @@ case 7:
         - LogicSig does not check anything.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 8:
     - Two transactions
     - First transaction (appl)(index: 0):
         - Application checks the rekeyto field of 0th transaction using absolute index.
         - LogicSig checks the application id
-    - Second transaction (pay)(index: 1):
+    - Second transaction (axfer)(index: 1):
         - LogicSig checks it's rekeyto field.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 9:
     - Two transactions
@@ -89,9 +111,13 @@ case 9:
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable. - RekeyTo
     The first transaction is vulnerable. The second transaction should not be reported
 
+    Vulnerable - Fee
+    The first transaction is vulnerable. The second transaction should not be reported
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 10:
     - Two transactions
@@ -102,8 +128,10 @@ case 10:
         - LogicSig checks the fields of both transactions using absolute indices.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 11:
     - Two transactions
@@ -114,21 +142,27 @@ case 11:
         - LogicSig checks the fields of both transactions using absolute indices
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 12:
     - Two transactions
     - First transaction (appl)(index: 0):
         - Application does not check anything.
         - has_logic_sig is True.
-    - Second transaction (pay)(index: 1):
+    - Second transaction (axfer)(index: 1):
         - LogicSig checks the fields of its own transaction field.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo
     Only the first transaction is reported as vulnerable.
 
+    Vulnerable - Fee
+    Only the first transaction is reported as vulnerable.
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 13:
     - Two transactions
@@ -138,46 +172,63 @@ case 13:
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo
     Second transaction is reported as vulnerable
 
+    Vulnerable - Fee
+    Second transaction is reported as vulnerable
+
+    Vulnerable - CloseRemainderTo
+    Second transaction is reported as vulnerable
+
+    Not Vulnerable - AssetCloseTo
 
 case 14:
     - Two transactions
     - First transaction (appl)(index: 0):
         - Application does not check anything.
         - LogicSig does not check anything.
-    - Second transaction (pay)(index: 1):
+    - Second transaction (axfer)(index: 1):
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo
     Both First and Second transactions are reported as vulnerable.
 
+    Vulnerable - Fee
+    Both First and Second transactions are reported as vulnerable.
+
+    Not Vulnerable - CloseRemainderTo
+    Vulnerable - AssetCloseTo
+    Second transaction is reported as vulnerable
 
 case 15:
     - Two transactions
     - First transaction (appl)(index: 0):
         - Application does not check anything.
         - LogicSig checks the rekeyto field of 0th transaction and 1st transaction using absolute indices
-    - Second transaction (pay)(index: 1):
+    - Second transaction (axfer)(index: 1):
         - LogicSig does not check anything.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 16:
     - Two transactions
     - First transaction (appl)(index: 0):
         - Application does not check anything.
         - LogicSig checks the rekeyto field of 0th transaction using absolute index.
-    - Second transaction (pay)(index: 1):
+    - Second transaction (axfer)(index: 1):
         - LogicSig checks it's rekeyto field.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 17:
     - Two transactions
@@ -188,21 +239,28 @@ case 17:
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo
     The first transaction is vulnerable. The second transaction should not be reported
 
+    Vulnerable - Fee
+    The first transaction is vulnerable. The second transaction should not be reported
+
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 18:
     - Two transactions
     - First transaction (appl)(index: 0):
         - Application checks the rekeyto field of 0th transaction using absolute index and 1st transaction using relative index(+4).
         - LogicSig checks the application id
-    - Second transaction (pay):
+    - Second transaction (axfer):
         - LogicSig does not check anything.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 19:
     - Two transactions
@@ -213,8 +271,10 @@ case 19:
         - LogicSig checks rekey field of the previous transaction using (-4) relative index.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 20:
     - Two transactions
@@ -225,8 +285,10 @@ case 20:
         - LogicSig checks rekey field of the first transaction using (+5) relative index.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 21:
     - Two transactions
@@ -237,21 +299,28 @@ case 21:
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo
     The first transaction is vulnerable. The second transaction should not be reported
 
+    Vulnerable - Fee
+    The first transaction is vulnerable. The second transaction should not be reported
+
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 22:
     - Two transactions
     - First transaction (appl):
         - Application does not check anything.
         - LogicSig checks the application id
-    - Second transaction (pay):
+    - Second transaction (axfer):
         - LogicSig checks the field of previous transaction using relative index(-1) and its own field directly.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 23:
     - Two transactions
@@ -262,8 +331,10 @@ case 23:
         - LogicSig checks the field of previous transaction using relative index(-1) and its own field directly.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 24:
     - Two transactions
@@ -274,20 +345,32 @@ case 24:
         - LogicSig checks the fields of its own transaction field.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     Only the first transaction is reported as vulnerable.
 
+    Vulnerable - Fee.
+    Only the first transaction is reported as vulnerable.
+
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 25:
     - Two transactions
     - First transaction (appl):
         - Application does not check anything.
-    - Second transaction (pay):
+    - Second transaction (axfer):
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     Second transaction is reported as vulnerable
+
+    Vulnerable - Fee.
+    Second transaction is reported as vulnerable
+
+    Not Vulnerable - CloseRemainderTo
+    Vulnerable - AssetCloseTo
+    Second transaction is reported
 
 
 case 26:
@@ -299,9 +382,16 @@ case 26:
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     Both First and Second transactions are reported as vulnerable.
 
+    Vulnerable - Fee.
+    Both First and Second transactions are reported as vulnerable.
+
+    Vulnerable - CloseRemainderTo
+    Second transaction is reported as vulnerable
+
+    Not Vulnerable - AssetCloseTo
 
 case 27:
     - Two transactions
@@ -312,21 +402,27 @@ case 27:
         - LogicSig does not check anything.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 28:
     - Two transactions
     - First transaction (appl):
         - Application checks the rekeyto field of 1st transaction using relative index(+5).
         - LogicSig checks the application id
-    - Second transaction (pay):
+    - Second transaction (axfer):
         - LogicSig checks rekey field of the previous transaction using (-4) relative index.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     Second transaction uses the wrong index. First contract will be vulnerable.
 
+    Vulnerable - Fee
+    Second transaction uses the wrong index. First contract will be vulnerable.
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 29:
     - Two transactions
@@ -337,9 +433,13 @@ case 29:
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     The first transaction is vulnerable. The second transaction should not be reported
 
+    Vulnerable - Fee.
+    The first transaction is vulnerable. The second transaction should not be reported
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 30:
     - Two transactions
@@ -350,19 +450,24 @@ case 30:
         - LogicSig does not check anything.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 31:
     - Two transactions
     - First transaction (appl):
         - Application does not check anything.
         - LogicSig checks the rekeyto field of 1st transaction using relative index(+4).
-    - Second transaction (pay):
+    - Second transaction (axfer):
         - LogicSig checks rekey field of the previous transaction using (-4) relative index.
 
 Expected:
-    Not Vulnerable
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 
 case 32:
@@ -370,13 +475,17 @@ case 32:
     - First transaction (appl):
         - Application does not check anything.
         - LogicSig checks the rekeyto field of 1st transaction using relative index(+5)
-    - Second transaction (pay):
+    - Second transaction (axfer):
         - LogicSig checks rekey field of the previous transaction using (-4) relative index.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     Second transaction uses the wrong index. First contract will be vulnerable.
 
+    Vulnerable - Fee.
+    Second transaction uses the wrong index. First contract will be vulnerable.
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 33:
     - Two transactions
@@ -387,8 +496,10 @@ case 33:
         - LogicSig checks rekey field of the 0th transaction using (+5) relative index.
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 34:
     - Two transactions
@@ -399,22 +510,30 @@ case 34:
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     The first transaction is vulnerable. The second transaction should not be reported
 
+    Vulnerable - Fee.
+    The first transaction is vulnerable. The second transaction should not be reported
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 35:
     - Two transactions
     - First transaction (appl)(index: 0):
         - Application does not check anything.
         - LogicSig checks the rekeyto field of 1st transaction using relative index(+3).
-    - Second transaction (pay):
+    - Second transaction (axfer):
         - LogicSig does not check anything.
 
 Expected:
-    Vulnerable.
+    Vulnerable - RekeyTo.
     The first transaction is vulnerable. The second transaction should not be reported
 
+    Vulnerable - Fee
+    The first transaction is vulnerable. The second transaction should not be reported
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 36:
     - Single transaction (index: 4).
@@ -423,8 +542,10 @@ case 36:
     - Absolute index is given in the config
 
 Expected:
-    Not Vulnerable
-
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 
 case 37:
     - Single transaction (index: 1)
@@ -433,14 +554,29 @@ case 37:
     - Absolute index is given in the config.
 
 Expected:
-    Not Vulnerable
+    Not Vulnerable - RekeyTo
+    Not Vulnerable - Fee
+    Not Vulnerable - CloseRemainderTo
+    Not Vulnerable - AssetCloseTo
 """
 from pathlib import Path
 from pyteal import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 
 def lsig1_case_1() -> Expr:
-    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.rekey_to() == Global.zero_address(),
+                    Txn.fee() < Int(10000),
+                    Txn.close_remainder_to() == Global.zero_address(),
+                    Txn.asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def lsig1_case_2() -> Expr:
@@ -493,6 +629,12 @@ def lsig1_case_15() -> Expr:
                     # int 0; gtxns RekeyTo
                     Gtxn[Int(0)].rekey_to() == Global.zero_address(),
                     Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[Int(0)].fee() < Int(100000),
+                    Gtxn[1].fee() < Int(1000),
+                    Gtxn[Int(0)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[1].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Int(0)].asset_close_to() == Global.zero_address(),
+                    Gtxn[1].asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -504,6 +646,9 @@ def lsig1_case_16() -> Expr:
     return Seq(
         [
             Assert(Gtxn[0].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[0].fee() < Int(10000)),
+            Assert(Gtxn[0].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[0].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -513,6 +658,9 @@ def lsig1_case_17() -> Expr:
     return Seq(
         [
             Assert(Gtxn[1].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[1].fee() < Int(10000)),
+            Assert(Gtxn[1].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[1].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -559,6 +707,12 @@ def lsig1_case_27() -> Expr:
                 And(
                     Txn.rekey_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(1)].rekey_to() == Global.zero_address(),
+                    Txn.fee() < Int(10000),
+                    Gtxn[Txn.group_index() + Int(1)].fee() < Int(10000),
+                    Txn.close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(1)].close_remainder_to() == Global.zero_address(),
+                    Txn.asset_close_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(1)].asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -586,6 +740,9 @@ def lsig1_case_29() -> Expr:
             Assert(
                 And(
                     Gtxn[Txn.group_index() + Int(3)].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(3)].fee() < Int(10000),
+                    Gtxn[Txn.group_index() + Int(3)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(3)].asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -601,6 +758,9 @@ def lsig1_case_30() -> Expr:
                     Txn.application_id() == Int(1337),
                     Txn.on_completion() == OnComplete.NoOp,
                     Gtxn[Txn.group_index() + Int(4)].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(4)].fee() < Int(10000),
+                    Gtxn[Txn.group_index() + Int(4)].asset_close_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(4)].close_remainder_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -620,6 +780,9 @@ def lsig1_case_32() -> Expr:
                     Txn.application_id() == Int(1337),
                     Txn.on_completion() == OnComplete.NoOp,
                     Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000),
+                    Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -633,6 +796,9 @@ def lsig1_case_33() -> Expr:
             Assert(
                 And(
                     Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[1].fee() < Int(10000),
+                    Gtxn[1].close_remainder_to() == Global.zero_address(),
+                    Gtxn[1].asset_close_to() == Global.zero_address(),
                     Txn.application_id() == Int(1337),
                     Txn.on_completion() == OnComplete.NoOp,
                 )
@@ -648,6 +814,9 @@ def lsig1_case_34() -> Expr:
             Assert(
                 And(
                     Gtxn[Txn.group_index() + Int(2)].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(2)].fee() < Int(10000),
+                    Gtxn[Txn.group_index() + Int(2)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(2)].asset_close_to() == Global.zero_address(),
                     Txn.application_id() == Int(1337),
                     Txn.on_completion() == OnComplete.NoOp,
                 )
@@ -663,6 +832,9 @@ def lsig1_case_35() -> Expr:
             Assert(
                 And(
                     Gtxn[Txn.group_index() + Int(3)].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(3)].fee() < Int(10000),
+                    Gtxn[Txn.group_index() + Int(3)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(3)].asset_close_to() == Global.zero_address(),
                     Txn.application_id() == Int(1337),
                     Txn.on_completion() == OnComplete.NoOp,
                 )
@@ -687,7 +859,19 @@ def lsig1_case_36() -> Expr:
 
 
 def lsig1_case_37() -> Expr:
-    return Seq([Assert(Gtxn[1].rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[1].fee() < Int(10000),
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[1].close_remainder_to() == Global.zero_address(),
+                    Gtxn[1].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def logic_sig() -> Expr:

--- a/tests/group_transactions/basic/logicsig_1.teal
+++ b/tests/group_transactions/basic/logicsig_1.teal
@@ -146,9 +146,21 @@ int 37
 bnz main_l30
 err
 main_l30:
+gtxn 1 Fee
+int 10000
+<
 gtxn 1 RekeyTo
 global ZeroAddress
 ==
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -170,6 +182,27 @@ int 3
 gtxns RekeyTo
 global ZeroAddress
 ==
+txn GroupIndex
+int 3
++
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 3
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 3
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
 txn ApplicationID
 int 1337
 ==
@@ -188,6 +221,27 @@ int 2
 gtxns RekeyTo
 global ZeroAddress
 ==
+txn GroupIndex
+int 2
++
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 2
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 2
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
 txn ApplicationID
 int 1337
 ==
@@ -203,6 +257,18 @@ main_l34:
 gtxn 1 RekeyTo
 global ZeroAddress
 ==
+gtxn 1 Fee
+int 10000
+<
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+&&
 txn ApplicationID
 int 1337
 ==
@@ -229,6 +295,27 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 &&
+txn GroupIndex
+int 5
++
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 5
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 5
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -244,6 +331,27 @@ txn GroupIndex
 int 4
 +
 gtxns RekeyTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 4
++
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 4
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 4
++
+gtxns CloseRemainderTo
 global ZeroAddress
 ==
 &&
@@ -265,6 +373,27 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 &&
+txn GroupIndex
+int 4
++
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 4
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 4
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -275,6 +404,27 @@ int 3
 gtxns RekeyTo
 global ZeroAddress
 ==
+txn GroupIndex
+int 3
++
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 3
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 3
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -297,6 +447,39 @@ txn GroupIndex
 int 1
 +
 gtxns RekeyTo
+global ZeroAddress
+==
+&&
+txn Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 1
++
+gtxns Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 1
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 1
++
+gtxns AssetCloseTo
 global ZeroAddress
 ==
 &&
@@ -366,10 +549,34 @@ gtxn 1 RekeyTo
 global ZeroAddress
 ==
 assert
+gtxn 1 Fee
+int 10000
+<
+assert
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+assert
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+assert
 int 1
 return
 main_l48:
 gtxn 0 RekeyTo
+global ZeroAddress
+==
+assert
+gtxn 0 Fee
+int 10000
+<
+assert
+gtxn 0 CloseRemainderTo
+global ZeroAddress
+==
+assert
+gtxn 0 AssetCloseTo
 global ZeroAddress
 ==
 assert
@@ -381,6 +588,33 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 gtxn 1 RekeyTo
+global ZeroAddress
+==
+&&
+int 0
+gtxns Fee
+int 100000
+<
+&&
+gtxn 1 Fee
+int 1000
+<
+&&
+int 0
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+int 0
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 &&
@@ -463,6 +697,18 @@ main_l58:
 txn RekeyTo
 global ZeroAddress
 ==
+txn Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return

--- a/tests/group_transactions/basic/logicsig_2.py
+++ b/tests/group_transactions/basic/logicsig_2.py
@@ -9,7 +9,19 @@ def lsig2_case_7() -> Expr:
 
 
 def lsig2_case_8() -> Expr:
-    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.rekey_to() == Global.zero_address(),
+                    Txn.fee() < Int(10000),
+                    Txn.close_remainder_to() == Global.zero_address(),
+                    Txn.asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def lsig2_case_9() -> Expr:
@@ -23,6 +35,12 @@ def lsig2_case_10() -> Expr:
                 And(
                     Gtxn[0].rekey_to() == Global.zero_address(),
                     Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[Int(0)].fee() < Int(100000),
+                    Gtxn[1].fee() < Int(1000),
+                    Gtxn[Int(0)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[1].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Int(0)].asset_close_to() == Global.zero_address(),
+                    Gtxn[1].asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -35,7 +53,19 @@ def lsig2_case_11() -> Expr:
 
 
 def lsig2_case_12() -> Expr:
-    return Seq([Assert(Gtxn[1].rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[1].fee() < Int(10000),
+                    Gtxn[1].close_remainder_to() == Global.zero_address(),
+                    Gtxn[1].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def lsig2_case_13() -> Expr:
@@ -53,7 +83,14 @@ def lsig2_case_15() -> Expr:
 def lsig2_case_16() -> Expr:
     return Seq(
         [
-            Assert(Txn.rekey_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Txn.rekey_to() == Global.zero_address(),
+                    Txn.fee() < Int(10000),
+                    Txn.close_remainder_to() == Global.zero_address(),
+                    Txn.asset_close_to() == Global.zero_address(),
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -71,6 +108,9 @@ def lsig2_case_19() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -80,6 +120,9 @@ def lsig2_case_20() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -95,7 +138,13 @@ def lsig2_case_22() -> Expr:
             Assert(
                 And(
                     Gtxn[Txn.group_index() - Int(1)].rekey_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() - Int(1)].fee() < Int(10000),
+                    Gtxn[Txn.group_index() - Int(1)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() - Int(1)].asset_close_to() == Global.zero_address(),
                     Txn.rekey_to() == Global.zero_address(),
+                    Txn.fee() < Int(10000),
+                    Txn.close_remainder_to() == Global.zero_address(),
+                    Txn.asset_close_to() == Global.zero_address(),
                 )
             ),
             Return(Int(1)),
@@ -108,7 +157,19 @@ def lsig2_case_23() -> Expr:
 
 
 def lsig2_case_24() -> Expr:
-    return Seq([Assert(Txn.rekey_to() == Global.zero_address()), Return(Int(1))])
+    return Seq(
+        [
+            Assert(
+                And(
+                    Txn.rekey_to() == Global.zero_address(),
+                    Txn.fee() < Int(10000),
+                    Txn.close_remainder_to() == Global.zero_address(),
+                    Txn.asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Return(Int(1)),
+        ]
+    )
 
 
 def lsig2_case_25() -> Expr:
@@ -127,6 +188,9 @@ def lsig2_case_28() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -144,6 +208,9 @@ def lsig2_case_31() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -153,6 +220,9 @@ def lsig2_case_32() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() - Int(4)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )
@@ -162,6 +232,9 @@ def lsig2_case_33() -> Expr:
     return Seq(
         [
             Assert(Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000)),
+            Assert(Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address()),
+            Assert(Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address()),
             Return(Int(1)),
         ]
     )

--- a/tests/group_transactions/basic/logicsig_2.teal
+++ b/tests/group_transactions/basic/logicsig_2.teal
@@ -159,6 +159,27 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 5
++
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 5
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 5
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
 int 1
 return
 main_l33:
@@ -169,6 +190,27 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 4
+-
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 4
+-
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 4
+-
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
 int 1
 return
 main_l34:
@@ -176,6 +218,27 @@ txn GroupIndex
 int 4
 -
 gtxns RekeyTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 4
+-
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 4
+-
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 4
+-
+gtxns AssetCloseTo
 global ZeroAddress
 ==
 assert
@@ -195,6 +258,27 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 4
+-
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 4
+-
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 4
+-
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
 int 1
 return
 main_l38:
@@ -210,6 +294,18 @@ main_l41:
 txn RekeyTo
 global ZeroAddress
 ==
+txn Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -220,7 +316,40 @@ int 1
 gtxns RekeyTo
 global ZeroAddress
 ==
+txn GroupIndex
+int 1
+-
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 1
+-
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 1
+-
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
 txn RekeyTo
+global ZeroAddress
+==
+&&
+txn Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
 global ZeroAddress
 ==
 &&
@@ -234,7 +363,40 @@ int 1
 gtxns RekeyTo
 global ZeroAddress
 ==
+txn GroupIndex
+int 1
+-
+gtxns Fee
+int 10000
+<
+&&
+txn GroupIndex
+int 1
+-
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn GroupIndex
+int 1
+-
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
 txn RekeyTo
+global ZeroAddress
+==
+&&
+txn Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
 global ZeroAddress
 ==
 &&
@@ -252,6 +414,27 @@ gtxns RekeyTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 5
++
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 5
++
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 5
++
+gtxns AssetCloseTo
+global ZeroAddress
+==
+assert
 int 1
 return
 main_l46:
@@ -259,6 +442,27 @@ txn GroupIndex
 int 4
 -
 gtxns RekeyTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 4
+-
+gtxns Fee
+int 10000
+<
+assert
+txn GroupIndex
+int 4
+-
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+assert
+txn GroupIndex
+int 4
+-
+gtxns AssetCloseTo
 global ZeroAddress
 ==
 assert
@@ -274,6 +478,18 @@ main_l49:
 txn RekeyTo
 global ZeroAddress
 ==
+txn Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -290,6 +506,18 @@ main_l53:
 gtxn 1 RekeyTo
 global ZeroAddress
 ==
+gtxn 1 Fee
+int 10000
+<
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -298,6 +526,33 @@ gtxn 0 RekeyTo
 global ZeroAddress
 ==
 gtxn 1 RekeyTo
+global ZeroAddress
+==
+&&
+int 0
+gtxns Fee
+int 100000
+<
+&&
+gtxn 1 Fee
+int 1000
+<
+&&
+int 0
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+int 0
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 &&
@@ -312,6 +567,33 @@ gtxn 1 RekeyTo
 global ZeroAddress
 ==
 &&
+int 0
+gtxns Fee
+int 100000
+<
+&&
+gtxn 1 Fee
+int 1000
+<
+&&
+int 0
+gtxns CloseRemainderTo
+global ZeroAddress
+==
+&&
+gtxn 1 CloseRemainderTo
+global ZeroAddress
+==
+&&
+int 0
+gtxns AssetCloseTo
+global ZeroAddress
+==
+&&
+gtxn 1 AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return
@@ -322,6 +604,18 @@ main_l57:
 txn RekeyTo
 global ZeroAddress
 ==
+txn Fee
+int 10000
+<
+&&
+txn CloseRemainderTo
+global ZeroAddress
+==
+&&
+txn AssetCloseTo
+global ZeroAddress
+==
+&&
 assert
 int 1
 return

--- a/tests/group_transactions/test_group_support.py
+++ b/tests/group_transactions/test_group_support.py
@@ -4,7 +4,12 @@ import pytest
 
 
 from tealer.detectors.abstract_detector import AbstractDetector
-from tealer.detectors.all_detectors import MissingRekeyTo
+from tealer.detectors.all_detectors import (
+    MissingRekeyTo,
+    MissingFeeCheck,
+    CanCloseAccount,
+    CanCloseAsset,
+)
 from tealer.utils.command_line.group_config import read_config_from_file
 from tealer.utils.command_line.common import init_tealer_from_config
 from tealer.utils.output import GroupTransactionOutput
@@ -18,7 +23,22 @@ ALL_TESTS: List[Tuple[Path, Type[AbstractDetector], Path]] = [
         Path("tests/group_transactions/basic/config.yaml"),
         MissingRekeyTo,
         Path("tests/group_transactions/basic/expected_output.yaml"),
-    )
+    ),
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        MissingFeeCheck,
+        Path("tests/group_transactions/basic/expected_output.yaml"),
+    ),
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        CanCloseAccount,
+        Path("tests/group_transactions/basic/expected_output_close_to.yaml"),
+    ),
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        CanCloseAsset,
+        Path("tests/group_transactions/basic/expected_output_asset_close_to.yaml"),
+    ),
 ]
 
 


### PR DESCRIPTION
The `MissingFeeCheck`, `CanCloseAccount`, `CanCloseAsset` detectors are updated to work on group transactions. The tests are updated to test these detectors as well.

The PR also adds support for use of `user-given` transaction type in the detectors.

The contracts are only vulnerable to `CanCloseAccount` only if the logic-sig is executed in a Payment transaction. The detector checks if the type of the transaction is Payment or not and only detects if the transaction is payment.

Note: The `CanCloseAccount` and `CanCloseAsset` detectors do use the transaction types before this PR. however, they relied on the information computed by tealer instead of the user-given configuration. 
