### PR TITLE
fix: py3.12 support (#1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "pycryptodomex",
         "requests",
         "pyyaml",
+        "setuptools"
     ],
     extras_require={"dev": ["pylint==2.13.4", "black==22.3.0", "mypy==0.942", "pytest-cov"]},
     license="AGPL-3.0",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "pycryptodomex",
         "requests",
         "pyyaml",
-        "setuptools"
+        "setuptools",
     ],
     extras_require={"dev": ["pylint==2.13.4", "black==22.3.0", "mypy==0.942", "pytest-cov"]},
     license="AGPL-3.0",


### PR DESCRIPTION
# Proposed changes

- SImilar to https://github.com/algorand/pyteal/issues/712, adds setuptools into requirements explicitly since 3.12 no longer includes it by default. Required in order to make tealer work with python 3.12 based environments and for us to release the integration on algokit