### PR TITLE
Add group transaction support for stateful detectors

### DIFF
--- a/tealer/analyses/dataflow/transaction_context/txn_types.py
+++ b/tealer/analyses/dataflow/transaction_context/txn_types.py
@@ -146,16 +146,18 @@ class TxnType(DataflowTransactionContext):  # pylint: disable=too-few-public-met
                 return set(U), set(U)
 
             true_values, false_values = None, None
-            if is_value_matches_key(key, arg1, ApplicationID):
+            if is_value_matches_key(key, arg1, ApplicationID) and value_3 is not None:
                 # TODO: ApplicationCreation transaction can be NoOp or OptIn
-                true_values, false_values = set([TealerTransactionType.ApplCreation]), set(
-                    APPLICATION_TRANSACTION_TYPES
-                ) - set([TealerTransactionType.ApplCreation])
-            elif is_value_matches_key(key, arg2, ApplicationID):
+                if isinstance(value_3, int) and value_3 == 0:
+                    true_values, false_values = set([TealerTransactionType.ApplCreation]), set(
+                        APPLICATION_TRANSACTION_TYPES
+                    ) - set([TealerTransactionType.ApplCreation])
+            elif is_value_matches_key(key, arg2, ApplicationID) and value_2 is not None:
                 # TODO: ApplicationCreation transaction can be NoOp or OptIn
-                true_values, false_values = set([TealerTransactionType.ApplCreation]), set(
-                    APPLICATION_TRANSACTION_TYPES
-                ) - set([TealerTransactionType.ApplCreation])
+                if isinstance(value_2, int) and value_2 == 0:
+                    true_values, false_values = set([TealerTransactionType.ApplCreation]), set(
+                        APPLICATION_TRANSACTION_TYPES
+                    ) - set([TealerTransactionType.ApplCreation])
 
             if is_value_matches_key(key, arg1, TypeEnum) and value_3 is not None:
                 compared_type = transaction_type_to_tealer_type(value_3)

--- a/tealer/detectors/anyone_can_delete.py
+++ b/tealer/detectors/anyone_can_delete.py
@@ -7,7 +7,10 @@ from tealer.detectors.abstract_detector import (
     DetectorClassification,
     DetectorType,
 )
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 from tealer.utils.output import ExecutionPaths
 
@@ -75,6 +78,14 @@ Eve calls `delete_application` method and deletes the application making its ass
             return not (
                 TealerTransactionType.ApplDeleteApplication in block_ctx.transaction_types
                 and block_ctx.sender.any_addr
+            )
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(self.tealer, self, checks_field)
             )
 
         output: List[

--- a/tealer/detectors/anyone_can_update.py
+++ b/tealer/detectors/anyone_can_update.py
@@ -7,7 +7,10 @@ from tealer.detectors.abstract_detector import (
     DetectorClassification,
     DetectorType,
 )
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 from tealer.utils.output import ExecutionPaths
 
@@ -74,6 +77,14 @@ Eve updates the application by calling `update_application` method and steals al
             return not (
                 TealerTransactionType.ApplUpdateApplication in block_ctx.transaction_types
                 and block_ctx.sender.any_addr
+            )
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(self.tealer, self, checks_field)
             )
 
         output: List[

--- a/tealer/detectors/is_deletable.py
+++ b/tealer/detectors/is_deletable.py
@@ -8,7 +8,10 @@ from tealer.detectors.abstract_detector import (
     DetectorType,
 )
 
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 from tealer.utils.output import ExecutionPaths
 
@@ -72,6 +75,14 @@ Do not approve `DeleteApplication` type application calls.
             # return False if Txn Type can be DeleteApplication.
             # return True if Txn Type cannot be DeleteApplication.
             return not TealerTransactionType.ApplDeleteApplication in block_ctx.transaction_types
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(self.tealer, self, checks_field)
+            )
 
         output: List[
             Tuple["Teal", List[List["BasicBlock"]]]

--- a/tealer/detectors/is_updatable.py
+++ b/tealer/detectors/is_updatable.py
@@ -7,7 +7,10 @@ from tealer.detectors.abstract_detector import (
     DetectorClassification,
     DetectorType,
 )
-from tealer.detectors.utils import detect_missing_tx_field_validations_group
+from tealer.detectors.utils import (
+    detect_missing_tx_field_validations_group,
+    detect_missing_tx_field_validations_group_complete,
+)
 from tealer.utils.teal_enums import TealerTransactionType
 from tealer.utils.output import ExecutionPaths
 
@@ -72,6 +75,14 @@ Do not approve `UpdateApplication` type application calls.
             # return False if Txn Type can be UpdateApplication.
             # return True if Txn Type cannot be UpdateApplication.
             return not TealerTransactionType.ApplUpdateApplication in block_ctx.transaction_types
+
+        # there should be a better to decide which function to call ??
+        if self.tealer.output_group:
+            # mypy complains if the value is returned directly. Uesd the second suggestion mentioned here:
+            # https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+            return list(
+                detect_missing_tx_field_validations_group_complete(self.tealer, self, checks_field)
+            )
 
         # paths_without_check: List[List[BasicBlock]] = detect_missing_tx_field_validations(
         #     self.teal, checks_field

