### PR TITLE
Add auto pypi release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-release:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: tealer-dists
+          path: dist/
+
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write  # For trusted publishing + codesigning.
+      contents: write  # For attaching signing artifacts to the release.
+    needs:
+      - build-release
+    steps:
+      - name: fetch dists
+        uses: actions/download-artifact@v4
+        with:
+          name: tealer-dists
+          path: dist/
+
+      - name: publish
+        uses: pypa/gh-action-pypi-publish@v1.8.11
+
+      - name: sign
+        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        with:
+          inputs: ./dist/*.tar.gz ./dist/*.whl
+          release-signing-artifacts: true
+          bundle-only: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Automated publishing of Python packages to PyPI upon a release event, including artifact signing for trusted publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->