--- a/tealer/detectors/utils.py
+++ b/tealer/detectors/utils.py
@@ -49,7 +49,7 @@ def validated_in_block(
     Returns:
         returns True if the field(s) is validated in this block or else False
     """
-    print(str(block), "\n", block, function.transaction_context(block).transaction_types)
+    # print(str(block), "\n", block, function.transaction_context(block).transaction_types)
     # if field is checked using `txn {field}`, return true
     if checks_field(function.transaction_context(block)):
         return True
@@ -453,13 +453,13 @@ def detect_missing_tx_field_validations_group_complete(  # pylint: disable=too-m
             # the contract has logic sig
             # check if the contracts executed in the txn check the field.
             # logic sig contract is given
-            print("A")
+            # print("A")
             if txn.logic_sig is not None and contract_checks_its_field(
                 txn.logic_sig, checks_field, txn.absoulte_index
             ):
                 # the logic sig checks its field, not vulnerable
                 continue
-            print("B")
+            # print("B")
             if txn.application is not None and contract_checks_its_field(
                 txn.application, checks_field, txn.absoulte_index
             ):

--- a/tealer/detectors/utils.py
+++ b/tealer/detectors/utils.py
@@ -49,8 +49,8 @@ def validated_in_block(
     Returns:
         returns True if the field(s) is validated in this block or else False
     """
+    print(str(block), "\n", block, function.transaction_context(block).transaction_types)
     # if field is checked using `txn {field}`, return true
-
     if checks_field(function.transaction_context(block)):
         return True
     # if absolute index is given, check if field was checked by accessing it using gtxn(s) instructions`
@@ -411,7 +411,8 @@ def detect_missing_tx_field_validations_group_complete(  # pylint: disable=too-m
     transaction type is "UpdateApplication". if "UpdateApplication" is a possible value then the contract is considered vulnerable and is reported.
 
     In order to find whether the given contract is vulnerable, it is sufficient to check the leaf blocks: whether transaction field can
-    have target value and execution reaches end of a leaf block.
+    have target value and execution reaches end of a leaf block. Note, this is not always true for AnyoneCanUpdate and AnyoneCanDelete dectectors. These
+    detectors depend on two fields that are tracked by independent keys. However, the current implementation is sufficient for the common patterns.
     - Only LogicSigs are vulnerable to Stateless detectors.
     - If a transaction does not have LogicSig then it is considered to be not vulnerable by Stateless detectors.
 
@@ -435,6 +436,10 @@ def detect_missing_tx_field_validations_group_complete(  # pylint: disable=too-m
             if detector.TYPE == DetectorType.STATELESS and not txn.has_logic_sig:
                 continue
 
+            if detector.TYPE == DetectorType.STATEFULL and txn.application is None:
+                # check for the application transaction type???
+                continue
+
             if (
                 vulnerable_transaction_types is not None
                 and txn.type not in vulnerable_transaction_types
@@ -448,11 +453,13 @@ def detect_missing_tx_field_validations_group_complete(  # pylint: disable=too-m
             # the contract has logic sig
             # check if the contracts executed in the txn check the field.
             # logic sig contract is given
+            print("A")
             if txn.logic_sig is not None and contract_checks_its_field(
                 txn.logic_sig, checks_field, txn.absoulte_index
             ):
                 # the logic sig checks its field, not vulnerable
                 continue
+            print("B")
             if txn.application is not None and contract_checks_its_field(
                 txn.application, checks_field, txn.absoulte_index
             ):
@@ -500,7 +507,7 @@ def detect_missing_tx_field_validations_group_complete(  # pylint: disable=too-m
             if checked:
                 continue
 
-            # the logic contract is vulnerable. mark the operation/group as vulnerable
+            # the contract is vulnerable. mark the operation/group as vulnerable
             is_vulnerable = True
 
             if detector.TYPE == DetectorType.STATELESS:
@@ -508,6 +515,12 @@ def detect_missing_tx_field_validations_group_complete(  # pylint: disable=too-m
                     vulnerable_transactions[txn] = [txn.logic_sig]
                 else:
                     vulnerable_transactions[txn] = []
+            elif detector.TYPE == DetectorType.STATEFULL:
+                if txn.application is not None:
+                    vulnerable_transactions[txn] = [txn.application]
+                else:
+                    vulnerable_transactions[txn] = []
+
         if is_vulnerable:
             output.append(GroupTransactionOutput(detector, group_txn, vulnerable_transactions))
     return output

--- a/tests/group_transactions/basic/app_1.py
+++ b/tests/group_transactions/basic/app_1.py
@@ -29,6 +29,8 @@ def app1_case_5() -> Expr:
                     Txn.fee() < Int(10000),
                     Txn.close_remainder_to() == Global.zero_address(),
                     Txn.asset_close_to() == Global.zero_address(),
+                    Txn.on_completion() != OnComplete.UpdateApplication,
+                    Txn.on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -45,6 +47,8 @@ def app1_case_6() -> Expr:
                     Gtxn[Txn.group_index()].fee() < Int(10000),
                     Gtxn[Txn.group_index()].close_remainder_to() == Global.zero_address(),
                     Gtxn[Txn.group_index()].asset_close_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index()].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index()].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -65,6 +69,10 @@ def app1_case_7() -> Expr:
                     Gtxn[1].close_remainder_to() == Global.zero_address(),
                     Gtxn[Int(0)].asset_close_to() == Global.zero_address(),
                     Gtxn[1].asset_close_to() == Global.zero_address(),
+                    Gtxn[0].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[0].on_completion() != OnComplete.DeleteApplication,
+                    Gtxn[Int(1)].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[Int(1)].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -83,6 +91,12 @@ def app1_case_8() -> Expr:
                     Gtxn[0].asset_close_to() == Global.zero_address(),
                 )
             ),
+            Assert(
+                And(
+                    Gtxn[0].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[0].on_completion() != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -97,6 +111,12 @@ def app1_case_9() -> Expr:
                     Gtxn[1].fee() < Int(10000),
                     Gtxn[1].close_remainder_to() == Global.zero_address(),
                     Gtxn[1].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Assert(
+                And(
+                    Gtxn[1].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[1].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -151,6 +171,16 @@ def app1_case_18() -> Expr:
                     Gtxn[Txn.group_index() + Int(4)].asset_close_to() == Global.zero_address(),
                 )
             ),
+            Assert(
+                And(
+                    Gtxn[0].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[0].on_completion() != OnComplete.DeleteApplication,
+                    Gtxn[Txn.group_index() + Int(4)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(4)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -163,6 +193,14 @@ def app1_case_19() -> Expr:
             Assert(Gtxn[Txn.group_index() + Int(4)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() + Int(4)].asset_close_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() + Int(4)].close_remainder_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(4)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(4)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -175,6 +213,12 @@ def app1_case_20() -> Expr:
             Assert(Gtxn[1].fee() < Int(10000)),
             Assert(Gtxn[1].asset_close_to() == Global.zero_address()),
             Assert(Gtxn[1].close_remainder_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[1].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[1].on_completion() != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -187,6 +231,14 @@ def app1_case_21() -> Expr:
             Assert(Gtxn[Txn.group_index() + Int(2)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() + Int(2)].asset_close_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() + Int(2)].close_remainder_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(2)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(2)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -223,6 +275,14 @@ def app1_case_28() -> Expr:
             Assert(Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -241,6 +301,8 @@ def app1_case_30() -> Expr:
                     Gtxn[0].fee() < Int(10000),
                     Gtxn[0].close_remainder_to() == Global.zero_address(),
                     Gtxn[0].asset_close_to() == Global.zero_address(),
+                    Gtxn[0].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[0].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -277,6 +339,8 @@ def app1_case_36() -> Expr:
                     Gtxn[4].fee() < Int(10000),
                     Gtxn[4].close_remainder_to() == Global.zero_address(),
                     Gtxn[4].asset_close_to() == Global.zero_address(),
+                    Gtxn[4].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[4].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -292,7 +356,6 @@ def approval_program() -> Expr:
     test_case = Btoi(Txn.application_args[Int(0)])
     return Seq(
         [
-            Assert(Txn.on_completion() == OnComplete.NoOp),
             Cond(
                 [test_case == Int(1), app1_case_1()],
                 [test_case == Int(2), app1_case_2()],

--- a/tests/group_transactions/basic/app_1.teal
+++ b/tests/group_transactions/basic/app_1.teal
@@ -1,8 +1,4 @@
 #pragma version 7
-txn OnCompletion
-int NoOp
-==
-assert
 int 0
 txnas ApplicationArgs
 btoi
@@ -245,6 +241,14 @@ gtxn 4 AssetCloseTo
 global ZeroAddress
 ==
 &&
+gtxn 4 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 4 OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -278,6 +282,14 @@ global ZeroAddress
 gtxn 0 AssetCloseTo
 global ZeroAddress
 ==
+&&
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -313,6 +325,20 @@ int 5
 gtxns CloseRemainderTo
 global ZeroAddress
 ==
+assert
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -363,6 +389,20 @@ gtxns CloseRemainderTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 2
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 2
++
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l55:
@@ -381,6 +421,14 @@ assert
 gtxn 1 CloseRemainderTo
 global ZeroAddress
 ==
+assert
+gtxn 1 OnCompletion
+int UpdateApplication
+!=
+gtxn 1 OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -412,6 +460,20 @@ int 4
 gtxns CloseRemainderTo
 global ZeroAddress
 ==
+assert
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -460,6 +522,28 @@ global ZeroAddress
 ==
 &&
 assert
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
+&&
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l58:
@@ -503,6 +587,14 @@ global ZeroAddress
 ==
 &&
 assert
+gtxn 1 OnCompletion
+int UpdateApplication
+!=
+gtxn 1 OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l67:
@@ -520,6 +612,14 @@ global ZeroAddress
 gtxn 0 AssetCloseTo
 global ZeroAddress
 ==
+&&
+assert
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -559,6 +659,24 @@ gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 &&
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -582,6 +700,16 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 &&
+txn GroupIndex
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -600,6 +728,14 @@ global ZeroAddress
 txn AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1

--- a/tests/group_transactions/basic/config.yaml
+++ b/tests/group_transactions/basic/config.yaml
@@ -319,7 +319,7 @@ groups:
           contract: LogicSig_2
           function: lsig2_case_9
         absolute_index: 1
-      
+
   - operation: case_10
     transactions:
       - txn_id: T1

--- a/tests/group_transactions/basic/expected_output_update_delete.yaml
+++ b/tests/group_transactions/basic/expected_output_update_delete.yaml
@@ -1,0 +1,104 @@
+name: BasicRekeyTo
+operations:
+  - operation: case_2
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_2
+  - operation: case_3
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_3
+  - operation: case_4
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_4
+  - operation: case_9
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_9
+  - operation: case_12
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_12
+  - operation: case_13
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_13
+  - operation: case_14
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_14
+  - operation: case_17
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_17
+  - operation: case_21
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_21
+  - operation: case_24
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_24
+  - operation: case_25
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_25
+  - operation: case_26
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_26
+  - operation: case_28
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_28
+  - operation: case_29
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_29
+  - operation: case_32
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_32
+  - operation: case_34
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_34
+  - operation: case_35
+    vulnerable_transactions:
+      - txn_id: T1
+        contracts:
+          - contract: App_1
+            function: app1_case_35

--- a/tests/group_transactions/basic/logicsig_1.py
+++ b/tests/group_transactions/basic/logicsig_1.py
@@ -11,7 +11,7 @@ Expected:
     - The detector should not report it as vulnerable.
     Not Vulnerable - RekeyTo
     Not Vulnerable - Fee
-    Not < Int(10000)t Vulnerable - AssetCloseTo
+    Not Vulnerable - AssetCloseTo
 
 
 case 2:
@@ -22,7 +22,7 @@ Expected:
     - The detector should report it as vulnerable
     Vulnerable - RekeyTo
     Vulnerable - Fee
-    Nor Vulnerable - CloseRemainderTo
+    Not Vulnerable - CloseRemainderTo
     Not Vulnerable - AssetCloseTo
 
 case 3:
@@ -572,6 +572,8 @@ def lsig1_case_1() -> Expr:
                     Txn.fee() < Int(10000),
                     Txn.close_remainder_to() == Global.zero_address(),
                     Txn.asset_close_to() == Global.zero_address(),
+                    Txn.on_completion() != OnComplete.UpdateApplication,
+                    Txn.on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -589,7 +591,7 @@ def lsig1_case_5() -> Expr:
             Assert(
                 And(
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
                 )
             ),
             Return(Int(1)),
@@ -635,6 +637,10 @@ def lsig1_case_15() -> Expr:
                     Gtxn[1].close_remainder_to() == Global.zero_address(),
                     Gtxn[Int(0)].asset_close_to() == Global.zero_address(),
                     Gtxn[1].asset_close_to() == Global.zero_address(),
+                    Gtxn[0].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[0].on_completion() != OnComplete.DeleteApplication,
+                    Gtxn[Int(1)].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[Int(1)].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -649,6 +655,12 @@ def lsig1_case_16() -> Expr:
             Assert(Gtxn[0].fee() < Int(10000)),
             Assert(Gtxn[0].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[0].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[0].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[0].on_completion() != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -661,6 +673,12 @@ def lsig1_case_17() -> Expr:
             Assert(Gtxn[1].fee() < Int(10000)),
             Assert(Gtxn[1].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[1].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[1].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[1].on_completion() != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -672,7 +690,7 @@ def lsig1_case_18() -> Expr:
             Assert(
                 And(
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
                 )
             ),
             Return(Int(1)),
@@ -713,6 +731,12 @@ def lsig1_case_27() -> Expr:
                     Gtxn[Txn.group_index() + Int(1)].close_remainder_to() == Global.zero_address(),
                     Txn.asset_close_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(1)].asset_close_to() == Global.zero_address(),
+                    Txn.on_completion() != OnComplete.UpdateApplication,
+                    Txn.on_completion() != OnComplete.DeleteApplication,
+                    Gtxn[Txn.group_index() + Int(1)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(1)].on_completion()
+                    != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -726,7 +750,7 @@ def lsig1_case_28() -> Expr:
             Assert(
                 And(
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
                 )
             ),
             Return(Int(1)),
@@ -743,6 +767,10 @@ def lsig1_case_29() -> Expr:
                     Gtxn[Txn.group_index() + Int(3)].fee() < Int(10000),
                     Gtxn[Txn.group_index() + Int(3)].close_remainder_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(3)].asset_close_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(3)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(3)].on_completion()
+                    != OnComplete.UpdateApplication,
                 )
             ),
             Return(Int(1)),
@@ -756,11 +784,15 @@ def lsig1_case_30() -> Expr:
             Assert(
                 And(
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
                     Gtxn[Txn.group_index() + Int(4)].rekey_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(4)].fee() < Int(10000),
                     Gtxn[Txn.group_index() + Int(4)].asset_close_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(4)].close_remainder_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(4)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(4)].on_completion()
+                    != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -778,11 +810,15 @@ def lsig1_case_32() -> Expr:
             Assert(
                 And(
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
                     Gtxn[Txn.group_index() + Int(5)].rekey_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000),
                     Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -800,7 +836,9 @@ def lsig1_case_33() -> Expr:
                     Gtxn[1].close_remainder_to() == Global.zero_address(),
                     Gtxn[1].asset_close_to() == Global.zero_address(),
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
+                    Gtxn[1].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[1].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -818,7 +856,11 @@ def lsig1_case_34() -> Expr:
                     Gtxn[Txn.group_index() + Int(2)].close_remainder_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(2)].asset_close_to() == Global.zero_address(),
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
+                    Gtxn[Txn.group_index() + Int(2)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(2)].on_completion()
+                    != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -836,7 +878,11 @@ def lsig1_case_35() -> Expr:
                     Gtxn[Txn.group_index() + Int(3)].close_remainder_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() + Int(3)].asset_close_to() == Global.zero_address(),
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
+                    Gtxn[Txn.group_index() + Int(3)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(3)].on_completion()
+                    != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -850,7 +896,7 @@ def lsig1_case_36() -> Expr:
             Assert(
                 And(
                     Txn.application_id() == Int(1337),
-                    Txn.on_completion() == OnComplete.NoOp,
+                    # Txn.on_completion() == OnComplete.NoOp,
                 )
             ),
             Return(Int(1)),
@@ -867,6 +913,8 @@ def lsig1_case_37() -> Expr:
                     Gtxn[1].rekey_to() == Global.zero_address(),
                     Gtxn[1].close_remainder_to() == Global.zero_address(),
                     Gtxn[1].asset_close_to() == Global.zero_address(),
+                    Gtxn[1].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[1].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),

--- a/tests/group_transactions/basic/logicsig_1.teal
+++ b/tests/group_transactions/basic/logicsig_1.teal
@@ -161,6 +161,14 @@ gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 &&
+gtxn 1 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 1 OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -168,10 +176,6 @@ main_l31:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -207,9 +211,19 @@ txn ApplicationID
 int 1337
 ==
 &&
-txn OnCompletion
-int NoOp
-==
+txn GroupIndex
+int 3
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 3
++
+gtxns OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -246,9 +260,19 @@ txn ApplicationID
 int 1337
 ==
 &&
-txn OnCompletion
-int NoOp
-==
+txn GroupIndex
+int 2
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 2
++
+gtxns OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -273,9 +297,13 @@ txn ApplicationID
 int 1337
 ==
 &&
-txn OnCompletion
-int NoOp
-==
+gtxn 1 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 1 OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -284,10 +312,6 @@ main_l35:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 txn GroupIndex
 int 5
 +
@@ -315,6 +339,20 @@ int 5
 gtxns AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -323,10 +361,6 @@ main_l36:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 txn GroupIndex
 int 4
 +
@@ -354,6 +388,20 @@ int 4
 gtxns CloseRemainderTo
 global ZeroAddress
 ==
+&&
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -362,10 +410,6 @@ main_l37:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 txn GroupIndex
 int 4
 +
@@ -393,6 +437,20 @@ int 4
 gtxns CloseRemainderTo
 global ZeroAddress
 ==
+&&
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 4
++
+gtxns OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -425,6 +483,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 &&
+txn GroupIndex
+int 3
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 3
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
 assert
 int 1
 return
@@ -432,10 +504,6 @@ main_l39:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -483,6 +551,28 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 &&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
+&&
+txn GroupIndex
+int 1
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 1
++
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -493,10 +583,6 @@ main_l42:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -504,10 +590,6 @@ main_l43:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -515,10 +597,6 @@ main_l44:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -526,10 +604,6 @@ main_l45:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -537,10 +611,6 @@ main_l46:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -561,6 +631,14 @@ gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 assert
+gtxn 1 OnCompletion
+int UpdateApplication
+!=
+gtxn 1 OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l48:
@@ -579,6 +657,14 @@ assert
 gtxn 0 AssetCloseTo
 global ZeroAddress
 ==
+assert
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -618,6 +704,24 @@ gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 &&
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -628,10 +732,6 @@ main_l51:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -639,10 +739,6 @@ main_l52:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -650,10 +746,6 @@ main_l53:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -661,10 +753,6 @@ main_l54:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -672,10 +760,6 @@ main_l55:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -683,10 +767,6 @@ main_l56:
 txn ApplicationID
 int 1337
 ==
-txn OnCompletion
-int NoOp
-==
-&&
 assert
 int 1
 return
@@ -708,6 +788,14 @@ global ZeroAddress
 txn AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1

--- a/tests/group_transactions/basic/logicsig_2.py
+++ b/tests/group_transactions/basic/logicsig_2.py
@@ -17,6 +17,8 @@ def lsig2_case_8() -> Expr:
                     Txn.fee() < Int(10000),
                     Txn.close_remainder_to() == Global.zero_address(),
                     Txn.asset_close_to() == Global.zero_address(),
+                    Txn.on_completion() != OnComplete.UpdateApplication,
+                    Txn.on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -41,6 +43,10 @@ def lsig2_case_10() -> Expr:
                     Gtxn[1].close_remainder_to() == Global.zero_address(),
                     Gtxn[Int(0)].asset_close_to() == Global.zero_address(),
                     Gtxn[1].asset_close_to() == Global.zero_address(),
+                    Gtxn[0].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[0].on_completion() != OnComplete.DeleteApplication,
+                    Gtxn[Int(1)].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[Int(1)].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -61,6 +67,12 @@ def lsig2_case_12() -> Expr:
                     Gtxn[1].fee() < Int(10000),
                     Gtxn[1].close_remainder_to() == Global.zero_address(),
                     Gtxn[1].asset_close_to() == Global.zero_address(),
+                )
+            ),
+            Assert(
+                And(
+                    Gtxn[1].on_completion() != OnComplete.UpdateApplication,
+                    Gtxn[1].on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -89,6 +101,8 @@ def lsig2_case_16() -> Expr:
                     Txn.fee() < Int(10000),
                     Txn.close_remainder_to() == Global.zero_address(),
                     Txn.asset_close_to() == Global.zero_address(),
+                    Txn.on_completion() != OnComplete.UpdateApplication,
+                    Txn.on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -111,6 +125,14 @@ def lsig2_case_19() -> Expr:
             Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -123,6 +145,14 @@ def lsig2_case_20() -> Expr:
             Assert(Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -141,10 +171,16 @@ def lsig2_case_22() -> Expr:
                     Gtxn[Txn.group_index() - Int(1)].fee() < Int(10000),
                     Gtxn[Txn.group_index() - Int(1)].close_remainder_to() == Global.zero_address(),
                     Gtxn[Txn.group_index() - Int(1)].asset_close_to() == Global.zero_address(),
+                    Gtxn[Txn.group_index() - Int(1)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() - Int(1)].on_completion()
+                    != OnComplete.DeleteApplication,
                     Txn.rekey_to() == Global.zero_address(),
                     Txn.fee() < Int(10000),
                     Txn.close_remainder_to() == Global.zero_address(),
                     Txn.asset_close_to() == Global.zero_address(),
+                    Txn.on_completion() != OnComplete.UpdateApplication,
+                    Txn.on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -165,6 +201,8 @@ def lsig2_case_24() -> Expr:
                     Txn.fee() < Int(10000),
                     Txn.close_remainder_to() == Global.zero_address(),
                     Txn.asset_close_to() == Global.zero_address(),
+                    Txn.on_completion() != OnComplete.UpdateApplication,
+                    Txn.on_completion() != OnComplete.DeleteApplication,
                 )
             ),
             Return(Int(1)),
@@ -191,6 +229,14 @@ def lsig2_case_28() -> Expr:
             Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -211,6 +257,14 @@ def lsig2_case_31() -> Expr:
             Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -223,6 +277,14 @@ def lsig2_case_32() -> Expr:
             Assert(Gtxn[Txn.group_index() - Int(4)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() - Int(4)].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() - Int(4)].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() - Int(4)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )
@@ -235,6 +297,14 @@ def lsig2_case_33() -> Expr:
             Assert(Gtxn[Txn.group_index() + Int(5)].fee() < Int(10000)),
             Assert(Gtxn[Txn.group_index() + Int(5)].close_remainder_to() == Global.zero_address()),
             Assert(Gtxn[Txn.group_index() + Int(5)].asset_close_to() == Global.zero_address()),
+            Assert(
+                And(
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.UpdateApplication,
+                    Gtxn[Txn.group_index() + Int(5)].on_completion()
+                    != OnComplete.DeleteApplication,
+                )
+            ),
             Return(Int(1)),
         ]
     )

--- a/tests/group_transactions/basic/logicsig_2.teal
+++ b/tests/group_transactions/basic/logicsig_2.teal
@@ -180,6 +180,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l33:
@@ -211,6 +225,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l34:
@@ -241,6 +269,20 @@ int 4
 gtxns AssetCloseTo
 global ZeroAddress
 ==
+assert
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -279,6 +321,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l38:
@@ -305,6 +361,14 @@ global ZeroAddress
 txn AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -337,6 +401,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 &&
+txn GroupIndex
+int 1
+-
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 1
+-
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 txn RekeyTo
 global ZeroAddress
 ==
@@ -352,6 +430,14 @@ global ZeroAddress
 txn AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -384,6 +470,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 &&
+txn GroupIndex
+int 1
+-
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+txn GroupIndex
+int 1
+-
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 txn RekeyTo
 global ZeroAddress
 ==
@@ -399,6 +499,14 @@ global ZeroAddress
 txn AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -435,6 +543,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 5
++
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l46:
@@ -466,6 +588,20 @@ gtxns AssetCloseTo
 global ZeroAddress
 ==
 assert
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int UpdateApplication
+!=
+txn GroupIndex
+int 4
+-
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
+assert
 int 1
 return
 main_l47:
@@ -489,6 +625,14 @@ global ZeroAddress
 txn AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -517,6 +661,14 @@ global ZeroAddress
 gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
+&&
+assert
+gtxn 1 OnCompletion
+int UpdateApplication
+!=
+gtxn 1 OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1
@@ -556,6 +708,24 @@ gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 &&
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -594,6 +764,24 @@ gtxn 1 AssetCloseTo
 global ZeroAddress
 ==
 &&
+gtxn 0 OnCompletion
+int UpdateApplication
+!=
+&&
+gtxn 0 OnCompletion
+int DeleteApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int UpdateApplication
+!=
+&&
+int 1
+gtxns OnCompletion
+int DeleteApplication
+!=
+&&
 assert
 int 1
 return
@@ -615,6 +803,14 @@ global ZeroAddress
 txn AssetCloseTo
 global ZeroAddress
 ==
+&&
+txn OnCompletion
+int UpdateApplication
+!=
+&&
+txn OnCompletion
+int DeleteApplication
+!=
 &&
 assert
 int 1

--- a/tests/group_transactions/test_group_support.py
+++ b/tests/group_transactions/test_group_support.py
@@ -9,6 +9,8 @@ from tealer.detectors.all_detectors import (
     MissingFeeCheck,
     CanCloseAccount,
     CanCloseAsset,
+    IsUpdatable,
+    IsDeletable,
 )
 from tealer.utils.command_line.group_config import read_config_from_file
 from tealer.utils.command_line.common import init_tealer_from_config
@@ -38,6 +40,16 @@ ALL_TESTS: List[Tuple[Path, Type[AbstractDetector], Path]] = [
         Path("tests/group_transactions/basic/config.yaml"),
         CanCloseAsset,
         Path("tests/group_transactions/basic/expected_output_asset_close_to.yaml"),
+    ),
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        IsUpdatable,
+        Path("tests/group_transactions/basic/expected_output_update_delete.yaml"),
+    ),
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        IsDeletable,
+        Path("tests/group_transactions/basic/expected_output_update_delete.yaml"),
     ),
 ]
 

--- a/tests/group_transactions/test_group_support.py
+++ b/tests/group_transactions/test_group_support.py
@@ -11,6 +11,8 @@ from tealer.detectors.all_detectors import (
     CanCloseAsset,
     IsUpdatable,
     IsDeletable,
+    AnyoneCanDelete,
+    AnyoneCanUpdate,
 )
 from tealer.utils.command_line.group_config import read_config_from_file
 from tealer.utils.command_line.common import init_tealer_from_config
@@ -49,6 +51,16 @@ ALL_TESTS: List[Tuple[Path, Type[AbstractDetector], Path]] = [
     (
         Path("tests/group_transactions/basic/config.yaml"),
         IsDeletable,
+        Path("tests/group_transactions/basic/expected_output_update_delete.yaml"),
+    ),
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        AnyoneCanUpdate,
+        Path("tests/group_transactions/basic/expected_output_update_delete.yaml"),
+    ),
+    (
+        Path("tests/group_transactions/basic/config.yaml"),
+        AnyoneCanDelete,
         Path("tests/group_transactions/basic/expected_output_update_delete.yaml"),
     ),
 ]


### PR DESCRIPTION
The PR adds group support tests for the stateful detectors.

The PR also fixes an issue in the transaction fiedl analysis of transaction types. The developers generally check the creation transaction using
```
txn ApplicationId # ApplicationId will be 0 in the creation transaction
int 0
==/!=
bz/bnz
```

The analysis did not consider the integer value compared against the ApplicationId. It is only checked if the Application is compared against an integer. if so, the analysis considered it to be an Application creation transaction. For example, below pattern is considered to be a check for the creation transaction.
```
txn AppplicationId
int 1337
==
bnz
```

The fix is simply to ensure that compared integer is `0`.